### PR TITLE
fix: browser fetch can not get the X-KeyServer-Version

### DIFF
--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -657,7 +657,8 @@ async fn main() -> Result<()> {
     let cors = CorsLayer::new()
         .allow_methods(Any)
         .allow_origin(Any)
-        .allow_headers(Any);
+        .allow_headers(Any)
+        .expose_headers(Any);
 
     let app = get_mysten_service(package_name!(), package_version!())
         .merge(


### PR DESCRIPTION
## Description 
fix this bug https://github.com/MystenLabs/ts-sdks/issues/284

need to add `expose_headers(Any)` in 
https://github.com/MystenLabs/seal/blob/872b05cc72d76f7521a058e5cb473c9d644281b0/crates/key-server/src/server.rs#L657-L660

[Can check the mdn doc](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Expose-Headers)

![image](https://github.com/user-attachments/assets/c01f459f-4e6f-46f5-a5fd-e87f10e3e943)


## Test plan 

test js code in browser devtools
```js
const myHeaders = new Headers();
myHeaders.append("Content-Type", "application/json");
myHeaders.append("Request-Id", "testtet-ttt-tt-tt");
myHeaders.append("Client-Sdk-Type", "typescript");
myHeaders.append("Client-Sdk-Version", "0.4.0");

const requestOptions = {
  method: "GET",
  headers: myHeaders,
  redirect: "follow"
};

fetch("http://localhost:2024/v1/service", requestOptions)
  .then((response) => {
    console.log(response.headers.get('x-keyserver-version'))
    return response.text()
    })
  .then((result) => console.log(result))
  .catch((error) => console.error(error));
```

you can check the console
![WX20250507-171341](https://github.com/user-attachments/assets/42559f46-221c-4635-ba19-b3a273bd0858)

