### PR TITLE
chore: fix logging runtime guard

### DIFF
--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -752,6 +752,7 @@ async fn start_server_background_tasks(
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let _guard = mysten_service::logging::init();
     let (monitor_handle, app) = app().await?;
 
     tokio::select! {
@@ -767,8 +768,6 @@ async fn main() -> Result<()> {
 }
 
 pub(crate) async fn app() -> Result<(JoinHandle<Result<()>>, Router)> {
-    let _guard = mysten_service::logging::init();
-
     // If CONFIG_PATH is set, read the configuration from the file.
     // Otherwise, use the local environment variables.
     let options = match env::var("CONFIG_PATH") {


### PR DESCRIPTION
## Description 

the logging runtime guard should cover the whole binary instead just of the http app, it'll be dropped shorted after `let (monitor_handle, app) = app().await?;` returned

## Test plan 

tested locally, now logs are flowing just fine