### PR TITLE
feat: add timeout configuration to all RPC calls

### DIFF
--- a/crates/key-server/src/externals.rs
+++ b/crates/key-server/src/externals.rs
@@ -32,6 +32,7 @@ pub(crate) fn add_upgraded_package(pkg_id: ObjectID, new_pkg_id: ObjectID) {
 pub(crate) async fn fetch_first_pkg_id(
     pkg_id: &ObjectID,
     network: &Network,
+    rpc_timeout: Duration,
 ) -> Result<ObjectID, InternalError> {
     match CACHE.get(pkg_id) {
         Some(first) => Ok(first),
@@ -53,7 +54,10 @@ pub(crate) async fn fetch_first_pkg_id(
                 )
             });
 
-            let response = Client::new()
+            let response = Client::builder()
+                .timeout(rpc_timeout)
+                .build()
+                .expect("Client::new()")
                 .post(network.graphql_url())
                 .json(&query)
                 .send()

--- a/crates/key-server/src/key_server_options.rs
+++ b/crates/key-server/src/key_server_options.rs
@@ -57,6 +57,13 @@ pub struct KeyServerOptions {
         deserialize_with = "deserialize_duration"
     )]
     pub session_key_ttl_max: Duration,
+
+    /// The timeout for RPC requests.
+    #[serde(
+        default = "default_rpc_timeout",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub rpc_timeout: Duration,
 }
 
 impl KeyServerOptions {
@@ -75,6 +82,7 @@ impl KeyServerOptions {
             rgp_update_interval: default_rgp_update_interval(),
             allowed_staleness: default_allowed_staleness(),
             session_key_ttl_max: default_session_key_ttl_max(),
+            rpc_timeout: default_rpc_timeout(),
         }
     }
 }
@@ -101,6 +109,10 @@ fn default_metrics_host_port() -> u16 {
 
 fn default_sdk_version_requirement() -> VersionReq {
     VersionReq::parse(">=0.4.5").expect("Failed to parse default SDK version requirement")
+}
+
+fn default_rpc_timeout() -> Duration {
+    Duration::from_secs(60)
 }
 
 #[test]

--- a/crates/key-server/src/mvr.rs
+++ b/crates/key-server/src/mvr.rs
@@ -15,6 +15,7 @@
 
 use crate::errors::InternalError;
 use crate::errors::InternalError::{Failure, InvalidMVRName, InvalidPackage};
+use crate::key_server_options::KeyServerOptions;
 use crate::mvr::mainnet::mvr_core::app_record::AppRecord;
 use crate::mvr::mainnet::mvr_core::name::Name;
 use crate::mvr::mainnet::sui::dynamic_field::Field;
@@ -69,9 +70,9 @@ impl<K: Eq + Hash, V> From<VecMap<K, V>> for HashMap<K, V> {
 pub(crate) async fn mvr_forward_resolution(
     client: &SuiClient,
     mvr_name: &str,
-    network: &Network,
+    key_server_options: &KeyServerOptions,
 ) -> Result<ObjectID, InternalError> {
-    let package_address = match network {
+    let package_address = match key_server_options.network {
         Network::Mainnet => get_from_mvr_registry(mvr_name, client)
             .await?
             .value
@@ -83,6 +84,7 @@ pub(crate) async fn mvr_forward_resolution(
             let networks: HashMap<_, _> = get_from_mvr_registry(
                 mvr_name,
                 &SuiClientBuilder::default()
+                    .request_timeout(key_server_options.rpc_timeout)
                     .build_mainnet()
                     .await
                     .map_err(|_| Failure)?,


### PR DESCRIPTION
## Description 

Define one `rpc_timeout` option in the config and use it in both Sui fullnode call and graphQL call (since IIUC, graphQL call will be deprecated soon).

## Test plan 

How did you test the new or updated feature?