### PR TITLE
Upgrade @mysten/seal to 0.3.6 to Fix TypeScript Compilation Issues

### DIFF
--- a/examples/frontend/package.json
+++ b/examples/frontend/package.json
@@ -22,9 +22,9 @@
   },
   "dependencies": {
     "@mysten/bcs": "^1.6.0",
-    "@mysten/dapp-kit": "^0.15.2",
+    "@mysten/dapp-kit": "0.15.2",
     "@mysten/seal": "0.3.5",
-    "@mysten/sui": "^1.26.1",
+    "@mysten/sui": "1.26.1",
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.2",

--- a/examples/frontend/package.json
+++ b/examples/frontend/package.json
@@ -22,9 +22,9 @@
   },
   "dependencies": {
     "@mysten/bcs": "^1.6.0",
-    "@mysten/dapp-kit": "0.15.2",
-    "@mysten/seal": "0.3.5",
-    "@mysten/sui": "1.26.1",
+    "@mysten/dapp-kit": "^0.15.2",
+    "@mysten/seal": "0.3.6",
+    "@mysten/sui": "^1.26.1",
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.2",


### PR DESCRIPTION
This PR upgrades @mysten/seal from 0.3.5 to 0.3.6 in the seal-example frontend project to resolve TypeScript compilation errors caused by a version mismatch with @mysten/sui.

`
➜ frontend git:(learn) ✗ npm run build

seal-example@0.0.0 build
tsc && vite build

src/AllowlistView.tsx:33:5 - error TS2322: Type 'import("/Users/yc/app/move/workspace/seal/examples/frontend/node_modules/@mysten/sui/dist/esm/client/client").SuiClient' is not assignable to type 'import("/Users/yc/app/move/workspace/seal/examples/frontend/node_modules/@mysten/seal/node_modules/@mysten/sui/dist/esm/client/client").SuiClient'.
Types of property 'core' are incompatible.
Type 'import("/Users/yc/app/move/workspace/seal/examples/frontend/node_modules/@mysten/sui/dist/esm/experimental/transports/jsonRPC").JSONRpcTransport' is not assignable to type 'import("/Users/yc/app/move/workspace/seal/examples/frontend/node_modules/@mysten/seal/node_modules/@mysten/sui/dist/esm/experimental/transports/jsonRPC").JSONRpcTransport'.
Property '#private' in type 'JSONRpcTransport' refers to a different member that cannot be accessed from within type 'JSONRpcTransport'.

33 suiClient,
~~~~~~~~~

node_modules/@mysten/seal/dist/esm/client.d.ts:14:5
14 suiClient: SuiClient;
~~~~~~~~~
The expected type comes from property 'suiClient' which is declared here on type 'SealClientOptions'

src/EncryptAndUpload.tsx:49:5 - error TS2322: Type 'import("/Users/yc/app/move/workspace/seal/examples/frontend/node_modules/@mysten/sui/dist/esm/client/client").SuiClient' is not assignable to type 'import("/Users/yc/app/move/workspace/seal/examples/frontend/node_modules/@mysten/seal/node_modules/@mysten/sui/dist/esm/client/client").SuiClient'.
Types of property 'core' are incompatible.
Type 'import("/Users/yc/app/move/workspace/seal/examples/frontend/node_modules/@mysten/sui/dist/esm/experimental/transports/jsonRPC").JSONRpcTransport' is not assignable to type 'import("/Users/yc/app/move/workspace/seal/examples/frontend/node_modules/@mysten/seal/node_modules/@mysten/sui/dist/esm/experimental/transports/jsonRPC").JSONRpcTransport'.
Property '#private' in type 'JSONRpcTransport' refers to a different member that cannot be accessed from within type 'JSONRpcTransport'.

49 suiClient,
~~~~~~~~~

node_modules/@mysten/seal/dist/esm/client.d.ts:14:5
14 suiClient: SuiClient;
~~~~~~~~~
The expected type comes from property 'suiClient' which is declared here on type 'SealClientOptions'

src/SubscriptionView.tsx:34:5 - error TS2322: Type 'import("/Users/yc/app/move/workspace/seal/examples/frontend/node_modules/@mysten/sui/dist/esm/client/client").SuiClient' is not assignable to type 'import("/Users/yc/app/move/workspace/seal/examples/frontend/node_modules/@mysten/seal/node_modules/@mysten/sui/dist/esm/client/client").SuiClient'.
Types of property 'core' are incompatible.
Type 'import("/Users/yc/app/move/workspace/seal/examples/frontend/node_modules/@mysten/sui/dist/esm/experimental/transports/jsonRPC").JSONRpcTransport' is not assignable to type 'import("/Users/yc/app/move/workspace/seal/examples/frontend/node_modules/@mysten/seal/node_modules/@mysten/sui/dist/esm/experimental/transports/jsonRPC").JSONRpcTransport'.
Property '#private' in type 'JSONRpcTransport' refers to a different member that cannot be accessed from within type 'JSONRpcTransport'.

34 suiClient,
~~~~~~~~~

node_modules/@mysten/seal/dist/esm/client.d.ts:14:5
14 suiClient: SuiClient;
~~~~~~~~~
The expected type comes from property 'suiClient' which is declared here on type 'SealClientOptions'

Found 3 errors in 3 files.

Errors Files
1 src/AllowlistView.tsx:33
1 src/EncryptAndUpload.tsx:49
1 src/SubscriptionView.tsx:34
`