### PR TITLE
removed move binding crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,9 +642,9 @@ source = "git+https://github.com/mystenmark/async-task?rev=4e45b26e11126b191701b
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1642,7 +1642,7 @@ name = "consensus-config"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "mysten-network",
  "rand 0.8.5",
  "serde",
@@ -1669,7 +1669,7 @@ dependencies = [
  "dashmap",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "futures",
  "http 1.3.1",
  "itertools 0.13.0",
@@ -1713,7 +1713,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "base64 0.21.7",
  "consensus-config",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "serde",
 ]
 
@@ -1911,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -1951,7 +1951,7 @@ name = "crypto"
 version = "0.5.11"
 dependencies = [
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "hex",
  "itertools 0.14.0",
  "rand 0.8.5",
@@ -2688,14 +2688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-compat-util"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?rev=42ba6c0#42ba6c03128233cdeb3fc6e0a22dabd0bfc55385"
-dependencies = [
- "serde_yaml 0.8.26",
-]
-
-[[package]]
 name = "enum_dispatch"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,57 +2785,6 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 [[package]]
 name = "fastcrypto"
 version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06674cac3bf7ec9a951971285e6051a45273dc4e265cca27c02a0d4ebcb46f8"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-secp256r1",
- "ark-serialize",
- "auto_ops",
- "base64ct",
- "bech32",
- "bincode",
- "blake2",
- "blst",
- "bs58 0.4.0",
- "curve25519-dalek-ng",
- "derive_more 0.99.18",
- "digest 0.10.7",
- "ecdsa 0.16.9",
- "ed25519-consensus",
- "elliptic-curve 0.13.8",
- "fastcrypto-derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "generic-array",
- "hex",
- "hex-literal",
- "hkdf",
- "lazy_static",
- "num-bigint 0.4.6",
- "once_cell",
- "p256",
- "rand 0.8.5",
- "readonly",
- "rfc6979 0.4.0",
- "rsa",
- "schemars 0.8.21",
- "secp256k1",
- "serde",
- "serde_json",
- "serde_with",
- "sha2 0.10.8",
- "sha3 0.10.8",
- "signature 2.2.0",
- "static_assertions",
- "thiserror 1.0.69",
- "tokio",
- "typenum",
- "zeroize",
-]
-
-[[package]]
-name = "fastcrypto"
-version = "0.1.9"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b#d1fcb853196c3de7888ed8fad74f419b8c8fbe3b"
 dependencies = [
  "aes",
@@ -2870,7 +2811,7 @@ dependencies = [
  "ecdsa 0.16.9",
  "ed25519-consensus",
  "elliptic-curve 0.13.8",
- "fastcrypto-derive 0.1.3 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto-derive",
  "generic-array",
  "hex",
  "hex-literal",
@@ -2901,18 +2842,6 @@ dependencies = [
 [[package]]
 name = "fastcrypto-derive"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0c2af2157f416cb885e11d36cd0de2753f6d5384752d364075c835f5f8f891"
-dependencies = [
- "convert_case 0.6.0",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "fastcrypto-derive"
-version = "0.1.3"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b#d1fcb853196c3de7888ed8fad74f419b8c8fbe3b"
 dependencies = [
  "quote",
@@ -2926,7 +2855,7 @@ source = "git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed
 dependencies = [
  "bcs",
  "digest 0.10.7",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "hex",
  "itertools 0.10.5",
  "rand 0.8.5",
@@ -2945,7 +2874,7 @@ version = "0.1.0"
 source = "git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b#d1fcb853196c3de7888ed8fad74f419b8c8fbe3b"
 dependencies = [
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "lazy_static",
  "num-bigint 0.4.6",
  "num-integer",
@@ -2971,7 +2900,7 @@ dependencies = [
  "bcs",
  "byte-slice-cast",
  "derive_more 0.99.18",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "ff 0.13.0",
  "im",
  "itertools 0.12.1",
@@ -3278,20 +3207,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "generator"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18470a76cb7f8ff746cf1f7470914f900252ec36bbc40b569d74b1258446827"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows",
 ]
 
 [[package]]
@@ -4523,7 +4438,7 @@ dependencies = [
  "chrono",
  "crypto",
  "duration-str",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "futures",
  "git-version",
  "hex",
@@ -4532,9 +4447,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee",
  "moka",
- "move-binding-derive",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-types",
+ "move-core-types",
  "mvr-types",
  "mysten-service",
  "once_cell",
@@ -4553,7 +4466,6 @@ dependencies = [
  "sui-move-build",
  "sui-sdk",
  "sui-sdk-types 0.0.2",
- "sui-transaction-builder 0.1.0",
  "sui-types",
  "tap",
  "temp-env",
@@ -4793,19 +4705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "lru"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5021,20 +4920,19 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.10"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9321642ca94a4282428e6ea4af8cc2ca4eac48ac7a6a4ea8f33f76d0ce70926"
+checksum = "8261cd88c312e0004c1d51baad2980c66528dfdb2bee62003e643a4d8f86b077"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
- "loom",
+ "equivalent",
  "parking_lot 0.12.4",
  "portable-atomic",
  "rustc_version",
  "smallvec",
  "tagptr",
- "thiserror 1.0.69",
  "uuid",
 ]
 
@@ -5048,7 +4946,7 @@ name = "move-abstract-interpreter-v2"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
 ]
 
 [[package]]
@@ -5062,49 +4960,14 @@ version = "0.0.3"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "anyhow",
- "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "enum-compat-util",
  "indexmap 2.11.4",
  "move-abstract-interpreter",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
+ "move-proc-macros",
  "ref-cast",
  "serde",
  "variant_count",
-]
-
-[[package]]
-name = "move-binary-format"
-version = "0.0.3"
-source = "git+https://github.com/mystenlabs/sui?rev=42ba6c0#42ba6c03128233cdeb3fc6e0a22dabd0bfc55385"
-dependencies = [
- "anyhow",
- "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?rev=42ba6c0)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=42ba6c0)",
- "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?rev=42ba6c0)",
- "ref-cast",
- "serde",
- "variant_count",
-]
-
-[[package]]
-name = "move-binding-derive"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/move-binding.git?rev=99f68a28c2f19be40a09e5f1281af748df9a8d3e#99f68a28c2f19be40a09e5f1281af748df9a8d3e"
-dependencies = [
- "bcs",
- "fastcrypto 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.14.0",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=42ba6c0)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=42ba6c0)",
- "move-types",
- "proc-macro2",
- "quote",
- "reqwest 0.12.15",
- "serde",
- "serde_json",
- "sui-sdk-types 0.0.2",
- "sui-transaction-builder 0.1.0",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -5119,9 +4982,9 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "anyhow",
  "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
  "serde",
@@ -5135,8 +4998,8 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "anyhow",
  "indexmap 2.11.4",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "petgraph 0.8.2",
  "serde-reflection",
 ]
@@ -5148,10 +5011,10 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-verifier-meter",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "petgraph 0.8.2",
 ]
@@ -5161,8 +5024,8 @@ name = "move-bytecode-verifier-meter"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "move-vm-config",
 ]
 
@@ -5173,10 +5036,10 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-verifier-meter",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "petgraph 0.8.2",
 ]
@@ -5188,10 +5051,10 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-verifier-meter",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "petgraph 0.8.2",
 ]
