### PR TITLE
[Key Server] Reduce gas budget for the evaluation of Seal policies

### DIFF
--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -93,7 +93,7 @@ mod seal_package;
 pub mod tests;
 mod time;
 
-const GAS_BUDGET: u64 = 500_000_000;
+const GAS_BUDGET: u64 = 25_000_000;
 const GIT_VERSION: &str = utils::git_version!();
 const DEFAULT_PORT: u16 = 2024;
 

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -93,7 +93,7 @@ mod seal_package;
 pub mod tests;
 mod time;
 
-const GAS_BUDGET: u64 = 25_000_000;
+const MAX_COMPUTATION_UNITS: u64 = 55_000; // 50K tier + 10% extra buffer
 const GIT_VERSION: &str = utils::git_version!();
 const DEFAULT_PORT: u16 = 2024;
 
@@ -419,11 +419,12 @@ impl Server {
             .add_staleness_check_to_ptb(self.options.allowed_staleness, vptb.ptb().clone());
 
         // Evaluate the `seal_approve*` function
+        let gas_budget = MAX_COMPUTATION_UNITS * gas_price;
         let tx_data = TransactionData::new_with_gas_coins(
             TransactionKind::ProgrammableTransaction(ptb),
             sender,
             vec![], // Empty gas payment for dry run
-            GAS_BUDGET,
+            gas_budget,
             gas_price,
         );
         let dry_run_res = self


### PR DESCRIPTION
## Description 

The key server calls the dry run API to evaluate Seal policies. To prevent abuse, the server currently uses a fixed gas budget of [500M](https://github.com/MystenLabs/seal/blob/main/crates/key-server/src/server.rs#L96) MIST, which is 1% of the [maximum value](https://docs.sui.io/concepts/tokenomics/gas-in-sui), to limit the cost of these calls.

Since Seal policies should not incur storage fees anyhow, this PR reduces the gas budget to the cost of ~50,000 computation units to further limit potential abuse. The rationale is as follows:

- With a reference gas price (RGP) of 500, the currently used budget corresponds to the [tier](https://docs.sui.io/concepts/tokenomics/gas-in-sui#computation) costing 1M computation units.
- 50,000 computation units, two tiers lower, is still above the cost of any policies we have observed.
- Since the "cost" of dry run is independent of the load on the chain (as it does not compete with other transactions), the enforced limit should not depend on the current Reference Gas Price, and instead be defined with regards to computation units.
- Increasing this value in the future will be backward compatible.

Feedback on the proposed value is welcome.