### PR TITLE
[do not merge] Lattice-based IBE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
  "http 1.4.0",
  "matchit 0.5.0",
  "pin-project-lite",
- "pkcs8",
+ "pkcs8 0.10.2",
  "quinn",
  "quinn-proto",
  "rand 0.8.6",
@@ -856,6 +856,12 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
 ]
+
+[[package]]
+name = "az"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
 
 [[package]]
 name = "backoff"
@@ -1717,7 +1723,7 @@ name = "consensus-config"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c1bff48780e5f#a3cc4467c9de48410a01fc2b6f3c1bff48780e5f"
 dependencies = [
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "mysten-network",
  "rand 0.8.6",
  "serde",
@@ -1741,7 +1747,7 @@ dependencies = [
  "dashmap 5.5.3",
  "enum_dispatch",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "futures",
  "http 1.4.0",
  "itertools 0.13.0",
@@ -1785,7 +1791,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c
 dependencies = [
  "base64 0.21.7",
  "consensus-config",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "serde",
 ]
 
@@ -2040,7 +2046,8 @@ name = "crypto"
 version = "0.6.7"
 dependencies = [
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
+ "fastcrypto-lattice",
  "fastcrypto-tbls",
  "hex",
  "itertools 0.14.0",
@@ -2329,6 +2336,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
+ "pem-rfc7468 0.6.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2338,7 +2347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "zeroize",
 ]
 
@@ -2640,7 +2649,7 @@ dependencies = [
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
  "signature 2.2.0",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2649,7 +2658,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
+ "pkcs8 0.10.2",
  "signature 2.2.0",
  "zeroize",
 ]
@@ -2720,8 +2729,8 @@ dependencies = [
  "ff 0.13.1",
  "generic-array",
  "group 0.13.0",
- "pem-rfc7468",
- "pkcs8",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.3",
  "subtle",
@@ -2876,6 +2885,57 @@ dependencies = [
 [[package]]
 name = "fastcrypto"
 version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e06674cac3bf7ec9a951971285e6051a45273dc4e265cca27c02a0d4ebcb46f8"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-secp256r1",
+ "ark-serialize",
+ "auto_ops",
+ "base64ct",
+ "bech32",
+ "bincode",
+ "blake2",
+ "blst",
+ "bs58 0.4.0",
+ "curve25519-dalek-ng",
+ "derive_more 0.99.20",
+ "digest 0.10.7",
+ "ecdsa 0.16.9",
+ "ed25519-consensus",
+ "elliptic-curve 0.13.8",
+ "fastcrypto-derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array",
+ "hex",
+ "hex-literal",
+ "hkdf",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "once_cell",
+ "p256",
+ "rand 0.8.6",
+ "readonly",
+ "rfc6979 0.4.0",
+ "rsa 0.8.2",
+ "schemars 0.8.22",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.9",
+ "sha3 0.10.8",
+ "signature 2.2.0",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tokio",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "fastcrypto"
+version = "0.1.9"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c#5f87e04bb21d295ef6b39375a06615d45cbb906c"
 dependencies = [
  "aes",
@@ -2903,7 +2963,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "ed25519-consensus",
  "elliptic-curve 0.13.8",
- "fastcrypto-derive",
+ "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "generic-array",
  "hex",
  "hex-literal",
@@ -2917,7 +2977,7 @@ dependencies = [
  "rand 0.8.6",
  "readonly",
  "rfc6979 0.4.0",
- "rsa",
+ "rsa 0.9.10",
  "schemars 0.8.22",
  "secp256k1",
  "serde",
@@ -2937,10 +2997,43 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c0c2af2157f416cb885e11d36cd0de2753f6d5384752d364075c835f5f8f891"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "fastcrypto-derive"
+version = "0.1.3"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c#5f87e04bb21d295ef6b39375a06615d45cbb906c"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "fastcrypto-lattice"
+version = "0.1.0"
+source = "git+https://github.com/MystenLabs/fastcrypto-lattice?rev=20a0d5c#20a0d5cf08fc3f33b8cf3f8f8f2a17751b562a51"
+dependencies = [
+ "bit-vec 0.6.3",
+ "fastcrypto 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex",
+ "itertools 0.12.1",
+ "num",
+ "num-complex",
+ "once_cell",
+ "rand 0.8.6",
+ "rand_distr",
+ "rug",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha3 0.10.8",
 ]
 
 [[package]]
@@ -2950,7 +3043,7 @@ source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39
 dependencies = [
  "bcs",
  "digest 0.10.7",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "hex",
  "itertools 0.10.5",
  "rand 0.8.6",
@@ -2969,7 +3062,7 @@ version = "0.1.0"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c#5f87e04bb21d295ef6b39375a06615d45cbb906c"
 dependencies = [
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "lazy_static",
  "num-bigint 0.4.6",
  "num-integer",
@@ -2995,7 +3088,7 @@ dependencies = [
  "bcs",
  "byte-slice-cast",
  "derive_more 0.99.20",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "ff 0.13.1",
  "im",
  "itertools 0.12.1",
@@ -3436,6 +3529,16 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gmp-mpfr-sys"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7db155b537cb791b133341f99f68371d86ee7fa4c79aacfbc376d72d23c70531"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "governor"
@@ -4548,7 +4651,7 @@ dependencies = [
  "bcs",
  "crypto",
  "duration-str",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-tbls",
  "futures",
  "git-version",
@@ -6783,6 +6886,15 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d159833a9105500e0398934e205e0773f0b27529557134ecfc51c27646adac"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
@@ -6894,13 +7006,35 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eff33bdbdfc54cc98a2eca766ebdec3e1b8fb7387523d5c9c9a2891da856f719"
+dependencies = [
+ "der 0.6.1",
+ "pkcs8 0.9.0",
+ "spki 0.6.0",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
  "der 0.7.10",
- "pkcs8",
- "spki",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -6910,7 +7044,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der 0.7.10",
- "spki",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -7604,6 +7738,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7929,6 +8073,27 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rsa"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55a77d189da1fee555ad95b7e50e7457d91c0e089ec68ca69ad2989413bbdab4"
+dependencies = [
+ "byteorder",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1 0.4.1",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
@@ -7938,14 +8103,26 @@ dependencies = [
  "num-bigint-dig",
  "num-integer",
  "num-traits",
- "pkcs1",
- "pkcs8",
+ "pkcs1 0.7.5",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sha2 0.10.9",
  "signature 2.2.0",
- "spki",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rug"
+version = "1.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a8857882aec59d27254b02481c709327c13de6fad1da60bfc4f9783eaaa61e"
+dependencies = [
+ "az",
+ "gmp-mpfr-sys",
+ "libc",
+ "libm",
 ]
 
 [[package]]
@@ -8260,7 +8437,7 @@ dependencies = [
  "bcs",
  "clap",
  "crypto",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "rand 0.8.6",
  "reqwest",
  "seal-committee",
@@ -8279,7 +8456,7 @@ version = "0.6.7"
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-tbls",
  "prost-types 0.14.3",
  "serde",
@@ -8297,7 +8474,7 @@ dependencies = [
  "bcs",
  "clap",
  "dirs 5.0.1",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-tbls",
  "move-package-alt-compilation",
  "prost-types 0.14.3",
@@ -8354,7 +8531,7 @@ dependencies = [
  "bcs",
  "chrono",
  "crypto",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "rand 0.8.6",
  "serde",
  "serde_json",
@@ -8385,7 +8562,7 @@ dependencies = [
  "base16ct 0.2.0",
  "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -8724,7 +8901,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c
 dependencies = [
  "bcs",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "serde",
  "serde_repr",
 ]
@@ -8915,6 +9092,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
 ]
 
 [[package]]
@@ -9297,7 +9484,7 @@ dependencies = [
  "consensus-config",
  "csv",
  "dirs 4.0.0",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "move-vm-config",
  "mysten-common",
  "nonzero_ext",
@@ -9341,7 +9528,7 @@ dependencies = [
  "either",
  "enum_dispatch",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "futures",
@@ -9562,7 +9749,7 @@ dependencies = [
  "anyhow",
  "bcs",
  "camino",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "move-core-types",
  "mysten-common",
  "prometheus",
@@ -9609,7 +9796,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "move-binary-format",
  "move-bytecode-utils",
  "move-core-types",
@@ -9633,7 +9820,7 @@ dependencies = [
  "bcs",
  "cached",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-zkp",
  "futures",
  "hyper 1.8.1",
@@ -9680,7 +9867,7 @@ version = "0.0.0"
 source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c1bff48780e5f#a3cc4467c9de48410a01fc2b6f3c1bff48780e5f"
 dependencies = [
  "anyhow",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "jsonrpsee",
  "mysten-metrics",
  "once_cell",
@@ -9703,7 +9890,7 @@ dependencies = [
  "bcs",
  "colored",
  "enum_dispatch",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "itertools 0.13.0",
  "json_to_table",
  "move-binary-format",
@@ -9740,7 +9927,7 @@ dependencies = [
  "bcs",
  "bip32",
  "colored",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "jsonrpc",
  "mockall",
  "mysten-common",
@@ -9773,7 +9960,7 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c1bff48780e5f#a3cc4467c9de48410a01fc2b6f3c1bff48780e5f"
 dependencies = [
  "anyhow",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "mysten-metrics",
  "prometheus",
  "reqwest",
@@ -9790,7 +9977,7 @@ version = "1.71.0"
 source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c1bff48780e5f#a3cc4467c9de48410a01fc2b6f3c1bff48780e5f"
 dependencies = [
  "anyhow",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
@@ -9817,7 +10004,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
  "indexmap 2.13.0",
@@ -9838,7 +10025,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-zkp",
  "linked-hash-map",
  "move-binary-format",
@@ -9859,7 +10046,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-zkp",
  "linked-hash-map",
  "move-binary-format",
@@ -9880,7 +10067,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-zkp",
  "indexmap 2.13.0",
  "move-binary-format",
@@ -9901,7 +10088,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
  "indexmap 2.13.0",
@@ -9943,7 +10130,7 @@ dependencies = [
  "bytes",
  "dashmap 5.5.3",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-tbls",
  "futures",
  "governor",
@@ -9998,7 +10185,7 @@ dependencies = [
  "bcs",
  "bin-version",
  "clap",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-zkp",
  "futures",
  "http 1.4.0",
@@ -10126,7 +10313,7 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c1bff48780e5f#a3cc4467c9de48410a01fc2b6f3c1bff48780e5f"
 dependencies = [
  "clap",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "move-binary-format",
  "move-core-types",
  "move-vm-config",
@@ -10185,7 +10372,7 @@ dependencies = [
  "axum 0.8.8",
  "bcs",
  "bytes",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "futures",
  "http 1.4.0",
  "itertools 0.13.0",
@@ -10234,7 +10421,7 @@ dependencies = [
  "async-trait",
  "base64 0.21.7",
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "futures",
  "futures-core",
  "jsonrpsee",
@@ -10303,7 +10490,7 @@ dependencies = [
  "anemo",
  "anemo-tower",
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "lru 0.10.1",
  "move-package-alt",
  "move-package-alt-compilation",
@@ -10329,7 +10516,7 @@ dependencies = [
  "bcs",
  "byteorder",
  "bytes",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "futures",
  "indicatif",
  "integer-encoding",
@@ -10363,7 +10550,7 @@ dependencies = [
  "chrono",
  "clap",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "futures",
  "hyper 1.8.1",
  "hyper-rustls",
@@ -10436,7 +10623,7 @@ dependencies = [
  "anemo",
  "anyhow",
  "bcs",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "mysten-common",
  "prometheus",
  "rand 0.8.6",
@@ -10489,8 +10676,8 @@ dependencies = [
  "axum 0.8.8",
  "axum-server",
  "ed25519",
- "fastcrypto",
- "pkcs8",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
+ "pkcs8 0.10.2",
  "rcgen",
  "reqwest",
  "rustls",
@@ -10552,7 +10739,7 @@ dependencies = [
  "derive_more 1.0.0",
  "enum_dispatch",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "im",
@@ -11769,7 +11956,7 @@ dependencies = [
  "bcs",
  "bincode",
  "eyre",
- "fastcrypto",
+ "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=5f87e04bb21d295ef6b39375a06615d45cbb906c)",
  "fdlimit",
  "hdrhistogram",
  "msim",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3018,7 +3018,7 @@ dependencies = [
 [[package]]
 name = "fastcrypto-lattice"
 version = "0.1.0"
-source = "git+https://github.com/MystenLabs/fastcrypto-lattice?rev=20a0d5c#20a0d5cf08fc3f33b8cf3f8f8f2a17751b562a51"
+source = "git+https://github.com/MystenLabs/fastcrypto-lattice?rev=249d3e7#249d3e73d628b3d0d8391af0c36e4f5a5db07ebe"
 dependencies = [
  "bit-vec 0.6.3",
  "fastcrypto 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -15,6 +15,7 @@ bcs.workspace = true
 itertools.workspace = true
 serde_with.workspace = true
 sui-sdk-types.workspace = true
+fastcrypto-lattice = { path = "../../../fastcrypto-lattice" }
 
 typenum = "1.18.0"
 

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -15,7 +15,7 @@ bcs.workspace = true
 itertools.workspace = true
 serde_with.workspace = true
 sui-sdk-types.workspace = true
-fastcrypto-lattice = { path = "../../../fastcrypto-lattice" }
+fastcrypto-lattice = { git = "https://github.com/MystenLabs/fastcrypto-lattice", rev = "20a0d5c" }
 
 typenum = "1.18.0"
 

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -15,7 +15,7 @@ bcs.workspace = true
 itertools.workspace = true
 serde_with.workspace = true
 sui-sdk-types.workspace = true
-fastcrypto-lattice = { git = "https://github.com/MystenLabs/fastcrypto-lattice", rev = "20a0d5c" }
+fastcrypto-lattice = { git = "https://github.com/MystenLabs/fastcrypto-lattice", rev = "249d3e7" }
 
 typenum = "1.18.0"
 

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -1220,6 +1220,10 @@ mod tests {
             elapsed
         }
 
+        fn size(label: &str, bytes: usize) {
+            println!("    {label:<32}{bytes:>8} B");
+        }
+
         let data = b"Hello, World!".to_vec();
         let aad = Some(b"something".to_vec());
         let configs = [(3u8, 2u8), (5, 3), (7, 4), (10, 7)];
@@ -1243,6 +1247,11 @@ mod tests {
             let public_keys = IBEPublicKeys::BonehFranklinBLS12381(
                 keypairs.iter().map(|(_, pk)| *pk).collect_vec(),
             );
+
+            let master_key = keypairs[0].0;
+            bench("extract (1 user key)", 50, || {
+                ibe::extract(&master_key, &full_id)
+            });
 
             bench("seal_encrypt", 20, || {
                 seal_encrypt(
@@ -1285,6 +1294,21 @@ mod tests {
             bench("seal_decrypt (verify)", 20, || {
                 seal_decrypt(&encrypted, &usks, Some(&public_keys)).unwrap()
             });
+
+            size(
+                "public key size",
+                bcs::to_bytes(&keypairs[0].1).unwrap().len(),
+            );
+            size(
+                "user secret key size",
+                bcs::to_bytes(&ibe::extract(&keypairs[0].0, &full_id))
+                    .unwrap()
+                    .len(),
+            );
+            size(
+                "encrypted object size",
+                bcs::to_bytes(&encrypted).unwrap().len(),
+            );
         }
 
         println!();
@@ -1312,6 +1336,11 @@ mod tests {
                 .collect_vec();
             let public_keys =
                 IBEPublicKeys::Falcon512(keypairs.iter().map(|(pk, _)| pk.clone()).collect_vec());
+
+            let master_key = keypairs[0].1.clone();
+            bench("extract (1 user key)", 5, || {
+                fastcrypto_lattice::ibe::FalconIBE::extract(&master_key, &full_id)
+            });
 
             bench("seal_encrypt", 5, || {
                 seal_encrypt(
@@ -1359,6 +1388,24 @@ mod tests {
             bench("seal_decrypt (verify)", 5, || {
                 seal_decrypt(&encrypted, &usks, Some(&public_keys)).unwrap()
             });
+
+            size(
+                "public key size",
+                bcs::to_bytes(&keypairs[0].0).unwrap().len(),
+            );
+            size(
+                "user secret key size",
+                bcs::to_bytes(&fastcrypto_lattice::ibe::FalconIBE::extract(
+                    &keypairs[0].1,
+                    &full_id,
+                ))
+                .unwrap()
+                .len(),
+            );
+            size(
+                "encrypted object size",
+                bcs::to_bytes(&encrypted).unwrap().len(),
+            );
         }
     }
 }

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -1177,4 +1177,160 @@ mod tests {
             dem_key,
         ))
     }
+
+    /// Run with: cargo test --release -p crypto --lib bench_ibe -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn bench_ibe() {
+        use std::time::Instant;
+
+        fn fmt(d: std::time::Duration) -> String {
+            if d.as_secs_f64() >= 1.0 {
+                format!("{:>8.2} s ", d.as_secs_f64())
+            } else if d.as_millis() >= 1 {
+                format!("{:>8.2} ms", d.as_secs_f64() * 1e3)
+            } else {
+                format!("{:>8.2} us", d.as_secs_f64() * 1e6)
+            }
+        }
+
+        fn bench<R>(label: &str, iters: u32, f: impl Fn() -> R) -> std::time::Duration {
+            // Warm-up.
+            let _ = f();
+            let start = Instant::now();
+            for _ in 0..iters {
+                let _ = f();
+            }
+            let elapsed = start.elapsed() / iters;
+            println!("    {label:<32}{}  (avg of {iters})", fmt(elapsed));
+            elapsed
+        }
+
+        let data = b"Hello, World!".to_vec();
+        let aad = Some(b"something".to_vec());
+        let configs = [(3u8, 2u8), (5, 3), (7, 4), (10, 7)];
+
+        println!();
+        println!("=== Boneh-Franklin BLS12-381 ===");
+        for (n, t) in configs {
+            println!("  n={n}, threshold={t}");
+            let package_id = ObjectID::random();
+            let id = vec![1, 2, 3, 4];
+            let full_id = create_full_id(&package_id, &id);
+            let mut rng = rand::thread_rng();
+            let keypairs = (0..n).map(|_| ibe::generate_key_pair(&mut rng)).collect_vec();
+            let services = keypairs.iter().map(|_| ObjectID::random()).collect_vec();
+            let public_keys =
+                IBEPublicKeys::BonehFranklinBLS12381(keypairs.iter().map(|(_, pk)| *pk).collect_vec());
+
+            bench("seal_encrypt", 20, || {
+                seal_encrypt(
+                    package_id,
+                    id.clone(),
+                    services.clone(),
+                    &public_keys,
+                    t,
+                    EncryptionInput::Hmac256Ctr {
+                        data: data.clone(),
+                        aad: aad.clone(),
+                    },
+                )
+                .unwrap()
+            });
+
+            let (encrypted, _) = seal_encrypt(
+                package_id,
+                id.clone(),
+                services.clone(),
+                &public_keys,
+                t,
+                EncryptionInput::Hmac256Ctr {
+                    data: data.clone(),
+                    aad: aad.clone(),
+                },
+            )
+            .unwrap();
+            let usks = IBEUserSecretKeys::BonehFranklinBLS12381(
+                services
+                    .iter()
+                    .zip(&keypairs)
+                    .map(|(s, kp)| (*s, ibe::extract(&kp.0, &full_id)))
+                    .collect(),
+            );
+
+            bench("seal_decrypt (no verify)", 20, || {
+                seal_decrypt(&encrypted, &usks, None).unwrap()
+            });
+            bench("seal_decrypt (verify)", 20, || {
+                seal_decrypt(&encrypted, &usks, Some(&public_keys)).unwrap()
+            });
+        }
+
+        println!();
+        println!("=== Falcon-512 ===");
+        for (n, t) in configs {
+            println!("  n={n}, threshold={t}");
+            let package_id = ObjectID::random();
+            let id = vec![1, 2, 3, 4];
+            let full_id = create_full_id(&package_id, &id);
+
+            let kg_start = Instant::now();
+            let keypairs = (0..n)
+                .map(|_| fastcrypto_lattice::ibe::FalconIBE::keygen(&mut thread_rng()))
+                .collect_vec();
+            println!(
+                "    {:<32}{}  (one-shot, n={n})",
+                "FalconIBE::keygen total",
+                fmt(kg_start.elapsed())
+            );
+
+            let services = keypairs.iter().map(|_| ObjectID::random()).collect_vec();
+            let public_keys =
+                IBEPublicKeys::Falcon512(keypairs.iter().map(|(pk, _)| pk.clone()).collect_vec());
+
+            bench("seal_encrypt", 5, || {
+                seal_encrypt(
+                    package_id,
+                    id.clone(),
+                    services.clone(),
+                    &public_keys,
+                    t,
+                    EncryptionInput::Hmac256Ctr {
+                        data: data.clone(),
+                        aad: aad.clone(),
+                    },
+                )
+                .unwrap()
+            });
+
+            let (encrypted, _) = seal_encrypt(
+                package_id,
+                id.clone(),
+                services.clone(),
+                &public_keys,
+                t,
+                EncryptionInput::Hmac256Ctr {
+                    data: data.clone(),
+                    aad: aad.clone(),
+                },
+            )
+            .unwrap();
+            let usks = IBEUserSecretKeys::Falcon512(
+                services
+                    .iter()
+                    .zip(&keypairs)
+                    .map(|(s, kp)| {
+                        (*s, fastcrypto_lattice::ibe::FalconIBE::extract(&kp.1, &full_id))
+                    })
+                    .collect(),
+            );
+
+            bench("seal_decrypt (no verify)", 5, || {
+                seal_decrypt(&encrypted, &usks, None).unwrap()
+            });
+            bench("seal_decrypt (verify)", 5, || {
+                seal_decrypt(&encrypted, &usks, Some(&public_keys)).unwrap()
+            });
+        }
+    }
 }

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -722,14 +722,13 @@ mod tests {
         let id = vec![1, 2, 3, 4];
         let full_id = create_full_id(&package_id, &id);
 
-        let mut rng = rand::thread_rng();
-        let keypairs = (0..3)
-            .map(|_| fastcrypto_lattice::ibe::FalconIBE::keygen(&mut rng))
+        let keypairs = (0..2)
+            .map(|_| fastcrypto_lattice::ibe::FalconIBE::keygen(&mut thread_rng()))
             .collect_vec();
 
         let services = keypairs.iter().map(|_| ObjectID::random()).collect_vec();
 
-        let threshold = 2;
+        let threshold = 1;
         let public_keys =
             IBEPublicKeys::Falcon512(keypairs.iter().map(|(pk, _)| pk.clone()).collect_vec());
 

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -82,6 +82,7 @@ pub enum IBEEncryptions {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum IBEPublicKeys {
     BonehFranklinBLS12381(Vec<ibe::PublicKey>),
+    Falcon(Vec<fastcrypto_lattice::falcon_util::PublicKey>),
 }
 
 pub enum IBEUserSecretKeys {

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -722,7 +722,7 @@ mod tests {
         let id = vec![1, 2, 3, 4];
         let full_id = create_full_id(&package_id, &id);
 
-        let keypairs = (0..2)
+        let keypairs = (0..3)
             .map(|_| fastcrypto_lattice::ibe::FalconIBE::keygen(&mut thread_rng()))
             .collect_vec();
 

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -183,8 +183,7 @@ pub fn seal_encrypt(
                 .zip(&services)
                 .zip(shares)
                 .map(|((pk, (_, idx)), share)| {
-                    let polys =
-                        derive_falcon_share_randomness(&randomness, *idx, pk, &full_id);
+                    let polys = derive_falcon_share_randomness(&randomness, *idx, pk, &full_id);
                     fastcrypto_lattice::ibe::FalconIBE::encrypt_deterministic(
                         polys,
                         pk,
@@ -527,6 +526,10 @@ impl IBEEncryptions {
                 let randomness = decrypt_randomness(encrypted_randomness, &randomness_key)?;
                 verify_nonce(&randomness, nonce)?;
             }
+            IBEEncryptions::Falcon512 { .. } => {
+                // No nonce to verify; the encrypted randomness only matters when
+                // `combine_and_check_share_consistency` is called with the public keys.
+            }
         }
         Ok(base_key)
     }
@@ -626,13 +629,12 @@ impl IBEEncryptions {
                         // Recompute the ciphertext deterministically and verify it matches.
                         // This catches any tampering with `(u, v)` — `w` is checked transitively
                         // via the polynomial-consistency check in the caller.
-                        let recomputed =
-                            fastcrypto_lattice::ibe::FalconIBE::encrypt_deterministic(
-                                (k, r, e1, e2),
-                                pk,
-                                &fastcrypto_lattice::ibe::Plaintext::<32>(share),
-                                full_id,
-                            );
+                        let recomputed = fastcrypto_lattice::ibe::FalconIBE::encrypt_deterministic(
+                            (k, r, e1, e2),
+                            pk,
+                            &fastcrypto_lattice::ibe::Plaintext::<32>(share),
+                            full_id,
+                        );
                         if bcs::to_bytes(&recomputed).expect("serializable")
                             != bcs::to_bytes(ciphertext).expect("serializable")
                         {
@@ -874,15 +876,19 @@ mod tests {
             .collect_vec();
 
         let services = keypairs.iter().map(|_| ObjectID::random()).collect_vec();
+        let services_ids = services
+            .into_iter()
+            .map(|id| NewObjectID::new(id.into_bytes()))
+            .collect_vec();
 
         let threshold = 1;
         let public_keys =
             IBEPublicKeys::Falcon512(keypairs.iter().map(|(pk, _)| pk.clone()).collect_vec());
 
-        let (encrypted, key) = seal_encrypt(
-            package_id,
+        let (encrypted, _key) = seal_encrypt(
+            NewObjectID::new(package_id.into_bytes()),
             id,
-            services.clone(),
+            services_ids.clone(),
             &public_keys,
             threshold,
             EncryptionInput::Aes256Gcm {
@@ -892,7 +898,7 @@ mod tests {
         )
         .unwrap();
 
-        let user_secret_keys = services
+        let user_secret_keys = services_ids
             .into_iter()
             .zip(keypairs)
             .map(|(s, kp)| {
@@ -925,14 +931,18 @@ mod tests {
             .map(|_| fastcrypto_lattice::ibe::FalconIBE::keygen(&mut thread_rng()))
             .collect_vec();
         let services = keypairs.iter().map(|_| ObjectID::random()).collect_vec();
+        let services_ids = services
+            .into_iter()
+            .map(|id| NewObjectID::new(id.into_bytes()))
+            .collect_vec();
         let threshold = 2;
         let public_keys =
             IBEPublicKeys::Falcon512(keypairs.iter().map(|(pk, _)| pk.clone()).collect_vec());
 
         let encrypted = seal_encrypt(
-            package_id,
+            NewObjectID::new(package_id.into_bytes()),
             id,
-            services.clone(),
+            services_ids.clone(),
             &public_keys,
             threshold,
             EncryptionInput::Hmac256Ctr {
@@ -944,16 +954,20 @@ mod tests {
         .0;
 
         let user_secret_keys = IBEUserSecretKeys::Falcon512(
-            services
+            services_ids
                 .iter()
                 .zip(&keypairs)
-                .map(|(s, kp)| (*s, fastcrypto_lattice::ibe::FalconIBE::extract(&kp.1, &full_id)))
+                .map(|(s, kp)| {
+                    (
+                        *s,
+                        fastcrypto_lattice::ibe::FalconIBE::extract(&kp.1, &full_id),
+                    )
+                })
                 .collect(),
         );
 
         // Decryption with verification should succeed.
-        let decrypted =
-            seal_decrypt(&encrypted, &user_secret_keys, Some(&public_keys)).unwrap();
+        let decrypted = seal_decrypt(&encrypted, &user_secret_keys, Some(&public_keys)).unwrap();
         assert_eq!(data, decrypted.as_slice());
 
         // Tampering with one encrypted_share's `w` should be caught by polynomial-consistency.
@@ -1215,17 +1229,24 @@ mod tests {
         for (n, t) in configs {
             println!("  n={n}, threshold={t}");
             let package_id = ObjectID::random();
+            let new_package_id = NewObjectID::new(package_id.into_bytes());
             let id = vec![1, 2, 3, 4];
             let full_id = create_full_id(&package_id, &id);
             let mut rng = rand::thread_rng();
-            let keypairs = (0..n).map(|_| ibe::generate_key_pair(&mut rng)).collect_vec();
-            let services = keypairs.iter().map(|_| ObjectID::random()).collect_vec();
-            let public_keys =
-                IBEPublicKeys::BonehFranklinBLS12381(keypairs.iter().map(|(_, pk)| *pk).collect_vec());
+            let keypairs = (0..n)
+                .map(|_| ibe::generate_key_pair(&mut rng))
+                .collect_vec();
+            let services = keypairs
+                .iter()
+                .map(|_| NewObjectID::new(ObjectID::random().into_bytes()))
+                .collect_vec();
+            let public_keys = IBEPublicKeys::BonehFranklinBLS12381(
+                keypairs.iter().map(|(_, pk)| *pk).collect_vec(),
+            );
 
             bench("seal_encrypt", 20, || {
                 seal_encrypt(
-                    package_id,
+                    new_package_id,
                     id.clone(),
                     services.clone(),
                     &public_keys,
@@ -1239,7 +1260,7 @@ mod tests {
             });
 
             let (encrypted, _) = seal_encrypt(
-                package_id,
+                new_package_id,
                 id.clone(),
                 services.clone(),
                 &public_keys,
@@ -1271,6 +1292,7 @@ mod tests {
         for (n, t) in configs {
             println!("  n={n}, threshold={t}");
             let package_id = ObjectID::random();
+            let new_package_id = NewObjectID::new(package_id.into_bytes());
             let id = vec![1, 2, 3, 4];
             let full_id = create_full_id(&package_id, &id);
 
@@ -1284,13 +1306,16 @@ mod tests {
                 fmt(kg_start.elapsed())
             );
 
-            let services = keypairs.iter().map(|_| ObjectID::random()).collect_vec();
+            let services = keypairs
+                .iter()
+                .map(|_| NewObjectID::new(ObjectID::random().into_bytes()))
+                .collect_vec();
             let public_keys =
                 IBEPublicKeys::Falcon512(keypairs.iter().map(|(pk, _)| pk.clone()).collect_vec());
 
             bench("seal_encrypt", 5, || {
                 seal_encrypt(
-                    package_id,
+                    new_package_id,
                     id.clone(),
                     services.clone(),
                     &public_keys,
@@ -1304,7 +1329,7 @@ mod tests {
             });
 
             let (encrypted, _) = seal_encrypt(
-                package_id,
+                new_package_id,
                 id.clone(),
                 services.clone(),
                 &public_keys,
@@ -1320,7 +1345,10 @@ mod tests {
                     .iter()
                     .zip(&keypairs)
                     .map(|(s, kp)| {
-                        (*s, fastcrypto_lattice::ibe::FalconIBE::extract(&kp.1, &full_id))
+                        (
+                            *s,
+                            fastcrypto_lattice::ibe::FalconIBE::extract(&kp.1, &full_id),
+                        )
                     })
                     .collect(),
             );

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -10,7 +10,9 @@ use fastcrypto::error::FastCryptoResult;
 use fastcrypto::groups::Scalar;
 use fastcrypto::hash::{HashFunction, Sha3_256};
 use fastcrypto_lattice::falcon_util::falcon;
-use fastcrypto_lattice::ibe::{sample_polynomial, IBE};
+use fastcrypto_lattice::falcon_util::falcon_field::Felt;
+use fastcrypto_lattice::falcon_util::polynomial::Polynomial;
+use fastcrypto_lattice::ibe::{sample_polynomial_from_seed, IBE};
 use itertools::Itertools;
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
@@ -18,7 +20,7 @@ use serde_with::serde_as;
 use std::collections::HashMap;
 pub use sui_sdk_types::Address as ObjectID;
 use tss::split;
-use utils::generate_random_bytes;
+use utils::{generate_random_bytes, xor};
 
 pub mod dem;
 pub mod elgamal;
@@ -81,6 +83,7 @@ pub enum IBEEncryptions {
     },
     Falcon512 {
         encrypted_shares: Vec<fastcrypto_lattice::ibe::Ciphertext<512>>,
+        encrypted_randomness: [u8; KEY_SIZE],
     },
 }
 
@@ -172,26 +175,44 @@ pub fn seal_encrypt(
             if pks.len() != number_of_shares as usize {
                 return Err(InvalidInput);
             }
-            let n = 512;
-            
+
+            let randomness: [u8; KEY_SIZE] = generate_random_bytes(&mut rng);
+
             let encrypted_shares = pks
                 .iter()
+                .zip(&services)
                 .zip(shares)
-                .map(|(pk, share)| {
-                    let k = sample_polynomial(n, &mut rng, 0..=1);
-                    let r = sample_polynomial(n, &mut rng, -1..=1);
-                    let e1 = sample_polynomial(n, &mut rng, -1..=1);
-                    let e2 = sample_polynomial(n, &mut rng, -1..=1);
-
+                .map(|((pk, (_, idx)), share)| {
+                    let polys =
+                        derive_falcon_share_randomness(&randomness, *idx, pk, &full_id);
                     fastcrypto_lattice::ibe::FalconIBE::encrypt_deterministic(
-                        (k, r, e1, e2),
+                        polys,
                         pk,
                         &fastcrypto_lattice::ibe::Plaintext::<32>(share),
                         &full_id,
                     )
                 })
                 .collect_vec();
-            IBEEncryptions::Falcon512 { encrypted_shares }
+
+            let ciphertext_bytes: Vec<Vec<u8>> = encrypted_shares
+                .iter()
+                .map(|c| bcs::to_bytes(c).expect("serializable"))
+                .collect();
+            let encrypted_randomness = xor(
+                &randomness,
+                &derive_key(
+                    KeyPurpose::EncryptedRandomness,
+                    &base_key,
+                    &ciphertext_bytes,
+                    threshold,
+                    &key_servers,
+                ),
+            );
+
+            IBEEncryptions::Falcon512 {
+                encrypted_shares,
+                encrypted_randomness,
+            }
         }
     };
 
@@ -295,7 +316,9 @@ pub fn seal_decrypt(
                 .collect_vec()
         }
         (
-            IBEEncryptions::Falcon512 { encrypted_shares },
+            IBEEncryptions::Falcon512 {
+                encrypted_shares, ..
+            },
             IBEUserSecretKeys::Falcon512(user_secret_keys),
         ) => {
             // Check that the encrypted object is valid,
@@ -304,18 +327,28 @@ pub fn seal_decrypt(
                 return Err(InvalidInput);
             }
 
-            services
+            let service_indices: Vec<usize> = services
                 .iter()
                 .enumerate()
-                .map(|(i, (object_id, index))| {
+                .filter(|(_, (id, _))| user_secret_keys.contains_key(id))
+                .map(|(i, _)| i)
+                .collect();
+            if service_indices.len() < *threshold as usize {
+                return Err(InvalidInput);
+            }
+
+            service_indices
+                .into_iter()
+                .map(|i| {
+                    let (object_id, index) = services[i];
                     let user_secret_key = user_secret_keys
-                        .get(object_id)
+                        .get(&object_id)
                         .expect("This shouldn't happen: It's checked above that this secret key is available");
                     (index, fastcrypto_lattice::ibe::FalconIBE::decrypt(
                         user_secret_key,
                         &encrypted_shares[i],
-                    ))
-                }).map(|(index, share)| (*index, share.0))
+                    ).0)
+                })
                 .collect_vec()
         }
         _ => panic!("This shouldn't happen: It's not checked above that this secret"),
@@ -366,6 +399,45 @@ impl KeyPurpose {
             KeyPurpose::DEM => &[1],
         }
     }
+}
+
+/// Domain separation tag for the Falcon per-share randomness derivation.
+const DST_FALCON_SHARE_RANDOMNESS: &[u8] = b"SUI-SEAL-IBE-FALCON512-SHARE-RAND-00";
+
+/// Derive the four small polynomials needed by [`fastcrypto_lattice::ibe::FalconIBE::encrypt_deterministic`]
+/// from a global seed, the share index, the recipient's public key, and the full id.
+/// Corresponds to `Hash(r, i, A_i, H(ID))` in the protocol.
+fn derive_falcon_share_randomness(
+    seed: &[u8; KEY_SIZE],
+    index: u8,
+    pk: &falcon::PublicKey<512>,
+    full_id: &[u8],
+) -> (
+    Polynomial<Felt>,
+    Polynomial<Felt>,
+    Polynomial<Felt>,
+    Polynomial<Felt>,
+) {
+    const N: usize = 512;
+    let pk_bytes = bcs::to_bytes(pk).expect("serializable");
+    let make = |tag: &[u8], range: std::ops::RangeInclusive<i32>| {
+        let seed_input = [
+            DST_FALCON_SHARE_RANDOMNESS,
+            tag,
+            seed,
+            &[index],
+            &pk_bytes,
+            full_id,
+        ]
+        .concat();
+        sample_polynomial_from_seed(N, &seed_input, range)
+    };
+    (
+        make(b"k", 0..=1),
+        make(b"r", -1..=1),
+        make(b"e1", -1..=1),
+        make(b"e2", -1..=1),
+    )
 }
 
 /// Derive a key for a specific purpose from the base key.
@@ -506,7 +578,73 @@ impl IBEEncryptions {
                     })
                     .collect::<FastCryptoResult<_>>()
             }
-            _ => unimplemented!(),
+            (
+                IBEEncryptions::Falcon512 {
+                    encrypted_shares,
+                    encrypted_randomness,
+                },
+                IBEPublicKeys::Falcon512(public_keys),
+            ) => {
+                if public_keys.len() != encrypted_shares.len()
+                    || encrypted_shares.len() != services.len()
+                {
+                    return Err(InvalidInput);
+                }
+
+                // Recover the global seed `r` used to derive every share's lattice randomness.
+                let randomness = xor(
+                    encrypted_randomness,
+                    &derive_key(
+                        KeyPurpose::EncryptedRandomness,
+                        base_key,
+                        &self.ciphertexts(),
+                        threshold,
+                        &services.iter().map(|(id, _)| *id).collect_vec(),
+                    ),
+                );
+
+                public_keys
+                    .iter()
+                    .zip(encrypted_shares)
+                    .zip(services)
+                    .map(|((pk, ciphertext), (_, idx))| {
+                        let (k, r, e1, e2) =
+                            derive_falcon_share_randomness(&randomness, *idx, pk, full_id);
+
+                        // The FO-style mask is `H(k_polynomial)`. Recover the share via
+                        // `share = w XOR H(k)`.
+                        let k_bytes: Vec<u8> = k
+                            .coefficients
+                            .iter()
+                            .flat_map(|f| f.value().to_le_bytes())
+                            .collect();
+                        let mut hash = Sha3_256::new();
+                        hash.update(&k_bytes);
+                        let hash_k: [u8; KEY_SIZE] = hash.finalize().digest;
+                        let share = xor(&hash_k, &ciphertext.w);
+
+                        // Recompute the ciphertext deterministically and verify it matches.
+                        // This catches any tampering with `(u, v)` — `w` is checked transitively
+                        // via the polynomial-consistency check in the caller.
+                        let recomputed =
+                            fastcrypto_lattice::ibe::FalconIBE::encrypt_deterministic(
+                                (k, r, e1, e2),
+                                pk,
+                                &fastcrypto_lattice::ibe::Plaintext::<32>(share),
+                                full_id,
+                            );
+                        if bcs::to_bytes(&recomputed).expect("serializable")
+                            != bcs::to_bytes(ciphertext).expect("serializable")
+                        {
+                            return Err(GeneralError(
+                                "Falcon ciphertext verification failed".to_string(),
+                            ));
+                        }
+                        Ok((*idx, share))
+                    })
+                    .collect::<FastCryptoResult<_>>()
+            }
+            _ => Err(InvalidInput),
         }
     }
 
@@ -516,7 +654,9 @@ impl IBEEncryptions {
             IBEEncryptions::BonehFranklinBLS12381 {
                 encrypted_shares, ..
             } => encrypted_shares.iter().map(|c| c.to_vec()).collect_vec(),
-            IBEEncryptions::Falcon512 { encrypted_shares } => encrypted_shares
+            IBEEncryptions::Falcon512 {
+                encrypted_shares, ..
+            } => encrypted_shares
                 .iter()
                 .map(|c| bcs::to_bytes(c).unwrap().to_vec())
                 .collect_vec(),
@@ -772,6 +912,62 @@ mod tests {
             )
             .unwrap()
         );
+    }
+
+    #[test]
+    fn test_pq_round_trip_with_verification() {
+        let data = b"Hello, World!";
+        let package_id = ObjectID::random();
+        let id = vec![1, 2, 3, 4];
+        let full_id = create_full_id(&package_id, &id);
+
+        let keypairs = (0..3)
+            .map(|_| fastcrypto_lattice::ibe::FalconIBE::keygen(&mut thread_rng()))
+            .collect_vec();
+        let services = keypairs.iter().map(|_| ObjectID::random()).collect_vec();
+        let threshold = 2;
+        let public_keys =
+            IBEPublicKeys::Falcon512(keypairs.iter().map(|(pk, _)| pk.clone()).collect_vec());
+
+        let encrypted = seal_encrypt(
+            package_id,
+            id,
+            services.clone(),
+            &public_keys,
+            threshold,
+            EncryptionInput::Hmac256Ctr {
+                data: data.to_vec(),
+                aad: Some(b"something".to_vec()),
+            },
+        )
+        .unwrap()
+        .0;
+
+        let user_secret_keys = IBEUserSecretKeys::Falcon512(
+            services
+                .iter()
+                .zip(&keypairs)
+                .map(|(s, kp)| (*s, fastcrypto_lattice::ibe::FalconIBE::extract(&kp.1, &full_id)))
+                .collect(),
+        );
+
+        // Decryption with verification should succeed.
+        let decrypted =
+            seal_decrypt(&encrypted, &user_secret_keys, Some(&public_keys)).unwrap();
+        assert_eq!(data, decrypted.as_slice());
+
+        // Tampering with one encrypted_share's `w` should be caught by polynomial-consistency.
+        let mut tampered = encrypted.clone();
+        match tampered.encrypted_shares {
+            IBEEncryptions::Falcon512 {
+                ref mut encrypted_shares,
+                ..
+            } => {
+                encrypted_shares[0].w[0] ^= 1;
+            }
+            _ => panic!(),
+        }
+        assert!(seal_decrypt(&tampered, &user_secret_keys, Some(&public_keys)).is_err());
     }
 
     #[test]

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -9,10 +9,10 @@ use fastcrypto::error::FastCryptoError::{GeneralError, InvalidInput};
 use fastcrypto::error::FastCryptoResult;
 use fastcrypto::groups::Scalar;
 use fastcrypto::hash::{HashFunction, Sha3_256};
-use fastcrypto_lattice::falcon_util::falcon;
-use fastcrypto_lattice::falcon_util::falcon_field::Felt;
-use fastcrypto_lattice::falcon_util::polynomial::Polynomial;
-use fastcrypto_lattice::ibe::{sample_polynomial_from_seed, IBE};
+use fastcrypto_lattice::falcon::falcon_field::Felt;
+use fastcrypto_lattice::falcon::polynomial::Polynomial;
+use fastcrypto_lattice::falcon::signature;
+use fastcrypto_lattice::ibe::sample_polynomial_from_seed;
 use itertools::Itertools;
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
@@ -90,12 +90,12 @@ pub enum IBEEncryptions {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum IBEPublicKeys {
     BonehFranklinBLS12381(Vec<ibe::PublicKey>),
-    Falcon512(Vec<falcon::PublicKey<512>>),
+    Falcon512(Vec<signature::PublicKey<512>>),
 }
 
 pub enum IBEUserSecretKeys {
     BonehFranklinBLS12381(HashMap<ObjectID, ibe::UserSecretKey>),
-    Falcon512(HashMap<ObjectID, falcon::Signature<512>>),
+    Falcon512(HashMap<ObjectID, signature::Signature<512>>),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -409,7 +409,7 @@ const DST_FALCON_SHARE_RANDOMNESS: &[u8] = b"SUI-SEAL-IBE-FALCON512-SHARE-RAND-0
 fn derive_falcon_share_randomness(
     seed: &[u8; KEY_SIZE],
     index: u8,
-    pk: &falcon::PublicKey<512>,
+    pk: &signature::PublicKey<512>,
     full_id: &[u8],
 ) -> (
     Polynomial<Felt>,

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -173,15 +173,18 @@ pub fn seal_encrypt(
                 return Err(InvalidInput);
             }
             let n = 512;
-            let k = sample_polynomial(512, &mut rng, 0..=1);
-
-            let r =
-            let seed =
+            
             let encrypted_shares = pks
                 .iter()
                 .zip(shares)
                 .map(|(pk, share)| {
+                    let k = sample_polynomial(n, &mut rng, 0..=1);
+                    let r = sample_polynomial(n, &mut rng, -1..=1);
+                    let e1 = sample_polynomial(n, &mut rng, -1..=1);
+                    let e2 = sample_polynomial(n, &mut rng, -1..=1);
+
                     fastcrypto_lattice::ibe::FalconIBE::encrypt_deterministic(
+                        (k, r, e1, e2),
                         pk,
                         &fastcrypto_lattice::ibe::Plaintext::<32>(share),
                         &full_id,

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -10,7 +10,7 @@ use fastcrypto::error::FastCryptoResult;
 use fastcrypto::groups::Scalar;
 use fastcrypto::hash::{HashFunction, Sha3_256};
 use fastcrypto_lattice::falcon_util::falcon;
-use fastcrypto_lattice::ibe::IBE;
+use fastcrypto_lattice::ibe::{sample_polynomial, IBE};
 use itertools::Itertools;
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
@@ -172,12 +172,16 @@ pub fn seal_encrypt(
             if pks.len() != number_of_shares as usize {
                 return Err(InvalidInput);
             }
+            let n = 512;
+            let k = sample_polynomial(512, &mut rng, 0..=1);
+
+            let r =
+            let seed =
             let encrypted_shares = pks
                 .iter()
                 .zip(shares)
                 .map(|(pk, share)| {
-                    fastcrypto_lattice::ibe::FalconIBE::encrypt(
-                        &mut rng,
+                    fastcrypto_lattice::ibe::FalconIBE::encrypt_deterministic(
                         pk,
                         &fastcrypto_lattice::ibe::Plaintext::<32>(share),
                         &full_id,

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -738,7 +738,10 @@ mod tests {
             services.clone(),
             &public_keys,
             threshold,
-            EncryptionInput::Plain,
+            EncryptionInput::Aes256Gcm {
+                data: b"Hello, World!".to_vec(),
+                aad: None,
+            },
         )
         .unwrap();
 
@@ -754,7 +757,7 @@ mod tests {
             .collect();
 
         assert_eq!(
-            key.to_vec(),
+            b"Hello, World!".to_vec(),
             seal_decrypt(
                 &encrypted,
                 &IBEUserSecretKeys::Falcon512(user_secret_keys),

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -9,6 +9,8 @@ use fastcrypto::error::FastCryptoError::{GeneralError, InvalidInput};
 use fastcrypto::error::FastCryptoResult;
 use fastcrypto::groups::Scalar;
 use fastcrypto::hash::{HashFunction, Sha3_256};
+use fastcrypto_lattice::falcon_util::falcon;
+use fastcrypto_lattice::ibe::IBE;
 use itertools::Itertools;
 use rand::thread_rng;
 use serde::{Deserialize, Serialize};
@@ -77,16 +79,20 @@ pub enum IBEEncryptions {
         encrypted_shares: Vec<ibe::Ciphertext>,
         encrypted_randomness: ibe::EncryptedRandomness,
     },
+    Falcon512 {
+        encrypted_shares: Vec<fastcrypto_lattice::ibe::Ciphertext<512>>,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum IBEPublicKeys {
     BonehFranklinBLS12381(Vec<ibe::PublicKey>),
-    Falcon(Vec<fastcrypto_lattice::falcon_util::PublicKey>),
+    Falcon512(Vec<falcon::PublicKey<512>>),
 }
 
 pub enum IBEUserSecretKeys {
     BonehFranklinBLS12381(HashMap<ObjectID, ibe::UserSecretKey>),
+    Falcon512(HashMap<ObjectID, falcon::Signature<512>>),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -162,13 +168,31 @@ pub fn seal_encrypt(
                 encrypted_randomness,
             }
         }
+        IBEPublicKeys::Falcon512(pks) => {
+            if pks.len() != number_of_shares as usize {
+                return Err(InvalidInput);
+            }
+            let encrypted_shares = pks
+                .iter()
+                .zip(shares)
+                .map(|(pk, share)| {
+                    fastcrypto_lattice::ibe::FalconIBE::encrypt(
+                        &mut rng,
+                        pk,
+                        &fastcrypto_lattice::ibe::Plaintext::<32>(share),
+                        &full_id,
+                    )
+                })
+                .collect_vec();
+            IBEEncryptions::Falcon512 { encrypted_shares }
+        }
     };
 
     // Derive the key used by the DEM
     let dem_key = derive_key(
         KeyPurpose::DEM,
         &base_key,
-        encrypted_shares.ciphertexts(),
+        &encrypted_shares.ciphertexts(),
         threshold,
         &key_servers,
     );
@@ -263,6 +287,31 @@ pub fn seal_decrypt(
                 })
                 .collect_vec()
         }
+        (
+            IBEEncryptions::Falcon512 { encrypted_shares },
+            IBEUserSecretKeys::Falcon512(user_secret_keys),
+        ) => {
+            // Check that the encrypted object is valid,
+            // e.g., that there is an encrypted share of the key per service
+            if encrypted_shares.len() != services.len() {
+                return Err(InvalidInput);
+            }
+
+            services
+                .iter()
+                .enumerate()
+                .map(|(i, (object_id, index))| {
+                    let user_secret_key = user_secret_keys
+                        .get(object_id)
+                        .expect("This shouldn't happen: It's checked above that this secret key is available");
+                    (index, fastcrypto_lattice::ibe::FalconIBE::decrypt(
+                        user_secret_key,
+                        &encrypted_shares[i],
+                    ))
+                }).map(|(index, share)| (*index, share.0))
+                .collect_vec()
+        }
+        _ => panic!("This shouldn't happen: It's not checked above that this secret"),
     };
 
     // Create the base key from the shares
@@ -282,7 +331,7 @@ pub fn seal_decrypt(
     let dem_key = derive_key(
         KeyPurpose::DEM,
         &base_key,
-        encrypted_shares.ciphertexts(),
+        &encrypted_shares.ciphertexts(),
         *threshold,
         &services.iter().map(|(id, _)| *id).collect_vec(),
     );
@@ -412,19 +461,22 @@ impl IBEEncryptions {
         base_key: &[u8; KEY_SIZE],
         threshold: u8,
     ) -> FastCryptoResult<Vec<(u8, [u8; KEY_SIZE])>> {
-        match self {
-            IBEEncryptions::BonehFranklinBLS12381 {
-                encrypted_randomness,
-                encrypted_shares,
-                nonce,
-            } => {
+        match (self, public_keys) {
+            (
+                IBEEncryptions::BonehFranklinBLS12381 {
+                    encrypted_randomness,
+                    encrypted_shares,
+                    nonce,
+                },
+                IBEPublicKeys::BonehFranklinBLS12381(public_keys),
+            ) => {
                 // Decrypt encrypted nonce,
                 let randomness = decrypt_randomness(
                     encrypted_randomness,
                     &derive_key(
                         KeyPurpose::EncryptedRandomness,
                         base_key,
-                        self.ciphertexts(),
+                        &self.ciphertexts(),
                         threshold,
                         &services.iter().map(|(id, _)| *id).collect_vec(),
                     ),
@@ -434,32 +486,33 @@ impl IBEEncryptions {
                 verify_nonce(&randomness, nonce)?;
 
                 // Decrypt all shares
-                match public_keys {
-                    IBEPublicKeys::BonehFranklinBLS12381(public_keys) => {
-                        if public_keys.len() != encrypted_shares.len() {
-                            return Err(InvalidInput);
-                        }
-                        public_keys
-                            .iter()
-                            .zip(encrypted_shares)
-                            .zip(services)
-                            .map(|((pk, ciphertext), service)| {
-                                decrypt_deterministic(&randomness, ciphertext, pk, full_id, service)
-                                    .map(|plaintext| (service.1, plaintext))
-                            })
-                            .collect::<FastCryptoResult<_>>()
-                    }
+                if public_keys.len() != encrypted_shares.len() {
+                    return Err(InvalidInput);
                 }
+                public_keys
+                    .iter()
+                    .zip(encrypted_shares)
+                    .zip(services)
+                    .map(|((pk, ciphertext), service)| {
+                        decrypt_deterministic(&randomness, ciphertext, pk, full_id, service)
+                            .map(|plaintext| (service.1, plaintext))
+                    })
+                    .collect::<FastCryptoResult<_>>()
             }
+            _ => unimplemented!(),
         }
     }
 
     /// Returns a binary representation of all encrypted shares.
-    fn ciphertexts(&self) -> &[impl AsRef<[u8]>] {
+    fn ciphertexts(&self) -> Vec<Vec<u8>> {
         match self {
             IBEEncryptions::BonehFranklinBLS12381 {
                 encrypted_shares, ..
-            } => encrypted_shares,
+            } => encrypted_shares.iter().map(|c| c.to_vec()).collect_vec(),
+            IBEEncryptions::Falcon512 { encrypted_shares } => encrypted_shares
+                .iter()
+                .map(|c| bcs::to_bytes(c).unwrap().to_vec())
+                .collect_vec(),
         }
     }
 }
@@ -664,6 +717,55 @@ mod tests {
     }
 
     #[test]
+    fn test_plain_round_trip_pq() {
+        let package_id = ObjectID::random();
+        let id = vec![1, 2, 3, 4];
+        let full_id = create_full_id(&package_id, &id);
+
+        let mut rng = rand::thread_rng();
+        let keypairs = (0..3)
+            .map(|_| fastcrypto_lattice::ibe::FalconIBE::keygen(&mut rng))
+            .collect_vec();
+
+        let services = keypairs.iter().map(|_| ObjectID::random()).collect_vec();
+
+        let threshold = 2;
+        let public_keys =
+            IBEPublicKeys::Falcon512(keypairs.iter().map(|(pk, _)| pk.clone()).collect_vec());
+
+        let (encrypted, key) = seal_encrypt(
+            package_id,
+            id,
+            services.clone(),
+            &public_keys,
+            threshold,
+            EncryptionInput::Plain,
+        )
+        .unwrap();
+
+        let user_secret_keys = services
+            .into_iter()
+            .zip(keypairs)
+            .map(|(s, kp)| {
+                (
+                    s,
+                    fastcrypto_lattice::ibe::FalconIBE::extract(&kp.1, &full_id),
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            key.to_vec(),
+            seal_decrypt(
+                &encrypted,
+                &IBEUserSecretKeys::Falcon512(user_secret_keys),
+                None,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
     fn typescript_test_vector() {
         let package_id = [0u8; 32];
         let inner_id = [1, 2, 3, 4];
@@ -840,7 +942,7 @@ mod tests {
         let dem_key = derive_key(
             KeyPurpose::DEM,
             &base_key,
-            encrypted_shares.ciphertexts(),
+            &encrypted_shares.ciphertexts(),
             threshold,
             &service_ids,
         );

--- a/crates/seal-cli/src/main.rs
+++ b/crates/seal-cli/src/main.rs
@@ -802,6 +802,18 @@ impl Display for ParseOutput {
                     serializable_to_string(&encapsulation)
                 )?;
             }
+            IBEEncryptions::Falcon512 {
+                encrypted_shares: shares,
+                encrypted_randomness,
+            } => {
+                writeln!(f, "  Type: Falcon-512")?;
+                writeln!(f, "  Shares: {} encrypted ciphertexts", shares.len())?;
+                write!(
+                    f,
+                    "  Encrypted randomness: {}",
+                    DefaultEncoding::encode(encrypted_randomness)
+                )?;
+            }
         };
         Ok(())
     }


### PR DESCRIPTION
## Description

Adds **Falcon-512 lattice-based IBE** as a post-quantum alternative to the existing Boneh-Franklin BLS12-381 scheme, implementing the **PQ-TSS-BF-KEM** protocol. The threshold secret-sharing layer is unchanged; only the per-share IBE encapsulation is swapped.

### What's included

- New `IBEEncryptions::Falcon512`, `IBEPublicKeys::Falcon512`, `IBEUserSecretKeys::Falcon512` variants.
- `seal_encrypt` / `seal_decrypt` Falcon paths.
- **Deterministic per-share randomness**: a single global seed `r` is sampled once; every share's lattice randomness `(k, r_i, e1, e2)` is derived via `Hash(r, i, A_i, H(ID))`. `c_r = r XOR k_r` is stored as `encrypted_randomness`.
- **Share-consistency verification** (`decrypt_all_shares_and_verify_nonce` Falcon arm): recovers `r`, re-derives each share's randomness, recomputes the share via `w XOR H(k)`, and re-encrypts to verify the ciphertext matches. Tampering with `(u, v)` is caught directly; tampering with `w` is caught by the polynomial-consistency check.
- Falcon arm for `seal-cli`'s `Display`.

### Protocol conformance

Every step of PQ-TSS-BF-KEM Encrypt/Decrypt is implemented, including the final ciphertext-verification assertion. One **known structural divergence** (pre-existing): the underlying primitive uses a Fujisaki-Okamoto-style mask (`w = share XOR H(k)`, random `k`) rather than the protocol's direct bit-encoding. Functionally equivalent for transport; verification works under either. Reconciling the encoding is tracked separately and would live in `fastcrypto-lattice`.

### Dependency

Depends on [MystenLabs/fastcrypto-lattice#1](https://github.com/MystenLabs/fastcrypto-lattice/pull/1) (merged) - pinned via git rev `20a0d5c`. That PR adds the deterministic encryption helpers and makes `Ciphertext` fields public.

## Benchmarks

`cargo test --release -p crypto --lib bench_ibe -- --ignored --nocapture` (Apple Silicon, single-threaded; 20-iter avg for BF ops, 50 for BF extract, 5 for Falcon).

### Boneh-Franklin BLS12-381

| n | t | extract | encrypt | decrypt (no verify) | decrypt (verify) | pub key | user sk | enc. object |
|--:|--:|--------:|--------:|--------------------:|-----------------:|--------:|--------:|------------:|
|  3 | 2 | 149 µs | 1.98 ms | 1.85 ms |  4.19 ms | 96 B | 48 B | 423 B |
|  5 | 3 | 128 µs | 2.87 ms | 3.00 ms |  6.93 ms | 96 B | 48 B | 553 B |
|  7 | 4 | 126 µs | 3.92 ms | 4.13 ms |  9.99 ms | 96 B | 48 B | 683 B |
| 10 | 7 | 134 µs | 5.64 ms | 6.02 ms | 14.78 ms | 96 B | 48 B | 878 B |

### Falcon-512

| n | t | keygen (total) | extract | encrypt | decrypt (no verify) | decrypt (verify) | pub key | user sk | enc. object |
|--:|--:|---------------:|--------:|--------:|--------------------:|-----------------:|--------:|--------:|------------:|
|  3 | 2 |  6.28 s |  9.4 ms | 272 µs |  79 µs | 348 µs | 2050 B | 2091 B | 12.6 KB |
|  5 | 3 |  8.87 s | 18.0 ms | 457 µs | 162 µs | 680 µs | 2050 B | 2091 B | 21.0 KB |
|  7 | 4 | 12.01 s | 14.8 ms | 633 µs | 185 µs | 945 µs | 2050 B | 2091 B | 29.3 KB |
| 10 | 7 | 17.28 s | 10.8 ms | 937 µs | 267 µs | 1.45 ms | 2050 B | 2091 B | 41.8 KB |

**Observations**
- Falcon ciphertexts are ~30-50x larger than BF (~4 KB/share vs ~65 B/share) - the dominant trade-off of the post-quantum scheme.
- Falcon keys are ~20-40x larger than BF (2 KB vs 48-96 B).
- Falcon `encrypt`/`decrypt` are actually faster than BF (lattice NTT + rounding vs BLS pairings); verification adds ~3-6x (BF) / ~5x (Falcon) to decrypt.
- Falcon `keygen` (~1.5-2.3 s/keypair) and `extract` (~10-18 ms, variable due to rejection sampling) are the expensive operations - both one-time / per-request server-side costs.

## Test plan

- `cargo test --workspace` - all suites pass (26 crypto tests incl. new `test_pq_round_trip_with_verification`).
- New test exercises the Falcon verification path: honest decrypt succeeds; flipping one bit of an encrypted share is rejected.
- `bench_ibe` is `#[ignore]`d (excluded from the default test run).

> [!NOTE]
> Marked **[do not merge]** - staging branch for the lattice IBE work.