@@ -5203,10 +5066,10 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "move-abstract-interpreter-v2",
  "move-abstract-stack",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-verifier-meter",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "petgraph 0.8.2",
 ]
@@ -5222,8 +5085,8 @@ dependencies = [
  "dirs-next",
  "hex",
  "insta",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "once_cell",
  "packed_struct",
  "serde",
@@ -5246,15 +5109,15 @@ dependencies = [
  "insta",
  "lsp-types 0.95.1",
  "move-abstract-interpreter",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-borrow-graph",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-ir-to-bytecode",
  "move-ir-types",
- "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-proc-macros",
  "move-symbol-pool",
  "once_cell",
  "petgraph 0.8.2",
@@ -5275,36 +5138,12 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "anyhow",
  "bcs",
- "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "enum-compat-util",
  "ethnum",
  "hex",
  "indexmap 2.11.4",
  "leb128",
- "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "num",
- "once_cell",
- "primitive-types",
- "rand 0.8.5",
- "ref-cast",
- "serde",
- "serde_bytes",
- "serde_with",
- "thiserror 1.0.69",
- "uint",
-]
-
-[[package]]
-name = "move-core-types"
-version = "0.0.4"
-source = "git+https://github.com/mystenlabs/sui?rev=42ba6c0#42ba6c03128233cdeb3fc6e0a22dabd0bfc55385"
-dependencies = [
- "anyhow",
- "bcs",
- "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?rev=42ba6c0)",
- "ethnum",
- "hex",
- "leb128",
- "move-proc-macros 0.1.0 (git+https://github.com/mystenlabs/sui?rev=42ba6c0)",
+ "move-proc-macros",
  "num",
  "once_cell",
  "primitive-types",
@@ -5330,12 +5169,12 @@ dependencies = [
  "indexmap 2.11.4",
  "lcov",
  "move-abstract-interpreter",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-verifier",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-ir-types",
  "move-trace-format",
  "petgraph 0.8.2",
@@ -5353,11 +5192,11 @@ dependencies = [
  "hex",
  "inline_colorization",
  "move-abstract-interpreter",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-coverage",
  "move-ir-types",
  "move-symbol-pool",
@@ -5374,9 +5213,9 @@ dependencies = [
  "codespan-reporting",
  "itertools 0.10.5",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-ir-types",
  "move-model-2",
  "move-symbol-pool",
@@ -5394,10 +5233,10 @@ dependencies = [
  "anyhow",
  "codespan-reporting",
  "log",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-ir-to-bytecode-syntax",
  "move-ir-types",
  "move-symbol-pool",
@@ -5412,7 +5251,7 @@ dependencies = [
  "anyhow",
  "hex",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-ir-types",
  "move-symbol-pool",
 ]
@@ -5424,7 +5263,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "hex",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-symbol-pool",
  "once_cell",
  "serde",
@@ -5440,11 +5279,11 @@ dependencies = [
  "codespan",
  "codespan-reporting",
  "indexmap 2.11.4",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-source-map",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-disassembler",
  "move-ir-types",
  "move-symbol-pool",
@@ -5464,12 +5303,12 @@ dependencies = [
  "colored",
  "dunce",
  "itertools 0.10.5",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-source-map",
  "move-bytecode-utils",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-disassembler",
  "move-docgen",
  "move-model-2",
@@ -5495,17 +5334,7 @@ name = "move-proc-macros"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
- "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "move-proc-macros"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui?rev=42ba6c0#42ba6c03128233cdeb3fc6e0a22dabd0bfc55385"
-dependencies = [
- "enum-compat-util 0.1.0 (git+https://github.com/mystenlabs/sui?rev=42ba6c0)",
+ "enum-compat-util",
  "quote",
  "syn 2.0.90",
 ]
@@ -5516,8 +5345,8 @@ version = "0.0.1"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "itertools 0.10.5",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "petgraph 0.8.2",
 ]
 
@@ -5527,8 +5356,8 @@ version = "0.1.1"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "hex",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "move-vm-runtime",
  "move-vm-types",
  "sha2 0.9.9",
@@ -5542,8 +5371,8 @@ version = "0.1.1"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "hex",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "move-vm-runtime-v0",
  "move-vm-types-v0",
  "sha2 0.9.9",
@@ -5557,8 +5386,8 @@ version = "0.1.1"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "hex",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "move-vm-runtime-v1",
  "move-vm-types-v1",
  "sha2 0.9.9",
@@ -5572,8 +5401,8 @@ version = "0.1.1"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "hex",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "move-vm-runtime-v2",
  "move-vm-types-v2",
  "sha2 0.9.9",
@@ -5596,23 +5425,11 @@ name = "move-trace-format"
 version = "0.0.1"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "serde",
  "serde_json",
  "zstd 0.13.2",
-]
-
-[[package]]
-name = "move-types"
-version = "0.1.0"
-source = "git+https://github.com/MystenLabs/move-binding.git?rev=99f68a28c2f19be40a09e5f1281af748df9a8d3e#99f68a28c2f19be40a09e5f1281af748df9a8d3e"
-dependencies = [
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=42ba6c0)",
- "primitive-types",
- "serde",
- "sui-sdk-types 0.0.2",
- "sui-transaction-builder 0.1.0",
 ]
 
 [[package]]
@@ -5620,7 +5437,7 @@ name = "move-vm-config"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "once_cell",
 ]
 
@@ -5644,9 +5461,9 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "better_any",
  "fail",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-verifier",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-trace-format",
  "move-vm-config",
  "move-vm-types",
@@ -5663,9 +5480,9 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "better_any",
  "fail",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-verifier-v0",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "move-vm-types-v0",
  "once_cell",
@@ -5681,9 +5498,9 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "better_any",
  "fail",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-verifier-v1",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "move-vm-types-v1",
  "once_cell",
@@ -5699,9 +5516,9 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "better_any",
  "fail",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-verifier-v2",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "move-vm-types-v2",
  "once_cell",
@@ -5716,8 +5533,8 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "anyhow",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "move-vm-profiler",
  "move-vm-types",
  "once_cell",
@@ -5730,8 +5547,8 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "move-vm-profiler",
  "serde",
  "smallvec",
@@ -5743,8 +5560,8 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "serde",
  "smallvec",
 ]
@@ -5755,8 +5572,8 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "serde",
  "smallvec",
 ]
@@ -5767,8 +5584,8 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "serde",
  "smallvec",
 ]
@@ -5895,7 +5712,7 @@ dependencies = [
  "antithesis_sdk",
  "anyhow",
  "either",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "futures",
  "mysten-metrics",
  "once_cell",
@@ -5942,7 +5759,7 @@ dependencies = [
  "bcs",
  "bytes",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "futures",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -8175,12 +7992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8193,7 +8004,7 @@ dependencies = [
  "bcs",
  "clap",
  "crypto",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "rand 0.8.5",
  "reqwest 0.11.27",
  "seal-sdk",
@@ -8247,7 +8058,7 @@ dependencies = [
  "bcs",
  "chrono",
  "crypto",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "hex",
  "rand 0.8.5",
  "serde",
@@ -8625,7 +8436,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "bcs",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "serde",
  "serde_repr",
 ]
@@ -8715,11 +8526,11 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "futures",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "once_cell",
  "prometheus",
  "rand 0.8.5",
@@ -9108,11 +8919,11 @@ dependencies = [
  "bcs",
  "indexmap 2.11.4",
  "leb128",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
  "move-bytecode-verifier-meter",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-regex-borrow-graph",
  "move-trace-format",
  "move-vm-config",
@@ -9140,11 +8951,11 @@ dependencies = [
  "anyhow",
  "bcs",
  "leb128",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v0",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "move-vm-profiler",
  "move-vm-runtime-v0",
@@ -9168,11 +8979,11 @@ dependencies = [
  "anyhow",
  "bcs",
  "leb128",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v1",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "move-vm-profiler",
  "move-vm-runtime-v1",
@@ -9195,11 +9006,11 @@ dependencies = [
  "anyhow",
  "bcs",
  "leb128",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v2",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "move-vm-profiler",
  "move-vm-runtime-v2",
@@ -9238,7 +9049,7 @@ dependencies = [
  "consensus-config",
  "csv",
  "dirs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "move-vm-config",
  "mysten-common",
  "nonzero_ext",
@@ -9283,7 +9094,7 @@ dependencies = [
  "either",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "futures",
@@ -9293,9 +9104,9 @@ dependencies = [
  "lru 0.10.1",
  "mockall",
  "moka",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-package",
  "move-symbol-pool",
  "mysten-common",
@@ -9410,7 +9221,7 @@ version = "1.58.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "anyhow",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "sui-json-rpc-types",
  "sui-types",
  "thiserror 1.0.69",
@@ -9431,7 +9242,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-interpreter-v2",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-verifier",
  "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v0",
@@ -9486,8 +9297,8 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "bcs",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "once_cell",
  "serde",
  "sui-types",
@@ -9517,9 +9328,9 @@ dependencies = [
  "anyhow",
  "bcs",
  "camino",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "fastcrypto",
+ "move-binary-format",
+ "move-core-types",
  "prometheus",
  "rand 0.8.5",
  "serde",
@@ -9577,15 +9388,15 @@ dependencies = [
  "diesel",
  "diesel-async",
  "diesel_migrations",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "futures",
  "hex",
  "indicatif",
  "itertools 0.13.0",
  "jsonrpsee",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "mysten-metrics",
  "object_store",
  "prometheus",
@@ -9614,7 +9425,7 @@ dependencies = [
  "sui-sdk",
  "sui-snapshot",
  "sui-storage",
- "sui-transaction-builder 0.0.0",
+ "sui-transaction-builder",
  "sui-types",
  "tap",
  "telemetry-subscribers",
@@ -9699,10 +9510,10 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "fastcrypto",
+ "move-binary-format",
  "move-bytecode-utils",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "schemars 0.8.21",
  "serde",
  "serde_json",
@@ -9724,7 +9535,7 @@ dependencies = [
  "cached",
  "chrono",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "fastcrypto-zkp",
  "futures",
  "http-body 0.4.6",
@@ -9733,9 +9544,9 @@ dependencies = [
  "indexmap 2.11.4",
  "itertools 0.13.0",
  "jsonrpsee",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-package",
  "mysten-metrics",
  "once_cell",
@@ -9756,7 +9567,7 @@ dependencies = [
  "sui-open-rpc-macros",
  "sui-protocol-config",
  "sui-storage",
- "sui-transaction-builder 0.0.0",
+ "sui-transaction-builder",
  "sui-types",
  "tap",
  "thiserror 1.0.69",
@@ -9774,7 +9585,7 @@ version = "0.0.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "jsonrpsee",
  "mysten-metrics",
  "once_cell",
@@ -9797,13 +9608,13 @@ dependencies = [
  "bcs",
  "colored",
  "enum_dispatch",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "itertools 0.13.0",
  "json_to_table",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-disassembler",
  "move-ir-types",
  "mysten-metrics",
@@ -9832,7 +9643,7 @@ dependencies = [
  "bcs",
  "bip32",
  "colored",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "jsonrpc",
  "mockall",
  "rand 0.8.5",
@@ -9864,7 +9675,7 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "mysten-metrics",
  "prometheus",
  "reqwest 0.12.15",
@@ -9882,13 +9693,13 @@ version = "1.58.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "anyhow",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "fastcrypto",
+ "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
  "move-command-line-common",
  "move-compiler",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-ir-types",
  "move-package",
  "move-symbol-pool",
@@ -9908,12 +9719,12 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "fastcrypto-vdf",
  "fastcrypto-zkp",
  "indexmap 2.11.4",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "move-stdlib-natives",
  "move-vm-runtime",
  "move-vm-types",
@@ -9931,11 +9742,11 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "fastcrypto-zkp",
  "linked-hash-map",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "move-stdlib-natives-v0",
  "move-vm-runtime-v0",
  "move-vm-types-v0",
@@ -9952,11 +9763,11 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "fastcrypto-zkp",
  "linked-hash-map",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "move-stdlib-natives-v1",
  "move-vm-runtime-v1",
  "move-vm-types-v1",
@@ -9973,11 +9784,11 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "bcs",
  "better_any",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "fastcrypto-zkp",
  "indexmap 2.11.4",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "move-stdlib-natives-v2",
  "move-vm-runtime-v2",
  "move-vm-types-v2",
@@ -9993,7 +9804,7 @@ version = "1.58.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "bcs",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "serde",
  "sui-types",
  "thiserror 1.0.69",
@@ -10013,7 +9824,7 @@ dependencies = [
  "bytes",
  "dashmap",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "fastcrypto-tbls",
  "futures",
  "governor",
@@ -10062,7 +9873,7 @@ dependencies = [
  "bin-version",
  "clap",
  "consensus-core",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "fastcrypto-zkp",
  "futures",
  "http 1.3.1",
@@ -10135,7 +9946,7 @@ version = "1.58.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "anyhow",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-package",
  "move-symbol-pool",
  "sui-framework-snapshot",
@@ -10156,9 +9967,9 @@ dependencies = [
  "bcs",
  "eyre",
  "lru 0.10.1",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-command-line-common",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "serde",
  "sui-types",
  "thiserror 1.0.69",
@@ -10212,8 +10023,8 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "clap",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "fastcrypto",
+ "move-core-types",
  "move-vm-config",
  "schemars 0.8.21",
  "serde",
@@ -10265,12 +10076,12 @@ dependencies = [
  "base64 0.21.7",
  "bcs",
  "bytes",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "http 1.3.1",
  "itertools 0.13.0",
  "mime",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "mysten-network",
  "prometheus",
  "prost 0.13.4",
@@ -10312,11 +10123,11 @@ dependencies = [
  "bcs",
  "clap",
  "colored",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "futures",
  "futures-core",
  "jsonrpsee",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "reqwest 0.12.15",
  "serde",
  "serde_json",
@@ -10327,7 +10138,7 @@ dependencies = [
  "sui-json-rpc-api",
  "sui-json-rpc-types",
  "sui-keys",
- "sui-transaction-builder 0.0.0",
+ "sui-transaction-builder",
  "sui-types",
  "thiserror 1.0.69",
  "tokio",
@@ -10341,7 +10152,6 @@ source = "git+https://github.com/mystenlabs/sui-rust-sdk?rev=86a9e06#86a9e06cde8
 dependencies = [
  "base64ct",
  "bcs",
- "blake2",
  "bnum",
  "bs58 0.5.1",
  "hex",
@@ -10382,7 +10192,7 @@ dependencies = [
  "anemo",
  "anemo-tower",
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "lru 0.10.1",
  "move-package",
  "msim",
@@ -10407,7 +10217,7 @@ dependencies = [
  "bcs",
  "byteorder",
  "bytes",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "futures",
  "indicatif",
  "integer-encoding",
@@ -10452,7 +10262,7 @@ dependencies = [
  "chrono",
  "clap",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "futures",
  "hyper 1.6.0",
  "hyper-rustls",
@@ -10461,9 +10271,9 @@ dependencies = [
  "itertools 0.13.0",
  "lru 0.10.1",
  "moka",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "mysten-metrics",
  "num_enum",
  "object_store",
@@ -10522,7 +10332,7 @@ dependencies = [
  "anemo",
  "anyhow",
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "move-bytecode-utils",
  "mysten-common",
  "prometheus",
@@ -10558,7 +10368,7 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "bcs",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "shared-crypto",
  "sui-genesis-builder",
  "sui-move-build",
@@ -10576,7 +10386,7 @@ dependencies = [
  "axum 0.8.4",
  "axum-server",
  "ed25519",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "pkcs8 0.10.2",
  "rcgen",
  "reqwest 0.12.15",
@@ -10597,26 +10407,12 @@ dependencies = [
  "async-trait",
  "bcs",
  "futures",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
+ "move-core-types",
  "sui-json",
  "sui-json-rpc-types",
  "sui-protocol-config",
  "sui-types",
-]
-
-[[package]]
-name = "sui-transaction-builder"
-version = "0.1.0"
-source = "git+https://github.com/mystenlabs/sui-rust-sdk?rev=86a9e06#86a9e06cde84671e96e776d926a85fc1f229314d"
-dependencies = [
- "base64ct",
- "bcs",
- "serde",
- "serde_json",
- "serde_with",
- "sui-sdk-types 0.0.2",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -10655,16 +10451,16 @@ dependencies = [
  "derive_more 1.0.0",
  "enum_dispatch",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "fastcrypto-tbls",
  "fastcrypto-zkp",
  "im",
  "indexmap 2.11.4",
  "itertools 0.13.0",
  "lru 0.10.1",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-trace-format",
  "move-vm-profiler",
  "move-vm-test-utils",
@@ -10716,11 +10512,11 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "move-abstract-stack",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier",
  "move-bytecode-verifier-meter",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "sui-protocol-config",
  "sui-types",
@@ -10732,11 +10528,11 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "move-abstract-stack",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v0",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "sui-protocol-config",
  "sui-types",
@@ -10748,11 +10544,11 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "move-abstract-stack",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v1",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "sui-types",
 ]
@@ -10763,11 +10559,11 @@ version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b137ae6a01cf038a6a0fd"
 dependencies = [
  "move-abstract-stack",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "move-bytecode-utils",
  "move-bytecode-verifier-meter",
  "move-bytecode-verifier-v2",
- "move-core-types 0.0.4 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-core-types",
  "move-vm-config",
  "sui-protocol-config",
  "sui-types",
@@ -11018,11 +10814,11 @@ source = "git+https://github.com/mystenlabs/sui?rev=22642cf#22642cfb2c813024ab2b
 dependencies = [
  "anyhow",
  "bcs",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "fastcrypto-zkp",
  "futures",
  "jsonrpsee",
- "move-binary-format 0.0.3 (git+https://github.com/mystenlabs/sui?rev=22642cf)",
+ "move-binary-format",
  "mysten-common",
  "prometheus",
  "rand 0.8.5",
@@ -11904,7 +11700,7 @@ dependencies = [
  "bincode",
  "collectable",
  "eyre",
- "fastcrypto 0.1.9 (git+https://github.com/MystenLabs/fastcrypto?rev=d1fcb853196c3de7888ed8fad74f419b8c8fbe3b)",
+ "fastcrypto",
  "fdlimit",
  "hdrhistogram",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ test-cluster = { git = "https://github.com/mystenlabs/sui", rev = "22642cf", pac
 
 # this matches the sdk version used by mvr-types dep: https://github.com/MystenLabs/mvr
 sui-sdk-types = { git = "https://github.com/mystenlabs/sui-rust-sdk", features = ["serde"], rev = "86a9e06" }
-sui-transaction-builder = { git = "https://github.com/mystenlabs/sui-rust-sdk", rev = "86a9e06" }
 
 [profile.release]
 panic = 'abort'

--- a/crates/key-server/Cargo.toml
+++ b/crates/key-server/Cargo.toml
@@ -44,10 +44,7 @@ reqwest = { version = "0.12", features = ["json"] }
 serde_with = { workspace = true, features = ["base64"] }
 hostname = "0.4"
 
-move-binding-derive = { git = "https://github.com/MystenLabs/move-binding.git", rev = "99f68a28c2f19be40a09e5f1281af748df9a8d3e" }
-move-types = { git = "https://github.com/MystenLabs/move-binding.git", rev = "99f68a28c2f19be40a09e5f1281af748df9a8d3e" }
 sui-sdk-types = { workspace = true }
-sui-transaction-builder = { workspace = true }
 prometheus_closure_metric = { workspace = true }
 hyper-util = "0.1.10"
 http-body-util = "0.1.2"

--- a/crates/key-server/src/mvr.rs
+++ b/crates/key-server/src/mvr.rs
@@ -16,16 +16,12 @@
 use crate::errors::InternalError;
 use crate::errors::InternalError::{Failure, InvalidMVRName, InvalidPackage};
 use crate::key_server_options::KeyServerOptions;
-use crate::mvr::mainnet::mvr_core::app_record::AppRecord;
-use crate::mvr::mainnet::mvr_core::name::Name;
-use crate::mvr::mainnet::sui::dynamic_field::Field;
-use crate::mvr::mainnet::sui::vec_map::VecMap;
-use crate::mvr::testnet::mvr_metadata::package_info::PackageInfo;
 use crate::sui_rpc_client::SuiRpcClient;
 use crate::types::Network;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
+use mvr_types::name::Name;
 use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
@@ -34,7 +30,8 @@ use std::str::FromStr;
 use sui_sdk::rpc_types::SuiObjectDataOptions;
 use sui_sdk::SuiClientBuilder;
 use sui_types::base_types::ObjectID;
-use sui_types::dynamic_field::DynamicFieldName;
+use sui_types::collection_types::Table;
+use sui_types::dynamic_field::{DynamicFieldName, Field};
 use sui_types::TypeTag;
 
 const MVR_REGISTRY: &str = "0xe8417c530cde59eddf6dfb760e8a0e3e2c6f17c69ddaab5a73dd6a6e65fc463b";
@@ -43,23 +40,49 @@ const MVR_CORE: &str = "0x62c1f5b1cb9e3bfc3dd1f73c95066487b662048a6358eabdbf67f6
 /// Testnet records are stored on mainnet on the registry defined above, but under the 'networks' section using the following ID as key
 const TESTNET_ID: &str = "4c78adac";
 
-/// Bindings for Move structs used in the MVR registry, specifically AppRecord and PackageInfo.
-#[allow(clippy::too_many_arguments)]
-pub mod mainnet {
-    use move_binding_derive::move_contract;
-    move_contract! {alias = "sui", package = "0x2"}
-    move_contract! {alias = "suins", package = "0xd22b24490e0bae52676651b4f56660a5ff8022a2576e0089f79b3c88d44e08f0", deps = [crate::mvr::mainnet::sui]}
-    move_contract! {alias = "mvr_core", package = "@mvr/core", deps = [crate::mvr::mainnet::sui, crate::mvr::mainnet::suins, crate::mvr::mainnet::mvr_metadata]}
-    move_contract! {alias = "mvr_metadata", package = "@mvr/metadata", deps = [crate::mvr::mainnet::sui]}
+#[derive(Deserialize, Clone, Debug)]
+pub struct VecMap<K, V>(sui_types::collection_types::VecMap<K, V>);
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct AppRecord {
+    _app_cap_id: ObjectID,
+    _ns_nft_id: ObjectID,
+    app_info: Option<AppInfo>,
+    networks: VecMap<String, AppInfo>,
+    _metadata: VecMap<String, String>,
+    _storage: ObjectID,
 }
-pub mod testnet {
-    use move_binding_derive::move_contract;
-    move_contract! {alias = "mvr_metadata", package = "@mvr/metadata", network = "testnet", deps = [crate::mvr::mainnet::sui]}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct AppInfo {
+    package_info_id: Option<ObjectID>,
+    package_address: Option<ObjectID>,
+    _upgrade_cap_id: Option<ObjectID>,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct PackageInfo {
+    _id: ObjectID,
+    _display: PackageDisplay,
+    _upgrade_cap_id: ObjectID,
+    package_address: ObjectID,
+    metadata: VecMap<String, String>,
+    _git_versioning: Table,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+pub struct PackageDisplay {
+    _gradient_from: String,
+    _gradient_to: String,
+    _text_color: String,
+    _name: String,
+    _uri_encoded_name: String,
 }
 
 impl<K: Eq + Hash, V> From<VecMap<K, V>> for HashMap<K, V> {
     fn from(value: VecMap<K, V>) -> Self {
         value
+            .0
             .contents
             .into_iter()
             .map(|entry| (entry.key, entry.value))
@@ -109,8 +132,7 @@ pub(crate) async fn mvr_forward_resolution(
                 .package_info_id
                 .ok_or(Failure(format!(
                     "No package info ID for MVR name {mvr_name} on testnet"
-                )))
-                .map(|id| ObjectID::new(id.into_inner()))?;
+                )))?;
             let package_info: PackageInfo = get_object(package_info_id, sui_rpc_client).await?;
 
             // Check that the name in the package info matches the MVR name.
@@ -126,7 +148,7 @@ pub(crate) async fn mvr_forward_resolution(
         }
         _ => return Err(Failure("Invalid network for MVR resolution".to_string())),
     };
-    Ok(ObjectID::new(package_address.into_inner()))
+    Ok(package_address)
 }
 
 /// Resolve the network from the network configuration for Custom.


### PR DESCRIPTION
## Description 

This PR removes the move-binding-derive and move-types crates dependency. The goal is to improve the developer experience when contributing on this repo, as the compilation may suddenly start failing if the Move packages specified in the move_contract! macro changes (or on unstable internet connections). Actually, this happened recently with the coin_registry module on the Sui framework, making this repo to fail to compile.

This also improves the security of the Seal ecosystem: if one server operator has to restart the server for any reason, a failing compilation could lead to the server being down during a long period.

I created manually the structs to replace the one auto-generated by move-bindings. I used the same layouts as the Move structures deployed on the mainnet at the time of writing.

PS: I figured out the sui-transaction-builder crate wasn't used anywhere (perhaps due to my changes?), I removed it as well.

## Test plan 

I made sure the existing tests passed.

I checked at the existing tests in key-server/mvr.rs, and saw that the function test_forward_resolution is already tested.

No new tests have been added.