### PR TITLE
some simplifications and improvements to the caching setup

### DIFF
--- a/crates/key-server/src/externals.rs
+++ b/crates/key-server/src/externals.rs
@@ -1,11 +1,11 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::cache::{Cache, CACHE_SIZE, CACHE_TTL};
+use crate::cache::Cache;
 use crate::errors::InternalError;
 use crate::types::Network;
 use crate::{mvr_forward_resolution, Timestamp};
-use once_cell::sync::Lazy;
+use std::sync::Arc;
 use std::time::Duration;
 use sui_sdk::error::SuiRpcResult;
 use sui_sdk::rpc_types::{CheckpointId, SuiData, SuiObjectDataOptions};
@@ -14,33 +14,93 @@ use sui_types::base_types::ObjectID;
 use tap::TapFallible;
 use tracing::{debug, warn};
 
-static CACHE: Lazy<Cache<ObjectID, ObjectID>> = Lazy::new(|| Cache::new(CACHE_TTL, CACHE_SIZE));
-static MVR_CACHE: Lazy<Cache<String, ObjectID>> = Lazy::new(|| Cache::new(CACHE_TTL, CACHE_SIZE));
-
-#[cfg(test)]
-pub(crate) fn add_package(pkg_id: ObjectID) {
-    CACHE.insert(pkg_id, pkg_id);
+pub(crate) struct PackageManager {
+    cache: Cache<ObjectID, ObjectID>,
+    sui_client: Arc<SuiClient>,
 }
 
-#[cfg(test)]
-pub(crate) fn add_upgraded_package(pkg_id: ObjectID, new_pkg_id: ObjectID) {
-    CACHE.insert(new_pkg_id, pkg_id);
+impl PackageManager {
+    pub fn new(sui_client: Arc<SuiClient>, cache_size: usize) -> Self {
+        Self {
+            cache: Cache::new(cache_size),
+            sui_client,
+        }
+    }
+
+    pub async fn fetch_first_pkg_id(&self, pkg_id: &ObjectID) -> Result<ObjectID, InternalError> {
+        if let Some(first) = self.cache.get(pkg_id) {
+            return Ok(first);
+        }
+
+        let object = self
+            .sui_client
+            .read_api()
+            .get_object_with_options(*pkg_id, SuiObjectDataOptions::default().with_bcs())
+            .await
+            .map_err(|_| InternalError::Failure)? // internal error that fullnode fails to respond, check fullnode.
+            .into_object()
+            .map_err(|_| InternalError::InvalidPackage)?; // user error that object does not exist or deleted.
+
+        let package = object
+            .bcs
+            .ok_or(InternalError::Failure)? // internal error that fullnode does not respond with bcs even though request includes the bcs option.
+            .try_as_package()
+            .ok_or(InternalError::InvalidPackage)?
+            .to_move_package(u64::MAX)
+            .map_err(|_| InternalError::InvalidPackage)?; // user error if the provided package throw MovePackageTooBig.
+
+        let first = package.original_package_id();
+        self.cache.insert(*pkg_id, first);
+        Ok(first)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn add_package(&self, pkg_id: ObjectID) {
+        self.cache.insert(pkg_id, pkg_id);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn add_upgraded_package(&self, pkg_id: ObjectID, new_pkg_id: ObjectID) {
+        self.cache.insert(new_pkg_id, pkg_id);
+    }
 }
 
-pub(crate) async fn check_mvr_package_id(
-    mvr_name: &Option<String>,
-    sui_client: &SuiClient,
-    network: &Network,
-    first_pkg_id: ObjectID,
-    req_id: Option<&str>,
-) -> Result<(), InternalError> {
-    // If an MVR name is provided, get it from cache or resolve it to the package
-    // id. Then check that it points to the first package ID.
-    if let Some(mvr_name) = &mvr_name {
-        let mvr_package_id = match get_mvr_cache(mvr_name) {
+pub(crate) struct MvrManager {
+    cache: Cache<String, ObjectID>,
+    sui_client: Arc<SuiClient>,
+    network: Network,
+}
+
+impl MvrManager {
+    pub fn new(sui_client: Arc<SuiClient>, network: Network, cache_size: usize) -> Self {
+        Self {
+            cache: Cache::new(cache_size),
+            sui_client,
+            network,
+        }
+    }
+
+    pub async fn check_mvr_package_id(
+        &self,
+        mvr_name: &Option<String>,
+        first_pkg_id: ObjectID,
+        req_id: Option<&str>,
+    ) -> Result<(), InternalError> {
+        let Some(mvr_name) = &mvr_name else {
+            return Ok(());
+        };
+
+        // If an MVR name is provided, get it from cache or resolve it to the package
+        // id. Then check that it points to the first package ID.
+        let mvr_package_id = match self.cache_get(mvr_name) {
             None => {
-                let mvr_package_id = mvr_forward_resolution(sui_client, mvr_name, network).await?;
-                insert_mvr_cache(mvr_name, mvr_package_id);
+                let mvr_package_id =
+                    mvr_forward_resolution(&self.sui_client, mvr_name, &self.network).await?;
+                debug!(
+                    "Resolved MVR name {} to package ID {} and adding it to the cache (req_id: {:?})",
+                    mvr_name, mvr_package_id, req_id
+                );
+                self.cache_insert(mvr_name.to_string(), mvr_package_id);
                 mvr_package_id
             }
             Some(mvr_package_id) => {
@@ -58,50 +118,22 @@ pub(crate) async fn check_mvr_package_id(
             );
             return Err(InternalError::InvalidMVRName);
         }
+        Ok(())
     }
-    Ok(())
-}
 
-pub(crate) async fn fetch_first_pkg_id(
-    pkg_id: &ObjectID,
-    sui_client: &SuiClient,
-) -> Result<ObjectID, InternalError> {
-    match CACHE.get(pkg_id) {
-        Some(first) => Ok(first),
-        None => {
-            let object = sui_client
-                .read_api()
-                .get_object_with_options(*pkg_id, SuiObjectDataOptions::default().with_bcs())
-                .await
-                .map_err(|_| InternalError::Failure)? // internal error that fullnode fails to respond, check fullnode.
-                .into_object()
-                .map_err(|_| InternalError::InvalidPackage)?; // user error that object does not exist or deleted.
-
-            let package = object
-                .bcs
-                .ok_or(InternalError::Failure)? // internal error that fullnode does not respond with bcs even though request includes the bcs option.
-                .try_as_package()
-                .ok_or(InternalError::InvalidPackage)?
-                .to_move_package(u64::MAX)
-                .map_err(|_| InternalError::InvalidPackage)?; // user error if the provided package throw MovePackageTooBig.
-
-            let first = package.original_package_id();
-            CACHE.insert(*pkg_id, first);
-            Ok(first)
-        }
+    fn cache_insert(&self, mvr_name: String, package_id: ObjectID) {
+        self.cache.insert(mvr_name, package_id);
     }
-}
 
-pub(crate) fn insert_mvr_cache(mvr_name: &str, package_id: ObjectID) {
-    MVR_CACHE.insert(mvr_name.to_string(), package_id);
-}
-
-pub(crate) fn get_mvr_cache(mvr_name: &str) -> Option<ObjectID> {
-    MVR_CACHE.get(&mvr_name.to_string())
+    fn cache_get(&self, mvr_name: &String) -> Option<ObjectID> {
+        self.cache.get(mvr_name)
+    }
 }
 
 /// Returns the timestamp for the latest checkpoint.
-pub(crate) async fn get_latest_checkpoint_timestamp(client: SuiClient) -> SuiRpcResult<Timestamp> {
+pub(crate) async fn get_latest_checkpoint_timestamp(
+    client: Arc<SuiClient>,
+) -> SuiRpcResult<Timestamp> {
     let latest_checkpoint_sequence_number = client
         .read_api()
         .get_latest_checkpoint_sequence_number()
@@ -115,7 +147,7 @@ pub(crate) async fn get_latest_checkpoint_timestamp(client: SuiClient) -> SuiRpc
     Ok(checkpoint.timestamp_ms)
 }
 
-pub(crate) async fn get_reference_gas_price(client: SuiClient) -> SuiRpcResult<u64> {
+pub(crate) async fn get_reference_gas_price(client: Arc<SuiClient>) -> SuiRpcResult<u64> {
     let rgp = client
         .read_api()
         .get_reference_gas_price()
@@ -154,19 +186,28 @@ pub(crate) fn current_epoch_time() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::externals::fetch_first_pkg_id;
-    use crate::types::Network;
-    use crate::InternalError;
-    use fastcrypto::ed25519::Ed25519KeyPair;
-    use fastcrypto::secp256k1::Secp256k1KeyPair;
-    use fastcrypto::secp256r1::Secp256r1KeyPair;
+    use std::str::FromStr as _;
+
+    use fastcrypto::{
+        ed25519::Ed25519KeyPair, secp256k1::Secp256k1KeyPair, secp256r1::Secp256r1KeyPair,
+    };
     use shared_crypto::intent::{Intent, IntentMessage, PersonalMessage};
-    use std::str::FromStr;
-    use sui_sdk::types::crypto::{get_key_pair, Signature};
-    use sui_sdk::types::signature::GenericSignature;
-    use sui_sdk::verify_personal_message_signature::verify_personal_message_signature;
-    use sui_sdk::SuiClientBuilder;
-    use sui_types::base_types::ObjectID;
+    use sui_sdk::{
+        verify_personal_message_signature::verify_personal_message_signature, SuiClientBuilder,
+    };
+    use sui_types::{
+        crypto::{get_key_pair, Signature},
+        signature::GenericSignature,
+    };
+
+    use super::*;
+
+    async fn package_manager() -> PackageManager {
+        PackageManager::new(Arc::new(SuiClientBuilder::default()
+            .build(&Network::Testnet.node_url())
+            .await
+            .expect("SuiClientBuilder should not failed unless provided with invalid network url")), 1000)
+    }
 
     #[tokio::test]
     async fn test_fetch_first_pkg_id() {
@@ -174,11 +215,7 @@ mod tests {
             "0xac7890f847ac6973ca615af9d7bbb642541f175e35e340e5d1241d0ffda9ed04",
         )
         .unwrap();
-        let sui_client = SuiClientBuilder::default()
-            .build(&Network::Testnet.node_url())
-            .await
-            .expect("SuiClientBuilder should not failed unless provided with invalid network url");
-        match fetch_first_pkg_id(&address, &sui_client).await {
+        match package_manager().await.fetch_first_pkg_id(&address).await {
             Ok(first) => {
                 assert_eq!(
                     first.to_hex_literal(),
@@ -190,15 +227,47 @@ mod tests {
             Err(e) => panic!("Test failed with error: {:?}", e),
         }
     }
+    #[tokio::test]
+    async fn test_mvr_manager() {
+        let mvr_manager = MvrManager::new(
+            Arc::new(SuiClientBuilder::default().build_mainnet().await.expect(
+                "SuiClientBuilder should not failed unless provided with invalid network url",
+            )),
+            Network::Mainnet,
+            1000,
+        );
+
+        assert!(mvr_manager
+            .check_mvr_package_id(
+                &Some("@mysten/kiosk".to_string()),
+                ObjectID::from_str(
+                    "0xdfb4f1d4e43e0c3ad834dcd369f0d39005c872e118c9dc1c5da9765bb93ee5f3"
+                )
+                .unwrap(),
+                None
+            )
+            .await
+            .is_ok());
+
+        // Verify the cache is added.
+        assert_eq!(
+            mvr_manager.cache_get(&"@mysten/kiosk".to_string()),
+            Some(
+                ObjectID::from_str(
+                    "0xdfb4f1d4e43e0c3ad834dcd369f0d39005c872e118c9dc1c5da9765bb93ee5f3"
+                )
+                .unwrap()
+            )
+        );
+    }
 
     #[tokio::test]
     async fn test_fetch_first_pkg_id_with_invalid_id() {
         let invalid_address = ObjectID::ZERO;
-        let sui_client = SuiClientBuilder::default()
-            .build(&Network::Mainnet.node_url())
+        let result = package_manager()
             .await
-            .expect("SuiClientBuilder should not failed unless provided with invalid network url");
-        let result = fetch_first_pkg_id(&invalid_address, &sui_client).await;
+            .fetch_first_pkg_id(&invalid_address)
+            .await;
         assert!(matches!(result, Err(InternalError::InvalidPackage)));
     }
 

--- a/crates/key-server/src/key_server_options.rs
+++ b/crates/key-server/src/key_server_options.rs
@@ -1,9 +1,9 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::errors::InternalError;
 use crate::from_mins;
 use crate::types::Network;
+use crate::{cache::CacheOptions, errors::InternalError};
 use anyhow::{anyhow, Result};
 use duration_str::deserialize_duration;
 use semver::VersionReq;
@@ -98,6 +98,10 @@ pub struct KeyServerOptions {
         deserialize_with = "deserialize_duration"
     )]
     pub session_key_ttl_max: Duration,
+
+    /// Configuration for the various caches used for optimization.
+    #[serde(default)]
+    pub cache: CacheOptions,
 }
 
 impl KeyServerOptions {
@@ -118,6 +122,7 @@ impl KeyServerOptions {
             rgp_update_interval: default_rgp_update_interval(),
             allowed_staleness: default_allowed_staleness(),
             session_key_ttl_max: default_session_key_ttl_max(),
+            cache: Default::default(),
         }
     }
 

--- a/crates/key-server/src/mvr.rs
+++ b/crates/key-server/src/mvr.rs
@@ -183,29 +183,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_forward_resolution() {
-        assert!(crate::externals::check_mvr_package_id(
-            &Some("@mysten/kiosk".to_string()),
-            &SuiClientBuilder::default().build_mainnet().await.unwrap(),
-            &Network::Mainnet,
-            ObjectID::from_str(
-                "0xdfb4f1d4e43e0c3ad834dcd369f0d39005c872e118c9dc1c5da9765bb93ee5f3"
-            )
-            .unwrap(),
-            None
-        )
-        .await
-        .is_ok());
-
-        // Verify the cache is added.
-        assert_eq!(
-            crate::externals::get_mvr_cache("@mysten/kiosk"),
-            Some(
-                ObjectID::from_str(
-                    "0xdfb4f1d4e43e0c3ad834dcd369f0d39005c872e118c9dc1c5da9765bb93ee5f3"
-                )
-                .unwrap()
-            )
-        );
         assert_eq!(
             mvr_forward_resolution(
                 &SuiClientBuilder::default().build_testnet().await.unwrap(),

--- a/crates/key-server/src/tests/server.rs
+++ b/crates/key-server/src/tests/server.rs
@@ -16,7 +16,7 @@ async fn test_get_latest_checkpoint_timestamp() {
     let tc = SealTestCluster::new(0, 0).await;
 
     let tolerance = 20000;
-    let timestamp = get_latest_checkpoint_timestamp(tc.cluster.sui_client().clone())
+    let timestamp = get_latest_checkpoint_timestamp(tc.sui_client.clone())
         .await
         .unwrap();
 


### PR DESCRIPTION
## Description

- remove the TTL handling which is unnecessary
- instead of static variables, wrap the caches in structs owned by the server
- make the cache sizes configurable through the config file
- pass around an `Arc<SuiClient>` instead of always cloning the client

## Test plan 

Automatic tests.