### PR TITLE
[cli] use encoded bytes instead of utf8 string

### DIFF
--- a/crates/seal-cli/src/main.rs
+++ b/crates/seal-cli/src/main.rs
@@ -324,12 +324,12 @@ enum Command {
         #[arg(long)]
         key: EncodedByteArray<KEY_LENGTH>,
     },
-    /// Encrypt a secret's utf-8 bytes using Seal. This uses the public fullnode for
+    /// Encrypt a secret's Hex encoded bytes using Seal. This uses the public fullnode for
     /// retrieval of key servers' public keys for the given network.
     Encrypt {
         /// The secret to encrypt.
         #[arg(long)]
-        secret: String,
+        secret: EncodedBytes,
 
         /// Unique per package identifier of the secret.
         #[arg(long)]
@@ -542,7 +542,7 @@ async fn main() -> FastCryptoResult<()> {
                 &IBEPublicKeys::BonehFranklinBLS12381(pks),
                 threshold,
                 EncryptionInput::Aes256Gcm {
-                    data: secret.as_bytes().to_vec(),
+                    data: secret.0,
                     aad: None,
                 },
             )

--- a/crates/seal-cli/src/main.rs
+++ b/crates/seal-cli/src/main.rs
@@ -327,13 +327,13 @@ enum Command {
     /// Encrypt a secret's Hex encoded bytes using Seal. This uses the public fullnode for
     /// retrieval of key servers' public keys for the given network.
     Encrypt {
-        /// The secret to encrypt.
-        #[arg(long)]
-        secret: EncodedBytes,
+        /// The secrets to encrypt.
+        #[arg(long, value_delimiter = ',')]
+        secrets: Vec<EncodedBytes>,
 
-        /// Unique per package identifier of the secret.
-        #[arg(long)]
-        id: EncodedBytes,
+        /// Unique per package identifier for all secrets.
+        #[arg(long, value_delimiter = ',')]
+        ids: Vec<EncodedBytes>,
 
         /// Package ID that defines seal policy.
         #[arg(short = 'p', long)]
@@ -503,13 +503,19 @@ async fn main() -> FastCryptoResult<()> {
         .map(SymmetricDecryptOutput)?
         .to_string(),
         Command::Encrypt {
-            secret,
-            id,
+            secrets,
+            ids,
             package_id,
             key_server_ids,
             threshold,
             network,
         } => {
+            if secrets.len() != ids.len() || secrets.is_empty() {
+                return Err(FastCryptoError::GeneralError(
+                    "Number of secrets and ids must be the same and must be greater than 0"
+                        .to_string(),
+                ));
+            }
             // Fetch key server info including public keys from blockchain
             let key_server_infos = fetch_key_server_urls(&key_server_ids, &network)
                 .await
@@ -535,21 +541,26 @@ async fn main() -> FastCryptoResult<()> {
             let package_id = NewObjectID::new(package_id.as_bytes().try_into().map_err(|e| {
                 FastCryptoError::GeneralError(format!("Invalid package ID: {}", e))
             })?);
-            let (encrypted_object, _) = seal_encrypt(
-                package_id,
-                id.0,
-                key_server_ids,
-                &IBEPublicKeys::BonehFranklinBLS12381(pks),
-                threshold,
-                EncryptionInput::Aes256Gcm {
-                    data: secret.0,
-                    aad: None,
-                },
+            let mut encrypted_objects = Vec::new();
+            for (id, secret) in ids.into_iter().zip(secrets.into_iter()) {
+                let (encrypted_object, _) = seal_encrypt(
+                    package_id,
+                    id.0,
+                    key_server_ids.clone(),
+                    &IBEPublicKeys::BonehFranklinBLS12381(pks.clone()),
+                    threshold,
+                    EncryptionInput::Aes256Gcm {
+                        data: secret.0,
+                        aad: None,
+                    },
+                )
+                .map_err(|e| FastCryptoError::GeneralError(format!("Encryption failed: {}", e)))?;
+                encrypted_objects.push(encrypted_object);
+            }
+            format!(
+                "Encoded encrypted object:\n{}",
+                Hex::encode(bcs::to_bytes(&encrypted_objects).expect("serialization failed"))
             )
-            .map_err(|e| FastCryptoError::GeneralError(format!("Encryption failed: {}", e)))?;
-
-            let bcs_bytes = bcs::to_bytes(&encrypted_object).expect("serialization failed");
-            format!("Encoded encrypted object:\n{}", Hex::encode(&bcs_bytes))
         }
         Command::FetchKeys {
             request,

--- a/docs/SealCLI.md
+++ b/docs/SealCLI.md
@@ -136,10 +136,10 @@ Encrypted shares:
 
 **Encrypt**
 
-Encrypt the secret’s UTF-8 bytes bound to a hex-encoded ID and a Seal policy package ID. Provide the key-server object IDs and the network. The CLI retrieves key-server's public keys from a public full node and returns a hex-encoded, BCS-serialized encrypted object.
+Encrypt the secret in hex-encoded bytes bound to a hex-encoded ID and a Seal policy package ID. Provide the key-server object IDs and the network. The CLI retrieves key-server's public keys from a public full node and returns a hex-encoded, BCS-serialized encrypted object.
 
 ```shell
-$ cargo run --bin seal-cli encrypt --secret 045a27812dbe456392913223221306 \
+$ cargo run --bin seal-cli encrypt --secret 0000 \
     --id 0000 \
     -p 0xfaeabd7f317dd7ae40d83b73cfa68b92795f48540d03f1232b33207e22d0a62f \
     -t 2 \

--- a/docs/SealCLI.md
+++ b/docs/SealCLI.md
@@ -139,8 +139,8 @@ Encrypted shares:
 Encrypt the secret in hex-encoded bytes bound to a hex-encoded ID and a Seal policy package ID. Provide the key-server object IDs and the network. The CLI retrieves key-server's public keys from a public full node and returns a hex-encoded, BCS-serialized encrypted object.
 
 ```shell
-$ cargo run --bin seal-cli encrypt --secret 0000 \
-    --id 0000 \
+$ cargo run --bin seal-cli encrypt --secrets 68656c6c6f,776f726c64 \
+    --ids 0000,0001 \
     -p 0xfaeabd7f317dd7ae40d83b73cfa68b92795f48540d03f1232b33207e22d0a62f \
     -t 2 \
     -k 0x73d05d62c18d9374e3ea529e8e0ed6161da1a141a94d3f76ae3fe4e99356db75,0xf5d14a81a982144ae441cd7d64b09027f116a468bd36e7eca494f750591623c8 \
@@ -149,6 +149,8 @@ $ cargo run --bin seal-cli encrypt --secret 0000 \
 Encrypted object:
 <ENCODED_ENCRYPTED_OBJECT>
 ```
+
+Note: `68656c6c6f` is the Hex encoding for UTF-8 string "hello". `776f726c64` is for `world`.
 
 **Fetch keys for the encoded request**
 


### PR DESCRIPTION
## Description 

i went back and forth on this. decided that we should stay consistent and use hex. even tho for the nautilus pattern its more useful to do utf8. 

ill update nautilus to convert the api key string from utf8 and reencode with hex for this

## Test plan 

How did you test the new or updated feature?