### PR TITLE
feat: Enhance Whitelist functionality by adding share_whitelist function and modify Cap struct to include store capability

### DIFF
--- a/move/patterns/sources/whitelist.move
+++ b/move/patterns/sources/whitelist.move
@@ -28,7 +28,7 @@ public struct Whitelist has key {
     addresses: table::Table<address, bool>,
 }
 
-public struct Cap has key {
+public struct Cap has key, store {
     id: UID,
     wl_id: ID,
 }
@@ -51,11 +51,16 @@ public fun create_whitelist(ctx: &mut TxContext): (Cap, Whitelist) {
     (cap, wl)
 }
 
+// Share a Whitelist created by create_whitelist.
+public fun share_whitelist(wl: Whitelist) {
+    transfer::share_object(wl);
+}
+
 // Helper function for creating a whitelist and send it back to sender.
 entry fun create_whitelist_entry(ctx: &mut TxContext) {
     let (cap, wl) = create_whitelist(ctx);
-    transfer::share_object(wl);
-    transfer::transfer(cap, ctx.sender());
+    share_whitelist(wl);
+    transfer::public_transfer(cap, ctx.sender());
 }
 
 public fun add(wl: &mut Whitelist, cap: &Cap, account: address) {

--- a/move/patterns/sources/whitelist.move
+++ b/move/patterns/sources/whitelist.move
@@ -51,7 +51,6 @@ public fun create_whitelist(ctx: &mut TxContext): (Cap, Whitelist) {
     (cap, wl)
 }
 
-// Share a Whitelist created by create_whitelist.
 public fun share_whitelist(wl: Whitelist) {
     transfer::share_object(wl);
 }


### PR DESCRIPTION
## Description 

- Added `store` ability to `Cap`
  - `Cap` is no longer restricted to being a publisher-only object. It is now freely transferable.
- Introduced `share_whitelist` function
  - The existing public fun `create_whitelist` function is insufficient due to the key-only constraint on `Whitelist`, which prevents transactions from being finalized.
  - By adding `share_whitelist`, it is now possible to create and add whitelist entries in a more composable way, beyond just `create_whitelist_entry`.

## Test plan 

tested locally 

```
sui client ptb --move-call $PID::whitelist::create_whitelist \
  --assign res \
  --transfer-objects "[res.0]" @$OWNER \
  --move-call $PID::whitelist::share_whitelist res.1
```