### PR TITLE
[github-action] Seal CI bootstrapping

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,14 +22,3 @@ jobs:
           token: ${{ secrets.SEAL_DEPLOY_DISPATCH_TOKEN }}
           event-type: seal-deploy-ci
           client-payload: '{"seal_key_server_commit": "${{ github.sha }}", "environment": "ci"}'
-
-  # run-integration-tests:
-  #   runs-on: ubuntu-latest
-  #   needs: deploy-seal-key-server
-  #   steps:
-  #     - name: Dispatch Seal Integration Tests in MystenLabs/ts-sdks
-  #       uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # pin@v3.0.0
-  #       with:
-  #         repository: MystenLabs/ts-sdks
-  #         token: ${{ secrets.TS_CI_DISPATCH_TOKEN }}
-  #         event-type: seal-integration-tests


### PR DESCRIPTION
Iterating to get the Pre land CI to work
This workflow calls out to a workflow that deploys the commit to the CI environment, then executes the ts-sdk integration tests.