### PR TITLE
[key-server] add hostname to metrics payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3316,6 +3316,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e806677ce663d0a199541030c816847b36e8dc095f70dae4a4f4ad63da5383"
 
 [[package]]
+name = "hostname"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4142,6 +4153,7 @@ dependencies = [
  "futures",
  "git-version",
  "hex",
+ "hostname",
  "http-body-util",
  "hyper-util",
  "jsonrpsee",

--- a/crates/key-server/Cargo.toml
+++ b/crates/key-server/Cargo.toml
@@ -42,6 +42,7 @@ moka = { version = "0.12.10", features = ["sync"] }
 snap = "1.1.0"
 reqwest = { version = "0.12", features = ["json"] }
 serde_with = { workspace = true, features = ["base64"] }
+hostname = "0.4"
 
 move-binding-derive = { git = "https://github.com/MystenLabs/move-binding.git", rev = "99f68a28c2f19be40a09e5f1281af748df9a8d3e" }
 move-types = { git = "https://github.com/MystenLabs/move-binding.git", rev = "99f68a28c2f19be40a09e5f1281af748df9a8d3e" }


### PR DESCRIPTION
## Description 

Some operators run all the `key-server` instances in a private-subnet and use a NAT to talk to outside, in that case, the egress ip will be the same for all instances in that subnet. So we're adding a `hostname` to the metrics payload, with this `hostname` and the `client_ip` label that `seal-proxy` [adds](https://github.com/MystenLabs/seal/pull/254), we should be able to distinguish the metrics from different machines in 99% of the cases.

## Test plan 

tested locally with docker compose