### PR TITLE
feat(server): monitor and catch background task error

### DIFF
--- a/crates/key-server/src/tests/server.rs
+++ b/crates/key-server/src/tests/server.rs
@@ -1,10 +1,14 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use prometheus::Registry;
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing_test::traced_test;
 
 use crate::externals::get_latest_checkpoint_timestamp;
+use crate::metrics::Metrics;
+use crate::start_server_background_tasks;
 use crate::tests::SealTestCluster;
 
 #[tokio::test]
@@ -32,7 +36,8 @@ async fn test_timestamp_updater() {
     let mut receiver = tc
         .server()
         .spawn_latest_checkpoint_timestamp_updater(None)
-        .await;
+        .await
+        .0;
 
     let tolerance = 20000;
 
@@ -59,10 +64,36 @@ async fn test_timestamp_updater() {
 async fn test_rgp_updater() {
     let tc = SealTestCluster::new(1, 0).await;
 
-    let mut receiver = tc.server().spawn_reference_gas_price_updater(None).await;
+    let mut receiver = tc.server().spawn_reference_gas_price_updater(None).await.0;
 
     let price = *receiver.borrow_and_update();
     assert_eq!(price, tc.cluster.get_reference_gas_price().await);
 
     receiver.changed().await.expect("Failed to get latest rgp");
+}
+
+// Tests that the server background task monitor can catch background task errors and panics.
+#[tokio::test]
+async fn test_server_background_task_monitor() {
+    let tc = SealTestCluster::new(1, 0).await;
+
+    let metrics_registry = Registry::default();
+    let metrics = Arc::new(Metrics::new(&metrics_registry));
+
+    let (latest_checkpoint_timestamp_receiver, _reference_gas_price_receiver, monitor_handle) =
+        start_server_background_tasks(Arc::new(tc.server().clone()), metrics.clone()).await;
+
+    // Drop the receiver to trigger the panic in the background
+    // spawn_latest_checkpoint_timestamp_updater task.
+    drop(latest_checkpoint_timestamp_receiver);
+
+    // Wait for the monitor to exit with an error. This should happen in a timely manner.
+    let result = tokio::time::timeout(std::time::Duration::from_secs(10), monitor_handle)
+        .await
+        .expect("Waiting for background monitor to exit timed out after 10 seconds");
+
+    // Check that the result is a panic.
+    assert!(result.is_err(), "Expected JoinError");
+    let err = result.unwrap_err();
+    assert!(err.is_panic(), "Expected JoinError::Panic");
 }


### PR DESCRIPTION
## Description 

If background tasks stop with an error or panic, previously the errors are ignored and the server will continue running
without the background tasks.

This PR adds a background task monitor that will catch the error, and stop the server.

## Test plan 

How did you test the new or updated feature?