### PR TITLE
feat: handle migrated object ids

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN cargo build --bin key-server --profile $PROFILE --config net.git-fetch-with-
 FROM debian:bullseye-slim AS runtime
 ARG master_key
 ARG key_server_object_id
-ARG new_key_server_object_id
+# TODO: remove this when the legacy key server is no longer needed
+ARG legacy_key_server_object_id
 ARG network
 
 EXPOSE 2024
@@ -23,7 +24,9 @@ COPY --from=builder /work/target/release/key-server /opt/key-server/bin/
 
 ENV MASTER_KEY=$master_key
 ENV KEY_SERVER_OBJECT_ID=$key_server_object_id
-ENV NEW_KEY_SERVER_OBJECT_ID=$new_key_server_object_id
 ENV NETWORK=$network
+
+# TODO: remove this when the legacy key server is no longer needed
+ENV LEGACY_KEY_SERVER_OBJECT_ID=$legacy_key_server_object_id
 
 ENTRYPOINT ["/opt/key-server/bin/key-server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN cargo build --bin key-server --profile $PROFILE --config net.git-fetch-with-
 FROM debian:bullseye-slim AS runtime
 ARG master_key
 ARG key_server_object_id
+ARG new_key_server_object_id
 ARG network
 
 EXPOSE 2024
@@ -22,6 +23,7 @@ COPY --from=builder /work/target/release/key-server /opt/key-server/bin/
 
 ENV MASTER_KEY=$master_key
 ENV KEY_SERVER_OBJECT_ID=$key_server_object_id
+ENV NEW_KEY_SERVER_OBJECT_ID=$new_key_server_object_id
 ENV NETWORK=$network
 
 ENTRYPOINT ["/opt/key-server/bin/key-server"]

--- a/crates/key-server/src/errors.rs
+++ b/crates/key-server/src/errors.rs
@@ -20,6 +20,7 @@ pub enum InternalError {
     MissingRequiredHeader(String),
     InvalidParameter,
     InvalidMVRName,
+    InvalidServiceId,
     Failure, // Internal error, try again later
 }
 
@@ -72,6 +73,9 @@ impl IntoResponse for InternalError {
             InternalError::InvalidMVRName => {
                 (StatusCode::FORBIDDEN, "Invalid MVR name".to_string())
             }
+            InternalError::InvalidServiceId => {
+                (StatusCode::BAD_REQUEST, "Invalid service ID".to_string())
+            }
             InternalError::Failure => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 "Internal server error, please try again later".to_string(),
@@ -102,6 +106,7 @@ impl InternalError {
             InternalError::MissingRequiredHeader(_) => "MissingRequiredHeader",
             InternalError::InvalidParameter => "InvalidParameter",
             InternalError::InvalidMVRName => "InvalidMVRName",
+            InternalError::InvalidServiceId => "InvalidServiceId",
             InternalError::Failure => "Failure",
         }
     }

--- a/crates/key-server/src/tests/mod.rs
+++ b/crates/key-server/src/tests/mod.rs
@@ -67,6 +67,8 @@ impl SealTestCluster {
                     sui_client: cluster.sui_client().clone(),
                     network: Network::TestCluster,
                     master_key,
+                    legacy_key_server_object_id: ObjectID::ZERO,
+                    legacy_key_server_object_id_sig: G1Element::generator(),
                     key_server_object_id: ObjectID::ZERO,
                     key_server_object_id_sig: G1Element::generator(),
                     sdk_version_requirement: VersionReq::STAR,


### PR DESCRIPTION
## Description 

this is to handle new object ids associated with registered key servers onchain.

## Test plan 

tested locally
```
curl --header "Client-Sdk-Version: 0.4.7" http://localhost:2024/v1/service                                                                                                                                                                                                              ✔  10031  11:33:49

{"service_id":"0x0000000000000000000000000000000000000000000000000000000000000001","pop":"rpaBwleOpgJgz2lLn6HphG8Pw/LTTC4Zmn+ir5bNs3hw5PqcCchbg04R4H8kuDfI","version":"0.4.1"}%

curl --header "Client-Sdk-Version: 0.4.7" http://localhost:2024/v1/service\?service_id\=0x666                                                                                                                                                                                           ✔  10033  11:46:52

{"service_id":"0x0000000000000000000000000000000000000000000000000000000000000666","pop":"iLapECJK+VdfqFoq5rb98m3TLiQIEHZ1zUYOkSASyVAG8zWKKZ+n3mgKFEY8qV6E","version":"0.4.1"}%

curl --header "Client-Sdk-Version: 0.4.7" http://localhost:2024/v1/service\?service_id\=0x1                                                                                                                                                                                             ✔  10034  11:47:05

{"service_id":"0x0000000000000000000000000000000000000000000000000000000000000001","pop":"rpaBwleOpgJgz2lLn6HphG8Pw/LTTC4Zmn+ir5bNs3hw5PqcCchbg04R4H8kuDfI","version":"0.4.1"}%
```