### PR TITLE
Make the package id note clearer and redundant

### DIFF
--- a/docs/UsingSeal.md
+++ b/docs/UsingSeal.md
@@ -316,7 +316,7 @@ A Seal key server can operate in one of two modes: `Open` or `Permissioned`:
 - **Open mode**: In open mode, the key server accepts decryption requests for *any* onchain package. It uses a single master key to serve all access policies across packages. This mode is suitable for public or general-purpose deployments where package-level isolation is not required.
 - **Permissioned mode**: In permissioned mode, the key server restricts access to a manually approved list of packages associated with specific clients or applications. Each client is served using a dedicated master key.
     - This mode also supports importing or exporting the client-specific key if needed, for purposes such as disaster recovery or key server rotation.
-    - The approved package IDs in permissioned mode *must* be the package ID of the first version of the package, so if the package is upgraded, the key server will still recognize it.
+    - The approved package ID for a client **must** be the package’s **first published version**. This ensures that the key server continues to recognize the package after upgrades. One does not need to add new versions of the package to a client's allowlist.
 
 You can choose the mode that best fits your deployment model and security requirements. The following sections provide more details on both options.
 
@@ -429,7 +429,10 @@ $ sui client call --function create_and_transfer_v1 --module key_server --packag
     - Include the list of packages this client will use.
 
 !!! info
-    You can map multiple packages from a developer to the same client (e.g., for different features or apps). However, if the developer later decides to [export the client key](#export-and-import-keys), access will be revoked for **all** packages mapped to that client. Confirm whether they prefer separate client per package (allowing for granular revocation) or a single consolidated client (allowing for simpler operations).
+    You can map multiple different packages from a developer to the same client (e.g., for different features or apps). However, if the developer later decides to [export the client key](#export-and-import-keys), access will be revoked for **all** packages mapped to that client. Confirm whether they prefer separate client per package (allowing for granular revocation) or a single consolidated client (allowing for simpler operations).
+
+!!! info
+    When adding a package for a feature or app, you must add the package ID of the package’s **first published version**. This ensures that the key server continues to recognize the package after upgrades. You do not need to add new versions of a package to a client's allowlist.
 
 For example: 
 


### PR DESCRIPTION
## Description 

Make the package id note clearer and redundant

## Test plan 

Tested with mkdocs serve locally