### PR TITLE
[server] Measure delay up to 150s

### DIFF
--- a/crates/key-server/src/metrics.rs
+++ b/crates/key-server/src/metrics.rs
@@ -81,7 +81,7 @@ impl Metrics {
             checkpoint_timestamp_delay: register_histogram_with_registry!(
                 "checkpoint_timestamp_delay",
                 "Delay of timestamp of the latest checkpoint",
-                buckets(0.0, 120000.0, 1000.0),
+                buckets(0.0, 150000.0, 1000.0),
                 registry
             )
             .unwrap(),


### PR DESCRIPTION
## Description 

Measure timestampe delay up to 150s, so a margin above the allowed 120s threshold.

## Test plan 

N/A