### PR TITLE
Add missing header error

### DIFF
--- a/crates/key-server/src/errors.rs
+++ b/crates/key-server/src/errors.rs
@@ -17,6 +17,7 @@ pub enum InternalError {
     InvalidCertificate,
     InvalidSDKVersion,
     DeprecatedSDKVersion,
+    MissingRequiredHeader(String),
     InvalidParameter,
     Failure, // Internal error, try again later
 }
@@ -55,6 +56,10 @@ impl IntoResponse for InternalError {
                 StatusCode::UPGRADE_REQUIRED,
                 "Deprecated SDK version".to_string(),
             ),
+            InternalError::MissingRequiredHeader(ref inner) => (
+                StatusCode::BAD_REQUEST,
+                format!("Missing required header: {}", inner).to_string(),
+            ),
             InternalError::InvalidSessionSignature => (
                 StatusCode::FORBIDDEN,
                 "Invalid session key signature".to_string(),
@@ -90,6 +95,7 @@ impl InternalError {
             InternalError::InvalidSessionSignature => "InvalidSessionSignature",
             InternalError::InvalidSDKVersion => "InvalidSDKVersion",
             InternalError::DeprecatedSDKVersion => "DeprecatedSDKVersion",
+            InternalError::MissingRequiredHeader(_) => "MissingRequiredHeader",
             InternalError::InvalidParameter => "InvalidParameter",
             InternalError::Failure => "Failure",
         }

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -1,6 +1,8 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
-use crate::errors::InternalError::{DeprecatedSDKVersion, InvalidSDKVersion};
+use crate::errors::InternalError::{
+    DeprecatedSDKVersion, InvalidSDKVersion, MissingRequiredHeader,
+};
 use crate::externals::{current_epoch_time, duration_since, get_reference_gas_price};
 use crate::metrics::{call_with_duration, observation_callback, status_callback, Metrics};
 use crate::signed_message::{signed_message, signed_request};
@@ -587,7 +589,7 @@ async fn handle_request_headers(
     );
 
     version
-        .ok_or(InvalidSDKVersion)
+        .ok_or(MissingRequiredHeader("Client-Sdk-Version".to_string()))
         .and_then(|v| v.to_str().map_err(|_| InvalidSDKVersion))
         .and_then(|v| state.validate_sdk_version(v))
         .tap_err(|e| {


### PR DESCRIPTION
## Description 

A request without headers currently gets an InvalidSDKVersion error. This adds a `MissingRequiredHeader` error which is currently only used for the `Client-Sdk-Version` header.

## Test plan 

N/A