### PR TITLE
[docs] add permalinks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,9 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets
   - pymdownx.superfences
+  - toc:
+      permalink: true
+      permalink_title: Anchor link to this section for reference
 nav:
   - Home: index.md
   - Seal Design: Design.md


### PR DESCRIPTION
## Description 

<img width="438" height="142" alt="image" src="https://github.com/user-attachments/assets/76b4630e-ce13-45fa-aec8-f1ebe97ab082" />

now you can link to a particular section, useful to share with builders on particular section
## Test plan 

How did you test the new or updated feature?