### PR TITLE
feat(metrics): add axum middle layer to collect HTTP request metrics

### DIFF
--- a/crates/key-server/src/metrics.rs
+++ b/crates/key-server/src/metrics.rs
@@ -1,10 +1,14 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use axum::{extract::State, middleware};
 use prometheus::{
-    register_histogram_with_registry, register_int_counter_vec_with_registry,
-    register_int_counter_with_registry, Histogram, IntCounter, IntCounterVec, Registry,
+    register_histogram_vec_with_registry, register_histogram_with_registry,
+    register_int_counter_vec_with_registry, register_int_counter_with_registry,
+    register_int_gauge_vec_with_registry, Histogram, HistogramVec, IntCounter, IntCounterVec,
+    IntGaugeVec, Registry,
 };
+use std::sync::Arc;
 use std::time::Instant;
 
 #[derive(Debug)]
@@ -38,6 +42,15 @@ pub(crate) struct Metrics {
 
     /// Total number of requests per number of ids
     pub requests_per_number_of_ids: Histogram,
+
+    /// HTTP request latency by route
+    pub http_request_duration_millis: HistogramVec,
+
+    /// HTTP request count by route and status code
+    pub http_requests_total: IntCounterVec,
+
+    /// HTTP request in flight by route
+    pub http_request_in_flight: IntGaugeVec,
 }
 
 impl Metrics {
@@ -111,6 +124,28 @@ impl Metrics {
                 registry
             )
             .unwrap(),
+            http_request_duration_millis: register_histogram_vec_with_registry!(
+                "http_request_duration_millis",
+                "HTTP request duration in milliseconds",
+                &["route"],
+                default_fast_call_duration_buckets(),
+                registry
+            )
+            .unwrap(),
+            http_requests_total: register_int_counter_vec_with_registry!(
+                "http_requests_total",
+                "Total number of HTTP requests",
+                &["route", "status"],
+                registry
+            )
+            .unwrap(),
+            http_request_in_flight: register_int_gauge_vec_with_registry!(
+                "http_request_in_flight",
+                "Number of HTTP requests in flight",
+                &["route"],
+                registry
+            )
+            .unwrap(),
         }
     }
 
@@ -171,4 +206,38 @@ fn default_external_call_duration_buckets() -> Vec<f64> {
 
 fn default_fast_call_duration_buckets() -> Vec<f64> {
     buckets(10.0, 100.0, 10.0)
+}
+
+pub(crate) async fn metrics_middleware(
+    State(metrics): State<Arc<Metrics>>,
+    request: axum::extract::Request,
+    next: middleware::Next,
+) -> axum::response::Response {
+    let route = request.uri().path().to_string();
+    let start = std::time::Instant::now();
+
+    metrics
+        .http_request_in_flight
+        .with_label_values(&[&route])
+        .inc();
+
+    let response = next.run(request).await;
+
+    metrics
+        .http_request_in_flight
+        .with_label_values(&[&route])
+        .dec();
+    let duration = start.elapsed().as_millis() as f64;
+    let status = response.status().as_str().to_string();
+
+    metrics
+        .http_request_duration_millis
+        .with_label_values(&[&route])
+        .observe(duration);
+    metrics
+        .http_requests_total
+        .with_label_values(&[&route, &status])
+        .inc();
+
+    response
 }

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -732,12 +732,14 @@ async fn main() -> Result<()> {
             axum::Router::new()
                 .route("/v1/fetch_key", post(handle_fetch_key))
                 .route("/v1/service", get(handle_get_service))
+                .layer(from_fn_with_state(state.clone(), handle_request_headers))
+                .layer(map_response(add_response_headers))
+                // Outside most middlewares that tracks metrics for HTTP requests and response
+                // status.
                 .layer(from_fn_with_state(
                     state.metrics.clone(),
                     metrics_middleware,
                 ))
-                .layer(from_fn_with_state(state.clone(), handle_request_headers))
-                .layer(map_response(add_response_headers))
                 .with_state(state),
         )
         .layer(cors);

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -30,6 +30,7 @@ use fastcrypto::traits::VerifyingKey;
 use jsonrpsee::core::ClientError;
 use jsonrpsee::types::error::{INVALID_PARAMS_CODE, METHOD_NOT_FOUND_CODE};
 use key_server_options::KeyServerOptions;
+use metrics::metrics_middleware;
 use mysten_service::get_mysten_service;
 use mysten_service::metrics::start_prometheus_server;
 use mysten_service::package_name;
@@ -731,6 +732,10 @@ async fn main() -> Result<()> {
             axum::Router::new()
                 .route("/v1/fetch_key", post(handle_fetch_key))
                 .route("/v1/service", get(handle_get_service))
+                .layer(from_fn_with_state(
+                    state.metrics.clone(),
+                    metrics_middleware,
+                ))
                 .layer(from_fn_with_state(state.clone(), handle_request_headers))
                 .layer(map_response(add_response_headers))
                 .with_state(state),


### PR DESCRIPTION
## Description 

This has some duplication with existing metrics. The middle layer allow us to keep track of all routes' metrics without
adding metrics for individual request handler. Also, when adding new routes in the future, the metrics are auto-collected.

Contributed to CRY-291

## Test plan 

Local node testing to verify metrics