### PR TITLE
[cli] add service id to fetch key cli response

### DIFF
--- a/crates/seal-cli/src/main.rs
+++ b/crates/seal-cli/src/main.rs
@@ -565,7 +565,7 @@ async fn main() -> FastCryptoResult<()> {
                 ))
             })?;
 
-            // Fetch keys from key server urls and collect seal responses.
+            // Fetch keys from key server urls and collect service id and its seal responses.
             let mut seal_responses = Vec::new();
             let client = reqwest::Client::new();
             for server in &fetch_key_server_urls(&key_server_ids, &network)
@@ -595,7 +595,7 @@ async fn main() -> FastCryptoResult<()> {
                             let response: FetchKeyResponse =
                                 serde_json::from_slice(&response_bytes)
                                     .expect("Failed to deserialize response");
-                            seal_responses.push(response);
+                            seal_responses.push((server.object_id, response));
                             println!("\n Success {}", server.name);
                         } else {
                             let error_text = response

--- a/docs/UsingSeal.md
+++ b/docs/UsingSeal.md
@@ -683,7 +683,7 @@ Encrypted shares:
   Encapsulation: 841b3a59241e099e8b8d9cec1d531b1e8fe4b4170433e30d9aaa9fc764201f69e589a0b2a0e65bfb279d4b25ee1ce8141812bfb785abdb05134c3958f53c2e81e7bc06e5c1f1ebd7e489b5cf652216b13e6b7c2b13da70a4a7c05c3544a1ddf7
 ```
 
-Encrypt a secret for a hex-encoded unique identifier and a Seal policy package ID. Use the specified key server object IDs and network. The CLI retrieves public keys from a public Full node.
+Encrypt a secret for a hex-encoded unique identifier and a Seal policy package ID. Use the specified key server object IDs and network. The CLI retrieves public keys from a public Full node. The output is an Hex BCS encoded encrypted object. 
 
 ```shell
 $ cargo run --bin seal-cli encrypt --secret 045a27812dbe456392913223221306 \
@@ -697,7 +697,7 @@ Encrypted object:
 <ENCODED_ENCRYPTED_OBJECT>
 ```
 
-Fetch keys for the encoded request. Provide the threshold, key server object IDs, and network.
+Fetch keys for the encoded request. Provide the threshold, key server object IDs, and network. The response is a Hex BCS encoded vector of tuples of key server object ID and its corresping `FetchKeyResponse`. 
 
 ```shell
 $ cargo run --bin seal-cli fetch-keys --request <ENCODED_REQUEST> \


### PR DESCRIPTION
## Description 

this is useful when enclave gets this fetchkey response to use the service id to look up the public key. so we are not assuming seal responses' ordering. 

## Test plan 

How did you test the new or updated feature?