### PR TITLE
feat(server): sui RPC error resilience

### DIFF
--- a/crates/key-server/src/key_server_options.rs
+++ b/crates/key-server/src/key_server_options.rs
@@ -54,6 +54,48 @@ pub enum ServerMode {
     },
 }
 
+/// Configuration for the RPC client.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcConfig {
+    /// The timeout for RPC requests.
+    pub timeout: Duration,
+
+    /// The retry configuration for RPC requests.
+    pub retry_config: RetryConfig,
+}
+
+impl Default for RpcConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(60),
+            retry_config: RetryConfig::default(),
+        }
+    }
+}
+
+/// Configuration for the retry logic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetryConfig {
+    /// The maximum number of retries.
+    pub max_retries: u32,
+
+    /// The minimum delay between retries.
+    pub min_delay: Duration,
+
+    /// The maximum delay between retries.
+    pub max_delay: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            min_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(10),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyServerOptions {
     /// The network this key server is running on.
@@ -98,6 +140,10 @@ pub struct KeyServerOptions {
         deserialize_with = "deserialize_duration"
     )]
     pub session_key_ttl_max: Duration,
+
+    /// The configuration for the Sui RPC client.
+    #[serde(default)]
+    pub rpc_config: RpcConfig,
 }
 
 impl KeyServerOptions {
@@ -118,6 +164,25 @@ impl KeyServerOptions {
             rgp_update_interval: default_rgp_update_interval(),
             allowed_staleness: default_allowed_staleness(),
             session_key_ttl_max: default_session_key_ttl_max(),
+            rpc_config: RpcConfig::default(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn new_for_testing(network: Network) -> Self {
+        Self {
+            network,
+            sdk_version_requirement: default_sdk_version_requirement(),
+            server_mode: ServerMode::Open {
+                legacy_key_server_object_id: None,
+                key_server_object_id: ObjectID::random(),
+            },
+            metrics_host_port: default_metrics_host_port(),
+            checkpoint_update_interval: default_checkpoint_update_interval(),
+            rgp_update_interval: default_rgp_update_interval(),
+            allowed_staleness: default_allowed_staleness(),
+            session_key_ttl_max: default_session_key_ttl_max(),
+            rpc_config: RpcConfig::default(),
         }
     }
 

--- a/crates/key-server/src/mvr.rs
+++ b/crates/key-server/src/mvr.rs
@@ -124,10 +124,10 @@ pub(crate) async fn mvr_forward_resolution(
 /// Given an MVR name, look up the record in the MVR registry on mainnet.
 async fn get_from_mvr_registry(
     mvr_name: &str,
-    sui_rpc_client: &SuiRpcClient,
+    mainnet_sui_rpc_client: &SuiRpcClient,
 ) -> Result<Field<Name, AppRecord>, InternalError> {
     let dynamic_field_name = dynamic_field_name(mvr_name)?;
-    let record_id = sui_rpc_client
+    let record_id = mainnet_sui_rpc_client
         .get_dynamic_field_object(
             ObjectID::from_str(MVR_REGISTRY).unwrap(),
             dynamic_field_name.clone(),
@@ -138,7 +138,7 @@ async fn get_from_mvr_registry(
         .map_err(|_| InvalidMVRName)?;
 
     // TODO: Is there a way to get the BCS data in the above call instead of making a second call?
-    get_object(record_id, sui_rpc_client).await
+    get_object(record_id, mainnet_sui_rpc_client).await
 }
 
 /// Construct a `DynamicFieldName` from an MVR name for use in the MVR registry.

--- a/crates/key-server/src/mvr.rs
+++ b/crates/key-server/src/mvr.rs
@@ -15,11 +15,13 @@
 
 use crate::errors::InternalError;
 use crate::errors::InternalError::{Failure, InvalidMVRName, InvalidPackage};
+use crate::key_server_options::KeyServerOptions;
 use crate::mvr::mainnet::mvr_core::app_record::AppRecord;
 use crate::mvr::mainnet::mvr_core::name::Name;
 use crate::mvr::mainnet::sui::dynamic_field::Field;
 use crate::mvr::mainnet::sui::vec_map::VecMap;
 use crate::mvr::testnet::mvr_metadata::package_info::PackageInfo;
+use crate::sui_rpc_client::SuiRpcClient;
 use crate::types::Network;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::Identifier;
@@ -30,7 +32,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::str::FromStr;
 use sui_sdk::rpc_types::SuiObjectDataOptions;
-use sui_sdk::{SuiClient, SuiClientBuilder};
+use sui_sdk::SuiClientBuilder;
 use sui_types::base_types::ObjectID;
 use sui_types::dynamic_field::DynamicFieldName;
 use sui_types::TypeTag;
@@ -67,12 +69,12 @@ impl<K: Eq + Hash, V> From<VecMap<K, V>> for HashMap<K, V> {
 
 /// Given an MVR name, look up the package it points to.
 pub(crate) async fn mvr_forward_resolution(
-    client: &SuiClient,
+    sui_rpc_client: &SuiRpcClient,
     mvr_name: &str,
-    network: &Network,
+    key_server_options: &KeyServerOptions,
 ) -> Result<ObjectID, InternalError> {
-    let package_address = match network {
-        Network::Mainnet => get_from_mvr_registry(mvr_name, client)
+    let package_address = match key_server_options.network {
+        Network::Mainnet => get_from_mvr_registry(mvr_name, sui_rpc_client)
             .await?
             .value
             .app_info
@@ -82,10 +84,14 @@ pub(crate) async fn mvr_forward_resolution(
         Network::Testnet => {
             let networks: HashMap<_, _> = get_from_mvr_registry(
                 mvr_name,
-                &SuiClientBuilder::default()
-                    .build_mainnet()
-                    .await
-                    .map_err(|_| Failure)?,
+                &SuiRpcClient::new(
+                    SuiClientBuilder::default()
+                        .request_timeout(key_server_options.rpc_config.timeout)
+                        .build_mainnet()
+                        .await
+                        .map_err(|_| Failure)?,
+                    key_server_options.rpc_config.retry_config.clone(),
+                ),
             )
             .await?
             .value
@@ -99,7 +105,7 @@ pub(crate) async fn mvr_forward_resolution(
                 .package_info_id
                 .ok_or(Failure)
                 .map(|id| ObjectID::new(id.into_inner()))?;
-            let package_info: PackageInfo = get_object(package_info_id, client).await?;
+            let package_info: PackageInfo = get_object(package_info_id, sui_rpc_client).await?;
 
             // Check that the name in the package info matches the MVR name.
             let metadata: HashMap<_, _> = package_info.metadata.into();
@@ -118,14 +124,13 @@ pub(crate) async fn mvr_forward_resolution(
 /// Given an MVR name, look up the record in the MVR registry on mainnet.
 async fn get_from_mvr_registry(
     mvr_name: &str,
-    mainnet_client: &SuiClient,
+    sui_rpc_client: &SuiRpcClient,
 ) -> Result<Field<Name, AppRecord>, InternalError> {
     let dynamic_field_name = dynamic_field_name(mvr_name)?;
-    let record_id = mainnet_client
-        .read_api()
+    let record_id = sui_rpc_client
         .get_dynamic_field_object(
             ObjectID::from_str(MVR_REGISTRY).unwrap(),
-            dynamic_field_name,
+            dynamic_field_name.clone(),
         )
         .await
         .map_err(|_| Failure)?
@@ -133,7 +138,7 @@ async fn get_from_mvr_registry(
         .map_err(|_| InvalidMVRName)?;
 
     // TODO: Is there a way to get the BCS data in the above call instead of making a second call?
-    get_object(record_id, mainnet_client).await
+    get_object(record_id, sui_rpc_client).await
 }
 
 /// Construct a `DynamicFieldName` from an MVR name for use in the MVR registry.
@@ -157,11 +162,10 @@ fn dynamic_field_name(mvr_name: &str) -> Result<DynamicFieldName, InternalError>
 
 async fn get_object<T: for<'a> Deserialize<'a>>(
     object_id: ObjectID,
-    client: &SuiClient,
+    sui_rpc_client: &SuiRpcClient,
 ) -> Result<T, InternalError> {
     bcs::from_bytes(
-        client
-            .read_api()
+        sui_rpc_client
             .get_object_with_options(object_id, SuiObjectDataOptions::new().with_bcs())
             .await
             .map_err(|_| Failure)?
@@ -174,7 +178,9 @@ async fn get_object<T: for<'a> Deserialize<'a>>(
 #[cfg(test)]
 mod tests {
     use crate::errors::InternalError::InvalidMVRName;
+    use crate::key_server_options::{KeyServerOptions, RetryConfig};
     use crate::mvr::mvr_forward_resolution;
+    use crate::sui_rpc_client::SuiRpcClient;
     use crate::types::Network;
     use mvr_types::name::VersionedName;
     use std::str::FromStr;
@@ -185,8 +191,11 @@ mod tests {
     async fn test_forward_resolution() {
         assert!(crate::externals::check_mvr_package_id(
             &Some("@mysten/kiosk".to_string()),
-            &SuiClientBuilder::default().build_mainnet().await.unwrap(),
-            &Network::Mainnet,
+            &SuiRpcClient::new(
+                SuiClientBuilder::default().build_mainnet().await.unwrap(),
+                RetryConfig::default(),
+            ),
+            &KeyServerOptions::new_for_testing(Network::Mainnet),
             ObjectID::from_str(
                 "0xdfb4f1d4e43e0c3ad834dcd369f0d39005c872e118c9dc1c5da9765bb93ee5f3"
             )
@@ -208,9 +217,12 @@ mod tests {
         );
         assert_eq!(
             mvr_forward_resolution(
-                &SuiClientBuilder::default().build_testnet().await.unwrap(),
+                &SuiRpcClient::new(
+                    SuiClientBuilder::default().build_testnet().await.unwrap(),
+                    RetryConfig::default()
+                ),
                 "@mysten/kiosk",
-                &Network::Testnet
+                &KeyServerOptions::new_for_testing(Network::Testnet),
             )
             .await
             .unwrap(),
@@ -223,9 +235,12 @@ mod tests {
         // This MVR name is not registered on mainnet.
         assert_eq!(
             mvr_forward_resolution(
-                &SuiClientBuilder::default().build_mainnet().await.unwrap(),
+                &SuiRpcClient::new(
+                    SuiClientBuilder::default().build_mainnet().await.unwrap(),
+                    RetryConfig::default(),
+                ),
                 "@pkg/seal-demo-1234",
-                &Network::Mainnet
+                &KeyServerOptions::new_for_testing(Network::Mainnet),
             )
             .await
             .err()
@@ -236,9 +251,12 @@ mod tests {
         // ..but it is on testnet.
         assert_eq!(
             mvr_forward_resolution(
-                &SuiClientBuilder::default().build_testnet().await.unwrap(),
+                &SuiRpcClient::new(
+                    SuiClientBuilder::default().build_testnet().await.unwrap(),
+                    RetryConfig::default(),
+                ),
                 "@pkg/seal-demo-1234",
-                &Network::Testnet
+                &KeyServerOptions::new_for_testing(Network::Testnet),
             )
             .await
             .unwrap(),
@@ -253,9 +271,12 @@ mod tests {
     async fn test_invalid_name() {
         assert_eq!(
             mvr_forward_resolution(
-                &SuiClientBuilder::default().build_mainnet().await.unwrap(),
+                &SuiRpcClient::new(
+                    SuiClientBuilder::default().build_mainnet().await.unwrap(),
+                    RetryConfig::default(),
+                ),
                 "@saemundur/seal",
-                &Network::Mainnet
+                &KeyServerOptions::new_for_testing(Network::Mainnet),
             )
             .await
             .err()
@@ -265,9 +286,12 @@ mod tests {
 
         assert_eq!(
             mvr_forward_resolution(
-                &SuiClientBuilder::default().build_mainnet().await.unwrap(),
+                &SuiRpcClient::new(
+                    SuiClientBuilder::default().build_mainnet().await.unwrap(),
+                    RetryConfig::default(),
+                ),
                 "invalid_name",
-                &Network::Mainnet
+                &KeyServerOptions::new_for_testing(Network::Mainnet),
             )
             .await
             .err()

--- a/crates/key-server/src/sui_rpc_client.rs
+++ b/crates/key-server/src/sui_rpc_client.rs
@@ -1,0 +1,385 @@
+// Copyright (c), Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use crypto::ObjectID;
+use sui_sdk::{
+    error::SuiRpcResult,
+    rpc_types::{
+        Checkpoint, CheckpointId, DryRunTransactionBlockResponse, SuiObjectDataOptions,
+        SuiObjectResponse,
+    },
+    SuiClient,
+};
+use sui_types::{dynamic_field::DynamicFieldName, transaction::TransactionData};
+
+use crate::key_server_options::RetryConfig;
+
+/// Trait for determining if an error is retriable
+pub trait RetriableError {
+    /// Returns true if the error is transient and the operation should be retried
+    fn is_retriable_error(&self) -> bool;
+}
+
+impl RetriableError for sui_sdk::error::Error {
+    fn is_retriable_error(&self) -> bool {
+        match self {
+            // Low level networking errors are retriable.
+            // TODO: Add more retriable errors here
+            sui_sdk::error::Error::RpcError(rpc_error) => {
+                matches!(
+                    rpc_error,
+                    jsonrpsee::core::ClientError::Transport(_)
+                        | jsonrpsee::core::ClientError::RequestTimeout
+                )
+            }
+            _ => false,
+        }
+    }
+}
+
+/// Executes an async function with automatic retries for retriable errors
+async fn sui_rpc_with_retries<T, E, F, Fut>(rpc_config: &RetryConfig, mut func: F) -> Result<T, E>
+where
+    E: RetriableError,
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<T, E>>,
+{
+    let mut attempts_remaining = rpc_config.max_retries;
+    let mut current_delay = rpc_config.min_delay;
+
+    loop {
+        let result = func().await;
+
+        // Return immediately on success
+        if result.is_ok() {
+            return result;
+        }
+
+        // Check if error is retriable and we have attempts left
+        if let Err(ref error) = result {
+            if error.is_retriable_error() && attempts_remaining > 1 {
+                // Wait before retrying with exponential backoff
+                tokio::time::sleep(current_delay).await;
+
+                // Implement exponential backoff.
+                // Double the delay for next retry, but cap at max_delay
+                current_delay = std::cmp::min(current_delay * 2, rpc_config.max_delay);
+                attempts_remaining -= 1;
+                continue;
+            }
+        }
+
+        // Either non-retriable error or no attempts remaining
+        return result;
+    }
+}
+
+/// Client for interacting with the Sui RPC API.
+#[derive(Clone)]
+pub struct SuiRpcClient {
+    sui_client: SuiClient,
+    rpc_retry_config: RetryConfig,
+}
+
+impl SuiRpcClient {
+    pub fn new(sui_client: SuiClient, rpc_retry_config: RetryConfig) -> Self {
+        Self {
+            sui_client,
+            rpc_retry_config,
+        }
+    }
+
+    /// Returns a reference to the underlying SuiClient.
+    pub fn sui_client(&self) -> &SuiClient {
+        &self.sui_client
+    }
+
+    /// Dry runs a transaction block.
+    pub async fn dry_run_transaction_block(
+        &self,
+        tx_data: TransactionData,
+    ) -> SuiRpcResult<DryRunTransactionBlockResponse> {
+        sui_rpc_with_retries(&self.rpc_retry_config, || async {
+            self.sui_client
+                .read_api()
+                .dry_run_transaction_block(tx_data.clone())
+                .await
+        })
+        .await
+    }
+
+    /// Returns an object with the given options.
+    pub async fn get_object_with_options(
+        &self,
+        object_id: ObjectID,
+        options: SuiObjectDataOptions,
+    ) -> SuiRpcResult<SuiObjectResponse> {
+        sui_rpc_with_retries(&self.rpc_retry_config, || async {
+            self.sui_client
+                .read_api()
+                .get_object_with_options(object_id, options.clone())
+                .await
+        })
+        .await
+    }
+
+    /// Returns the latest checkpoint sequence number.
+    pub async fn get_latest_checkpoint_sequence_number(&self) -> SuiRpcResult<u64> {
+        sui_rpc_with_retries(&self.rpc_retry_config, || async {
+            self.sui_client
+                .read_api()
+                .get_latest_checkpoint_sequence_number()
+                .await
+        })
+        .await
+    }
+
+    /// Returns a checkpoint by its sequence number.
+    pub async fn get_checkpoint(&self, checkpoint_id: CheckpointId) -> SuiRpcResult<Checkpoint> {
+        sui_rpc_with_retries(&self.rpc_retry_config, || async {
+            self.sui_client
+                .read_api()
+                .get_checkpoint(checkpoint_id)
+                .await
+        })
+        .await
+    }
+
+    /// Returns the current reference gas price.
+    pub async fn get_reference_gas_price(&self) -> SuiRpcResult<u64> {
+        sui_rpc_with_retries(&self.rpc_retry_config, || async {
+            self.sui_client.read_api().get_reference_gas_price().await
+        })
+        .await
+    }
+
+    /// Returns an object with the given dynamic field name.
+    pub async fn get_dynamic_field_object(
+        &self,
+        object_id: ObjectID,
+        dynamic_field_name: DynamicFieldName,
+    ) -> SuiRpcResult<SuiObjectResponse> {
+        sui_rpc_with_retries(&self.rpc_retry_config, || async {
+            self.sui_client
+                .read_api()
+                .get_dynamic_field_object(object_id, dynamic_field_name.clone())
+                .await
+        })
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::key_server_options::RetryConfig;
+    use crate::sui_rpc_client::sui_rpc_with_retries;
+    use crate::sui_rpc_client::RetriableError;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    /// Mock error type for testing retry behavior
+    #[derive(Debug, Clone)]
+    struct MockError {
+        is_retriable: bool,
+    }
+
+    impl std::fmt::Display for MockError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "MockError(retriable: {})", self.is_retriable)
+        }
+    }
+
+    impl std::error::Error for MockError {}
+
+    impl RetriableError for MockError {
+        fn is_retriable_error(&self) -> bool {
+            self.is_retriable
+        }
+    }
+
+    /// Mock function that tracks call count and returns errors as configured
+    async fn mock_function_with_counter(
+        counter: Arc<AtomicU32>,
+        fail_count: u32,
+        error_type: MockError,
+    ) -> Result<String, MockError> {
+        let call_count = counter.fetch_add(1, Ordering::SeqCst) + 1;
+
+        if call_count <= fail_count {
+            Err(error_type)
+        } else {
+            Ok(format!("Success on attempt {}", call_count))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_sui_rpc_with_retries_success_first_attempt() {
+        let retry_config = RetryConfig {
+            max_retries: 3,
+            min_delay: Duration::from_millis(10),
+            max_delay: Duration::from_millis(100),
+        };
+
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_clone = counter.clone();
+
+        let result = sui_rpc_with_retries(&retry_config, || async {
+            mock_function_with_counter(
+                counter_clone.clone(),
+                0, // Don't fail any attempts
+                MockError { is_retriable: true },
+            )
+            .await
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Success on attempt 1");
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_sui_rpc_with_retries_success_after_retriable_failures() {
+        let retry_config = RetryConfig {
+            max_retries: 3,
+            min_delay: Duration::from_millis(10),
+            max_delay: Duration::from_millis(100),
+        };
+
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_clone = counter.clone();
+
+        let result = sui_rpc_with_retries(&retry_config, || async {
+            mock_function_with_counter(
+                counter_clone.clone(),
+                2, // Fail first 2 attempts, succeed on 3rd
+                MockError { is_retriable: true },
+            )
+            .await
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "Success on attempt 3");
+        assert_eq!(counter.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn test_sui_rpc_with_retries_exhausts_all_retries() {
+        let retry_config = RetryConfig {
+            max_retries: 3,
+            min_delay: Duration::from_millis(10),
+            max_delay: Duration::from_millis(100),
+        };
+
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_clone = counter.clone();
+
+        let result = sui_rpc_with_retries(&retry_config, || async {
+            mock_function_with_counter(
+                counter_clone.clone(),
+                10, // Fail more attempts than max_retries
+                MockError { is_retriable: true },
+            )
+            .await
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().is_retriable);
+        assert_eq!(counter.load(Ordering::SeqCst), 3); // max_retries attempts
+    }
+
+    #[tokio::test]
+    async fn test_sui_rpc_with_retries_non_retriable_error() {
+        let retry_config = RetryConfig {
+            max_retries: 3,
+            min_delay: Duration::from_millis(10),
+            max_delay: Duration::from_millis(100),
+        };
+
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_clone = counter.clone();
+
+        let result = sui_rpc_with_retries(&retry_config, || async {
+            mock_function_with_counter(
+                counter_clone.clone(),
+                10, // Fail more attempts than max_retries
+                MockError {
+                    is_retriable: false,
+                }, // Non-retriable error
+            )
+            .await
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert!(!result.unwrap_err().is_retriable);
+        assert_eq!(counter.load(Ordering::SeqCst), 1); // Should only attempt once
+    }
+
+    #[tokio::test]
+    async fn test_sui_rpc_with_retries_zero_retries() {
+        let retry_config = RetryConfig {
+            max_retries: 1, // Only one attempt
+            min_delay: Duration::from_millis(10),
+            max_delay: Duration::from_millis(100),
+        };
+
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_clone = counter.clone();
+
+        let result = sui_rpc_with_retries(&retry_config, || async {
+            mock_function_with_counter(
+                counter_clone.clone(),
+                10, // Always fail
+                MockError { is_retriable: true },
+            )
+            .await
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(counter.load(Ordering::SeqCst), 1); // Should only attempt once
+    }
+
+    #[tokio::test]
+    async fn test_exponential_backoff_delays() {
+        let retry_config = RetryConfig {
+            max_retries: 6,
+            min_delay: Duration::from_millis(100),
+            max_delay: Duration::from_millis(1000),
+        };
+
+        let counter = Arc::new(AtomicU32::new(0));
+        let counter_clone = counter.clone();
+
+        let start_time = std::time::Instant::now();
+
+        let result = sui_rpc_with_retries(&retry_config, || async {
+            mock_function_with_counter(
+                counter_clone.clone(),
+                5, // Fail first 5 attempts, succeed on 6th
+                MockError { is_retriable: true },
+            )
+            .await
+        })
+        .await;
+
+        let elapsed = start_time.elapsed();
+
+        assert!(result.is_ok());
+        assert_eq!(counter.load(Ordering::SeqCst), 6);
+
+        // Expected delays: 100ms, 200ms, 400ms, 800ms, 1000ms (exponential backoff with max cap)
+        // Total expected minimum delay: 2500ms
+        let expected_min_duration = Duration::from_millis(2500);
+        assert!(
+            elapsed >= expected_min_duration,
+            "Expected at least {:?} but got {:?}",
+            expected_min_duration,
+            elapsed
+        );
+    }
+}

--- a/crates/key-server/src/tests/e2e.rs
+++ b/crates/key-server/src/tests/e2e.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::errors::InternalError::UnsupportedPackageId;
-use crate::key_server_options::{ClientConfig, ClientKeyType, KeyServerOptions, ServerMode};
+use crate::key_server_options::{
+    ClientConfig, ClientKeyType, KeyServerOptions, RetryConfig, RpcConfig, ServerMode,
+};
+use crate::sui_rpc_client::SuiRpcClient;
 use crate::tests::externals::get_key;
 use crate::tests::whitelist::{add_user_to_whitelist, create_whitelist, whitelist_create_ptb};
 use crate::tests::SealTestCluster;
@@ -382,6 +385,7 @@ async fn create_server(
         sdk_version_requirement: VersionReq::from_str(">=0.4.6").unwrap(),
         allowed_staleness: Duration::from_secs(120),
         session_key_ttl_max: from_mins(30),
+        rpc_config: RpcConfig::default(),
     };
 
     let vars = vars
@@ -391,7 +395,7 @@ async fn create_server(
         .collect::<Vec<_>>();
 
     Server {
-        sui_client,
+        sui_rpc_client: SuiRpcClient::new(sui_client, RetryConfig::default()),
         master_keys: temp_env::with_vars(vars, || MasterKeys::load(&options)).unwrap(),
         key_server_oid_to_pop: HashMap::new(),
         options,

--- a/crates/key-server/src/tests/mod.rs
+++ b/crates/key-server/src/tests/mod.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::externals::{add_package, add_upgraded_package};
-use crate::key_server_options::{KeyServerOptions, ServerMode};
+use crate::key_server_options::{KeyServerOptions, RetryConfig, RpcConfig, ServerMode};
+use crate::sui_rpc_client::SuiRpcClient;
 use crate::tests::KeyServerType::Open;
 use crate::types::Network;
 use crate::{from_mins, DefaultEncoding, MasterKeys, Server};
@@ -111,7 +112,10 @@ impl SealTestCluster {
                     )
                     .await;
                 let server = Server {
-                    sui_client: self.cluster.sui_client().clone(),
+                    sui_rpc_client: SuiRpcClient::new(
+                        self.cluster.sui_client().clone(),
+                        RetryConfig::default(),
+                    ),
                     master_keys: MasterKeys::Open { master_key },
                     key_server_oid_to_pop: HashMap::new(),
                     options: KeyServerOptions {
@@ -126,6 +130,7 @@ impl SealTestCluster {
                         sdk_version_requirement: VersionReq::from_str(">=0.4.6").unwrap(),
                         allowed_staleness: Duration::from_secs(120),
                         session_key_ttl_max: from_mins(30),
+                        rpc_config: RpcConfig::default(),
                     },
                 };
                 self.servers.push((key_server_object_id, server));

--- a/crates/key-server/src/tests/server.rs
+++ b/crates/key-server/src/tests/server.rs
@@ -7,8 +7,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use tracing_test::traced_test;
 
 use crate::externals::get_latest_checkpoint_timestamp;
+use crate::key_server_options::RetryConfig;
 use crate::metrics::Metrics;
 use crate::start_server_background_tasks;
+use crate::sui_rpc_client::SuiRpcClient;
 use crate::tests::SealTestCluster;
 
 #[tokio::test]
@@ -16,9 +18,12 @@ async fn test_get_latest_checkpoint_timestamp() {
     let tc = SealTestCluster::new(0).await;
 
     let tolerance = 20000;
-    let timestamp = get_latest_checkpoint_timestamp(tc.cluster.sui_client().clone())
-        .await
-        .unwrap();
+    let timestamp = get_latest_checkpoint_timestamp(SuiRpcClient::new(
+        tc.cluster.sui_client().clone(),
+        RetryConfig::default(),
+    ))
+    .await
+    .unwrap();
 
     let actual_timestamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
## Description 

This PR improves Seal Server RPC interaction with Sui in two aspects:
- Adding a configurable RPC timeout to the Sui client
- Add add retry behavior to allow automatic retry on certain errors (e.g. low level networking error).

The implementation wraps the Sui client into a SuiRpcClient struct.

Completes CRY-291

## Test plan 

How did you test the new or updated feature?