### PR TITLE
feat[metrics]: add uptime metrics to key server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4010,6 +4010,7 @@ dependencies = [
  "once_cell",
  "parking_lot 0.12.3",
  "prometheus",
+ "prometheus-closure-metric",
  "rand 0.8.5",
  "reqwest",
  "semver",

--- a/crates/key-server/Cargo.toml
+++ b/crates/key-server/Cargo.toml
@@ -46,6 +46,7 @@ move-binding-derive = { git = "https://github.com/MystenLabs/move-binding.git", 
 move-types = { git = "https://github.com/MystenLabs/move-binding.git", rev = "99f68a28c2f19be40a09e5f1281af748df9a8d3e" }
 sui-sdk-types = { git = "https://github.com/mystenlabs/sui-rust-sdk", features = ["serde"], rev = "86a9e06" }
 sui-transaction-builder = { git = "https://github.com/mystenlabs/sui-rust-sdk", rev = "86a9e06" }
+prometheus_closure_metric = { git = "https://github.com/MystenLabs/sui", rev = "42ba6c0", package = "prometheus-closure-metric" }
 
 [dev-dependencies]
 tracing-test = "0.2.5"

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -642,6 +642,24 @@ async fn add_response_headers(mut response: Response) -> Response {
     response
 }
 
+/// Creates a [prometheus::core::Collector] that tracks the uptime of the server.
+fn uptime_metric(version: &str) -> Box<dyn prometheus::core::Collector> {
+    let opts = prometheus::opts!("uptime", "uptime of the node service in seconds")
+        .variable_label("version");
+
+    let start_time = std::time::Instant::now();
+    let uptime = move || start_time.elapsed().as_secs();
+    let metric = prometheus_closure_metric::ClosureMetric::new(
+        opts,
+        prometheus_closure_metric::ValueType::Counter,
+        uptime,
+        &[version],
+    )
+    .unwrap();
+
+    Box::new(metric)
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let master_key = env::var("MASTER_KEY").expect("MASTER_KEY must be set");
@@ -689,6 +707,14 @@ async fn main() -> Result<()> {
         options.metrics_host_port,
     ))
     .default_registry();
+
+    // Tracks the uptime of the server.
+    let registry_clone = registry.clone();
+    tokio::task::spawn(async move {
+        registry_clone
+            .register(uptime_metric(PACKAGE_VERSION))
+            .expect("metrics defined at compile time must be valid");
+    });
 
     // hook up custom application metrics
     let metrics = Arc::new(Metrics::new(&registry));

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -644,7 +644,7 @@ async fn add_response_headers(mut response: Response) -> Response {
 
 /// Creates a [prometheus::core::Collector] that tracks the uptime of the server.
 fn uptime_metric(version: &str) -> Box<dyn prometheus::core::Collector> {
-    let opts = prometheus::opts!("uptime", "uptime of the node service in seconds")
+    let opts = prometheus::opts!("uptime", "uptime of the key server in seconds")
         .variable_label("version");
 
     let start_time = std::time::Instant::now();


### PR DESCRIPTION
## Description 

Tracks how long the seal server is up, with additional binary version information.

## Test plan 

How did you test the new or updated feature?