### PR TITLE
More informative error message in case a parameter is invalid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3918,6 +3918,7 @@ dependencies = [
  "crypto",
  "fastcrypto",
  "hex",
+ "jsonrpsee",
  "lru 0.13.0",
  "mysten-service",
  "once_cell",

--- a/crates/key-server/Cargo.toml
+++ b/crates/key-server/Cargo.toml
@@ -37,6 +37,7 @@ parking_lot = "0.12.3"
 once_cell = "1.20.2"
 chrono = "0.4.39"
 semver = "1.0.26"
+jsonrpsee = "0.24.0"
 
 [dev-dependencies]
 tracing-test = "0.2.5"

--- a/crates/key-server/src/errors.rs
+++ b/crates/key-server/src/errors.rs
@@ -61,7 +61,8 @@ impl IntoResponse for InternalError {
             ),
             InternalError::InvalidParameter => (
                 StatusCode::SERVICE_UNAVAILABLE,
-                "Invalid parameter".to_string(),
+                "Invalid parameter. If the object was just created, try again in a few minutes."
+                    .to_string(),
             ),
             InternalError::Failure => (
                 StatusCode::SERVICE_UNAVAILABLE,

--- a/crates/key-server/src/errors.rs
+++ b/crates/key-server/src/errors.rs
@@ -17,6 +17,7 @@ pub enum InternalError {
     InvalidCertificate,
     InvalidSDKVersion,
     DeprecatedSDKVersion,
+    InvalidParameter,
     Failure, // Internal error, try again later
 }
 
@@ -58,6 +59,10 @@ impl IntoResponse for InternalError {
                 StatusCode::FORBIDDEN,
                 "Invalid session key signature".to_string(),
             ),
+            InternalError::InvalidParameter => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Invalid parameter".to_string(),
+            ),
             InternalError::Failure => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 "Internal server error, please try again later".to_string(),
@@ -85,6 +90,7 @@ impl InternalError {
             InternalError::InvalidSessionSignature => "InvalidSessionSignature",
             InternalError::InvalidSDKVersion => "InvalidSDKVersion",
             InternalError::DeprecatedSDKVersion => "DeprecatedSDKVersion",
+            InternalError::InvalidParameter => "InvalidParameter",
             InternalError::Failure => "Failure",
         }
     }

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -22,6 +22,8 @@ use fastcrypto::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use fastcrypto::encoding::{Base64, Encoding};
 use fastcrypto::serde_helpers::ToFromByteArray;
 use fastcrypto::traits::VerifyingKey;
+use jsonrpsee::core::ClientError;
+use jsonrpsee::types::error::INVALID_PARAMS_CODE;
 use mysten_service::get_mysten_service;
 use mysten_service::metrics::start_basic_prometheus_server;
 use mysten_service::package_name;
@@ -35,7 +37,7 @@ use std::env;
 use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
-use sui_sdk::error::SuiRpcResult;
+use sui_sdk::error::{Error, SuiRpcResult};
 use sui_sdk::rpc_types::SuiTransactionBlockEffectsAPI;
 use sui_sdk::types::base_types::{ObjectID, SuiAddress};
 use sui_sdk::types::signature::GenericSignature;
@@ -255,7 +257,18 @@ impl Server {
             .await
             .map_err(|e| {
                 warn!("Dry run execution failed ({:?}) (req_id: {:?})", e, req_id);
-                InternalError::Failure
+                // A dry run will fail if called with a newly created object parameter that the FN has not yet seen.
+                // In that case, the user gets a 503 status code (service unavailable).
+                match e {
+                    Error::RpcError(ClientError::Call(e)) => match e.code() {
+                            INVALID_PARAMS_CODE => {
+                                warn!("Invalid parameter: This could be because the FN has not yet seen the object.");
+                                InternalError::InvalidParameter
+                            }
+                            _ => InternalError::Failure
+                        },
+                    _ => InternalError::Failure
+                }
             })?;
         debug!("Dry run response: {:?} (req_id: {:?})", dry_run_res, req_id);
         if dry_run_res.effects.status().is_err() {


### PR DESCRIPTION
If a parameter is given that is on-chain but not yet seen by the full node, an internal error is returned.

For the key server, it is not known if this is caused by the full node lagging a bit behind or because the object doesn't exist, but in either case we return a more informative error message to the user.