### PR TITLE
[1/3][key-server] use grpc client for get object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
  "pkcs8",
  "quinn",
  "quinn-proto",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rcgen",
  "ring",
  "rustls",
@@ -311,7 +311,7 @@ dependencies = [
  "libloading",
  "linkme",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc_version_runtime",
  "serde",
  "serde_json",
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
 dependencies = [
  "rustversion",
  "serde",
@@ -540,7 +540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -853,7 +853,7 @@ dependencies = [
  "fs-err",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "rustls",
@@ -873,7 +873,7 @@ dependencies = [
  "getrandom 0.2.17",
  "instant",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "tokio",
 ]
 
@@ -1061,7 +1061,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.117",
 ]
@@ -1330,7 +1330,7 @@ dependencies = [
  "digest 0.10.7",
  "group 0.13.0",
  "merlin",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "serde",
  "serde_derive",
@@ -1461,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1732,7 +1732,7 @@ source = "git+https://github.com/mystenlabs/sui?rev=6c3a7475b6fd4aea9b9f9443a6cf
 dependencies = [
  "fastcrypto",
  "mysten-network",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "shared-crypto",
 ]
@@ -1767,7 +1767,7 @@ dependencies = [
  "prometheus",
  "prost 0.14.3",
  "quinn-proto",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustls",
  "serde",
  "shared-crypto",
@@ -1800,6 +1800,18 @@ dependencies = [
  "consensus-config",
  "fastcrypto",
  "serde",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1949,7 +1961,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fef0a447ef2e9e6bd57e379f88702c58c4a4253ba82fb175bd7db012192311a"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
  "siphasher",
 ]
 
@@ -2054,7 +2066,7 @@ dependencies = [
  "fastcrypto-tbls",
  "hex",
  "itertools 0.14.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_with",
  "sui-sdk-types 0.2.2",
@@ -2299,7 +2311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2879,7 +2891,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.2",
+ "rand 0.9.4",
  "siphasher",
 ]
 
@@ -2923,7 +2935,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "once_cell",
  "p256",
- "rand 0.8.5",
+ "rand 0.8.6",
  "readonly",
  "rfc6979 0.4.0",
  "rsa",
@@ -2962,7 +2974,7 @@ dependencies = [
  "fastcrypto",
  "hex",
  "itertools 0.10.5",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde-big-array",
  "sha3 0.10.8",
@@ -2984,7 +2996,7 @@ dependencies = [
  "num-integer",
  "num-prime",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
 ]
@@ -3112,7 +3124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3461,7 +3473,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "portable-atomic",
  "quanta",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "spinning_top",
 ]
@@ -3484,7 +3496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.1",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_core 0.6.4",
  "rand_xorshift 0.3.0",
  "subtle",
@@ -3836,9 +3848,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3851,6 +3863,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -3863,7 +3876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-util",
  "log",
  "rustls",
@@ -3881,7 +3894,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3896,7 +3909,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3916,7 +3929,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -3941,7 +3954,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -4145,7 +4158,7 @@ version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
- "console",
+ "console 0.16.3",
  "portable-atomic",
  "unicode-width 0.2.2",
  "unit-prefix",
@@ -4185,11 +4198,11 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.46.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
 dependencies = [
- "console",
+ "console 0.15.11",
  "once_cell",
  "serde",
  "similar",
@@ -4213,9 +4226,9 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "inventory"
-version = "0.3.24"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
 dependencies = [
  "rustversion",
 ]
@@ -4228,9 +4241,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.12"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -4291,9 +4304,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.18"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jni"
@@ -4304,7 +4317,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-sys",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -4313,31 +4326,9 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn 2.0.117",
-]
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
@@ -4351,12 +4342,10 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.93"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797146bb2677299a1eb6b7b50a890f4c361b29ef967addf5b2fa45dae1bb6d7d"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
- "cfg-if",
- "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -4437,8 +4426,8 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot 0.12.5",
  "pin-project",
- "rand 0.8.5",
- "rustc-hash 2.1.2",
+ "rand 0.8.6",
+ "rustc-hash 2.1.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -4456,7 +4445,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-util",
  "jsonrpsee-core",
@@ -4495,7 +4484,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -4598,7 +4587,7 @@ dependencies = [
  "prometheus",
  "prometheus-closure-metric",
  "prost-types 0.14.3",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest",
  "seal-committee",
  "seal-sdk",
@@ -4684,11 +4673,11 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lcov"
-version = "0.8.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dab4f1d99e0dd8008da0d3452bb71ce08e1645465c2accc124bcb599c6b3143"
+checksum = "1ccfa6d5e585a884db65b37f38184e4364eaf74d884ac35d0a90fe9baf80b723"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4727,9 +4716,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -5096,9 +5085,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -5134,9 +5123,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "85f8024e1c8e71c778968af91d43700ce1d11b219d127d79fb2934153b82b42b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5381,7 +5370,7 @@ dependencies = [
  "move-proc-macros",
  "num",
  "primitive-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "ref-cast",
  "serde",
  "serde_bytes",
@@ -5894,7 +5883,7 @@ dependencies = [
  "msim-macros",
  "naive-timer",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "real_tokio",
  "serde",
  "socket2 0.4.10",
@@ -6004,7 +5993,7 @@ dependencies = [
  "mysten-metrics",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest",
  "serde_json",
  "snap",
@@ -6060,7 +6049,7 @@ dependencies = [
  "pin-project-lite",
  "prometheus",
  "quinn-proto",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustls",
  "serde",
  "snap",
@@ -6272,7 +6261,7 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
 ]
 
@@ -6287,7 +6276,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -6303,9 +6292,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-integer"
@@ -6351,7 +6340,7 @@ dependencies = [
  "num-integer",
  "num-modular",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6436,29 +6425,27 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.13.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+checksum = "c2858065e55c148d294a9f3aae3b0fa9458edadb41a108397094566f4e3c0dfb"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures-channel",
- "futures-core",
- "futures-util",
+ "futures",
  "http 1.4.0",
  "http-body-util",
  "httparse",
  "humantime",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "itertools 0.14.0",
  "md-5",
  "parking_lot 0.12.5",
  "percent-encoding",
  "quick-xml",
- "rand 0.10.0",
+ "rand 0.9.4",
  "reqwest",
  "ring",
  "rustls-pki-types",
@@ -6605,7 +6592,7 @@ dependencies = [
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -6808,7 +6795,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hmac",
  "indexmap 2.13.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6828,7 +6815,7 @@ dependencies = [
  "group 0.13.0",
  "hex",
  "lazy_static",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "static_assertions",
  "subtle",
@@ -6919,7 +6906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6969,6 +6956,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"
@@ -7148,7 +7141,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml_edit 0.25.5+spec-1.1.0",
 ]
 
 [[package]]
@@ -7210,15 +7203,15 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.11.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
  "bit-set 0.8.0",
  "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
  "regex-syntax 0.8.10",
@@ -7274,7 +7267,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7418,9 +7411,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
 dependencies = [
  "bitflags 2.11.0",
  "memchr",
@@ -7459,9 +7452,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
  "serde",
@@ -7469,9 +7462,9 @@ dependencies = [
 
 [[package]]
 name = "quick_cache"
-version = "0.6.21"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a70b1b8b47e31d0498ecbc3c5470bb931399a8bfed1fd79d1717a61ce7f96e3"
+checksum = "d4c901384fb8fb3d4510388129ce6e13ecd686eee610da778b6ea77219decd53"
 dependencies = [
  "ahash 0.8.12",
  "equivalent",
@@ -7491,7 +7484,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -7510,9 +7503,9 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -7594,9 +7587,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -7605,9 +7598,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -7615,9 +7608,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -7783,7 +7776,7 @@ source = "git+https://github.com/MystenLabs/tokio-msim-fork.git?rev=6b1da10b18f9
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio 1.1.1",
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
@@ -7907,7 +7900,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -8049,9 +8042,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
 dependencies = [
  "arrayvec",
  "num-traits",
@@ -8065,9 +8058,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-hex"
@@ -8182,9 +8175,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -8360,7 +8353,7 @@ dependencies = [
  "clap",
  "crypto",
  "fastcrypto",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest",
  "seal-committee",
  "seal-sdk",
@@ -8400,7 +8393,7 @@ dependencies = [
  "fastcrypto-tbls",
  "move-package-alt-compilation",
  "prost-types 0.14.3",
- "rand 0.8.5",
+ "rand 0.8.6",
  "seal-committee",
  "serde",
  "serde_json",
@@ -8454,7 +8447,7 @@ dependencies = [
  "chrono",
  "crypto",
  "fastcrypto",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sui-sdk-types 0.2.2",
@@ -8496,7 +8489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand 0.8.6",
  "secp256k1-sys",
 ]
 
@@ -8897,9 +8890,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "similar"
@@ -9007,7 +9000,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha1",
 ]
 
@@ -9413,7 +9406,7 @@ dependencies = [
  "object_store",
  "once_cell",
  "prometheus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest",
  "serde",
  "serde_json",
@@ -9479,7 +9472,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-build",
  "protox",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "reqwest",
  "roaring 0.10.12",
@@ -9676,7 +9669,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "prometheus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_with",
  "serde_yaml 0.8.26",
@@ -9701,7 +9694,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "socket2 0.5.10",
@@ -9748,7 +9741,7 @@ dependencies = [
  "fastcrypto-zkp",
  "futures",
  "http-body 0.4.6",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "im",
  "indexmap 2.13.0",
  "itertools 0.13.0",
@@ -9855,7 +9848,7 @@ dependencies = [
  "fastcrypto",
  "jsonrpc",
  "mockall",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "serde",
  "serde_json",
@@ -9939,7 +9932,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "move-vm-runtime",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "sui-protocol-config",
  "sui-types",
@@ -10025,7 +10018,7 @@ dependencies = [
  "move-stdlib-natives-v3",
  "move-vm-runtime-v3",
  "move-vm-types-v3",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "sui-protocol-config",
  "sui-types",
@@ -10071,7 +10064,7 @@ dependencies = [
  "once_cell",
  "prometheus",
  "prost 0.14.3",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_yaml 0.8.26",
  "shared-crypto",
@@ -10265,7 +10258,7 @@ dependencies = [
  "move-core-types",
  "move-vm-config",
  "mysten-common",
- "rand 0.8.5",
+ "rand 0.8.6",
  "schemars 0.8.22",
  "serde",
  "serde-env",
@@ -10329,7 +10322,7 @@ dependencies = [
  "prost 0.14.3",
  "prost-types 0.14.3",
  "protox",
- "rand 0.8.5",
+ "rand 0.8.6",
  "roaring 0.10.12",
  "serde",
  "serde_json",
@@ -10447,7 +10440,7 @@ dependencies = [
  "move-package-alt-compilation",
  "msim",
  "mysten-network",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "sui-framework",
  "sui-move-build",
@@ -10504,7 +10497,7 @@ dependencies = [
  "eyre",
  "fastcrypto",
  "futures",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-rustls",
  "indicatif",
  "integer-encoding",
@@ -10547,7 +10540,7 @@ dependencies = [
  "mysten-metrics",
  "mysten-network",
  "prometheus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sui-config",
  "sui-macros",
  "sui-node",
@@ -10576,7 +10569,7 @@ dependencies = [
  "move-bytecode-utils",
  "mysten-common",
  "prometheus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_with",
  "serde_yaml 0.8.26",
@@ -10720,7 +10713,7 @@ dependencies = [
  "proptest-derive",
  "prost 0.14.3",
  "prost-types 0.14.3",
- "rand 0.8.5",
+ "rand 0.8.6",
  "roaring 0.10.12",
  "rustls-pki-types",
  "schemars 0.8.22",
@@ -11023,12 +11016,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11052,7 +11045,7 @@ dependencies = [
  "move-core-types",
  "mysten-common",
  "prometheus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sui-config",
  "sui-core",
  "sui-framework",
@@ -11204,7 +11197,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rustc-hash 1.1.0",
  "sha2 0.10.9",
  "thiserror 1.0.69",
@@ -11255,7 +11248,7 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio 1.1.1",
  "parking_lot 0.12.5",
  "pin-project-lite",
  "signal-hook-registry",
@@ -11394,9 +11387,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.0.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "9b320e741db58cac564e26c607d3cc1fdc4a88fd36c879568c07856ed83ff3e9"
 dependencies = [
  "serde_core",
 ]
@@ -11430,23 +11423,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "8ca1a40644a28bce036923f6a431df0b34236949d111cc07cb6dca830c9ef2e1"
 dependencies = [
  "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.0",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -11470,7 +11463,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -11499,7 +11492,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -11595,7 +11588,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "pin-project",
@@ -11640,7 +11633,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util 0.7.18",
@@ -11898,7 +11891,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -11911,7 +11904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.8.6",
  "static_assertions",
 ]
 
@@ -11936,7 +11929,7 @@ dependencies = [
  "mysten-metrics",
  "once_cell",
  "prometheus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rocksdb",
  "serde",
  "sui-macros",
@@ -12068,9 +12061,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
@@ -12157,13 +12150,13 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.1",
  "wasm-bindgen",
 ]
 
@@ -12284,9 +12277,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.116"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc0882f7b5bb01ae8c5215a1230832694481c1a4be062fd410e12ea3da5b631"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -12297,19 +12290,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.66"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19280959e2844181895ef62f065c63e0ca07ece4771b53d89bfdb967d97cbf05"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.116"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75973d3066e01d035dbedaad2864c398df42f8dd7b1ea057c35b8407c015b537"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -12317,9 +12314,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.116"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91af5e4be765819e0bcfee7322c14374dc821e35e72fa663a830bbc7dc199eac"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -12330,9 +12327,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.116"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9bf0406a78f02f336bf1e451799cca198e8acde4ffa278f0fb20487b150a633"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -12386,9 +12383,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.93"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "749466a37ee189057f54748b200186b59a03417a117267baf3fd89cecc9fb837"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -12486,7 +12483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -12498,7 +12495,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -12515,25 +12512,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
 name = "windows-future"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -12578,7 +12562,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core 0.61.2",
+ "windows-core",
  "windows-link 0.1.3",
 ]
 
@@ -12964,9 +12948,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 dependencies = [
  "memchr",
 ]
@@ -13169,18 +13153,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG PROFILE=release
 WORKDIR work
 
 COPY ./crates ./crates
-COPY ./Cargo.toml ./
+COPY ./Cargo.toml ./Cargo.lock ./
 
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/Dockerfile.aggregator
+++ b/Dockerfile.aggregator
@@ -6,7 +6,7 @@ ARG PROFILE=release
 WORKDIR work
 
 COPY ./crates ./crates
-COPY ./Cargo.toml ./
+COPY ./Cargo.toml ./Cargo.lock ./
 
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION

--- a/crates/key-server/src/externals.rs
+++ b/crates/key-server/src/externals.rs
@@ -70,13 +70,14 @@ pub(crate) async fn fetch_first_pkg_id(
     match CACHE.get(pkg_id) {
         Some(first) => Ok(first),
         None => {
-            let package = sui_rpc_client.get_package(*pkg_id).await.map_err(|e| {
-                if e.code == Some(Code::NotFound) {
-                    InternalError::InvalidPackage
-                } else {
-                    InternalError::Failure("FN failed to respond".to_string())
-                }
-            })?;
+            let package = sui_rpc_client
+                .get_package(*pkg_id)
+                .await
+                .map_err(|e| match e.code {
+                    // NotFound = missing/non-package; None = FN protocol violation (missing BCS / decode failure) — both are client-facing, deterministic.
+                    Some(Code::NotFound) | None => InternalError::InvalidPackage,
+                    _ => InternalError::Failure("FN failed to respond".to_string()),
+                })?;
             let first = package.original_package_id();
             CACHE.insert(*pkg_id, first);
             Ok(first)

--- a/crates/key-server/src/externals.rs
+++ b/crates/key-server/src/externals.rs
@@ -9,9 +9,11 @@ use crate::sui_rpc_client::RpcResult;
 use crate::sui_rpc_client::SuiRpcClient;
 use moka::sync::Cache;
 use once_cell::sync::Lazy;
-use sui_sdk::rpc_types::{SuiData, SuiObjectDataOptions};
+use sui_sdk_types::{Object, ObjectData};
 use sui_types::base_types::ObjectID;
+use sui_types::move_package::MovePackage;
 use tap::TapFallible;
+use tonic::Code;
 use tracing::{debug, warn};
 
 static CACHE: Lazy<Cache<ObjectID, ObjectID>> = Lazy::new(default_lru_cache);
@@ -70,22 +72,26 @@ pub(crate) async fn fetch_first_pkg_id(
     match CACHE.get(pkg_id) {
         Some(first) => Ok(first),
         None => {
-            let object = sui_rpc_client
-                .get_object_with_options(*pkg_id, SuiObjectDataOptions::default().with_bcs())
+            let bcs_bytes = sui_rpc_client
+                .get_object_raw_bcs(*pkg_id)
                 .await
-                .map_err(|_| InternalError::Failure("FN failed to respond".to_string()))? // internal error that fullnode fails to respond, check fullnode.
-                .into_object()
-                .map_err(|_| InternalError::InvalidPackage)?; // user error that object does not exist or deleted.
+                .map_err(|e| {
+                    if e.code == Some(Code::NotFound) {
+                        InternalError::InvalidPackage
+                    } else {
+                        InternalError::Failure("FN failed to respond".to_string())
+                    }
+                })?;
 
-            let package = object
-                .bcs
-                .ok_or(InternalError::Failure(
-                    "No BCS object in response".to_string(),
-                ))? // internal error that fullnode does not respond with bcs even though request includes the bcs option.
-                .try_as_package()
-                .ok_or(InternalError::InvalidPackage)?
-                .to_move_package(u64::MAX)
-                .map_err(|_| InternalError::InvalidPackage)?; // user error if the provided package throw MovePackageTooBig.
+            let obj: Object =
+                bcs::from_bytes(&bcs_bytes).map_err(|_| InternalError::InvalidPackage)?;
+            let package: MovePackage = match obj.data() {
+                ObjectData::Package(p) => {
+                    let bytes = bcs::to_bytes(p).map_err(|_| InternalError::InvalidPackage)?;
+                    bcs::from_bytes(&bytes).map_err(|_| InternalError::InvalidPackage)?
+                }
+                _ => return Err(InternalError::InvalidPackage),
+            };
 
             let first = package.original_package_id();
             CACHE.insert(*pkg_id, first);

--- a/crates/key-server/src/externals.rs
+++ b/crates/key-server/src/externals.rs
@@ -9,9 +9,7 @@ use crate::sui_rpc_client::RpcResult;
 use crate::sui_rpc_client::SuiRpcClient;
 use moka::sync::Cache;
 use once_cell::sync::Lazy;
-use sui_sdk_types::{Object, ObjectData};
 use sui_types::base_types::ObjectID;
-use sui_types::move_package::MovePackage;
 use tap::TapFallible;
 use tonic::Code;
 use tracing::{debug, warn};
@@ -72,27 +70,13 @@ pub(crate) async fn fetch_first_pkg_id(
     match CACHE.get(pkg_id) {
         Some(first) => Ok(first),
         None => {
-            let bcs_bytes = sui_rpc_client
-                .get_object_raw_bcs(*pkg_id)
-                .await
-                .map_err(|e| {
-                    if e.code == Some(Code::NotFound) {
-                        InternalError::InvalidPackage
-                    } else {
-                        InternalError::Failure("FN failed to respond".to_string())
-                    }
-                })?;
-
-            let obj: Object =
-                bcs::from_bytes(&bcs_bytes).map_err(|_| InternalError::InvalidPackage)?;
-            let package: MovePackage = match obj.data() {
-                ObjectData::Package(p) => {
-                    let bytes = bcs::to_bytes(p).map_err(|_| InternalError::InvalidPackage)?;
-                    bcs::from_bytes(&bytes).map_err(|_| InternalError::InvalidPackage)?
+            let package = sui_rpc_client.get_package(*pkg_id).await.map_err(|e| {
+                if e.code == Some(Code::NotFound) {
+                    InternalError::InvalidPackage
+                } else {
+                    InternalError::Failure("FN failed to respond".to_string())
                 }
-                _ => return Err(InternalError::InvalidPackage),
-            };
-
+            })?;
             let first = package.original_package_id();
             CACHE.insert(*pkg_id, first);
             Ok(first)

--- a/crates/key-server/src/mvr.rs
+++ b/crates/key-server/src/mvr.rs
@@ -139,7 +139,11 @@ pub(crate) async fn mvr_forward_resolution(
             let package_info: PackageInfo = sui_rpc_client
                 .get_object(package_info_id)
                 .await
-                .map_err(|_| Failure(format!("Failed to get object {package_info_id}")))?;
+                .map_err(|e| match e.code {
+                    // None = FN protocol violation (missing BCS / decode failure) — deterministic, not retryable.
+                    None => InvalidPackage,
+                    _ => Failure(format!("Failed to get object {package_info_id}")),
+                })?;
 
             // Check that the name in the package info matches the MVR name.
             let metadata: HashMap<_, _> = package_info.metadata.into();
@@ -182,6 +186,7 @@ async fn get_from_mvr_registry(
         .await
         .map_err(|e| match e.code {
             Some(Code::NotFound) => InvalidMVRName,
+            // None = FN protocol violation (missing BCS / decode failure) — deterministic, not retryable.
             None => InvalidPackage,
             _ => Failure(format!(
                 "Failed to get dynamic field object '{dynamic_field_name}' from MVR registry"

--- a/crates/key-server/src/mvr.rs
+++ b/crates/key-server/src/mvr.rs
@@ -14,14 +14,14 @@
 //! * The app record and package info objects point to the package address that was used when the name was registered, but there could be more recent versions of the package.
 
 use crate::errors::InternalError;
-use crate::errors::InternalError::{Failure, InvalidMVRName};
+use crate::errors::InternalError::{Failure, InvalidMVRName, InvalidPackage};
 use crate::key_server_options::KeyServerOptions;
 use crate::sui_rpc_client::SuiRpcClient;
 use crate::types::Network;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
-use mvr_types::name::Name;
+use mvr_types::name::{Name, VersionedName};
 use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
@@ -137,7 +137,7 @@ pub(crate) async fn mvr_forward_resolution(
                     "No package info ID for MVR name {mvr_name} on testnet"
                 )))?;
             let package_info: PackageInfo = sui_rpc_client
-                .get_object_bcs(package_info_id)
+                .get_object(package_info_id)
                 .await
                 .map_err(|_| Failure(format!("Failed to get object {package_info_id}")))?;
 
@@ -163,16 +163,10 @@ async fn get_from_mvr_registry(
     mainnet_sui_rpc_client: &SuiRpcClient,
 ) -> Result<Field<Name, AppRecord>, InternalError> {
     let dynamic_field_name = dynamic_field_name(mvr_name)?;
-    // Derive the dynamic field child ID to look up the record directly
-    let registry_id = ObjectID::from_str(MVR_REGISTRY).unwrap();
-    let registry_address = Address::from_bytes(registry_id.into_bytes())
-        .map_err(|_| Failure("Invalid registry address".to_string()))?;
+    let registry_address = Address::new(ObjectID::from_str(MVR_REGISTRY).unwrap().into_bytes());
 
-    // Serialize the dynamic field key for derivation
-    let parsed_name =
-        mvr_types::name::VersionedName::from_str(mvr_name).map_err(|_| InvalidMVRName)?;
-    let name_bcs = bcs::to_bytes(&parsed_name.name)
-        .map_err(|_| Failure("Failed to BCS-encode name".to_string()))?;
+    let parsed_name = VersionedName::from_str(mvr_name).map_err(|_| InvalidMVRName)?;
+    let name_bcs = bcs::to_bytes(&parsed_name.name).expect("BCS encoding of Name should not fail");
     let name_type_tag = SdkTypeTag::Struct(Box::new(SdkStructTag::new(
         Address::from_str(MVR_CORE).unwrap(),
         "name".parse().unwrap(),
@@ -181,27 +175,23 @@ async fn get_from_mvr_registry(
     )));
 
     let child_id = registry_address.derive_dynamic_child_id(&name_type_tag, &name_bcs);
-    let child_object_id = ObjectID::from_bytes(child_id.as_bytes())
-        .map_err(|_| Failure("Invalid child object ID".to_string()))?;
+    let child_object_id = ObjectID::new(child_id.into_inner());
 
     mainnet_sui_rpc_client
-        .get_object_bcs::<Field<Name, AppRecord>>(child_object_id)
+        .get_object::<Field<Name, AppRecord>>(child_object_id)
         .await
-        .map_err(|e| {
-            if e.code == Some(Code::NotFound) {
-                InvalidMVRName
-            } else {
-                Failure(format!(
-                    "Failed to get dynamic field object '{dynamic_field_name}' from MVR registry"
-                ))
-            }
+        .map_err(|e| match e.code {
+            Some(Code::NotFound) => InvalidMVRName,
+            None => InvalidPackage,
+            _ => Failure(format!(
+                "Failed to get dynamic field object '{dynamic_field_name}' from MVR registry"
+            )),
         })
 }
 
 /// Construct a `DynamicFieldName` from an MVR name for use in the MVR registry.
 fn dynamic_field_name(mvr_name: &str) -> Result<DynamicFieldName, InternalError> {
-    let parsed_name =
-        mvr_types::name::VersionedName::from_str(mvr_name).map_err(|_| InvalidMVRName)?;
+    let parsed_name = VersionedName::from_str(mvr_name).map_err(|_| InvalidMVRName)?;
     if parsed_name.version.is_some() {
         return Err(InvalidMVRName);
     }

--- a/crates/key-server/src/mvr.rs
+++ b/crates/key-server/src/mvr.rs
@@ -14,7 +14,7 @@
 //! * The app record and package info objects point to the package address that was used when the name was registered, but there could be more recent versions of the package.
 
 use crate::errors::InternalError;
-use crate::errors::InternalError::{Failure, InvalidMVRName, InvalidPackage};
+use crate::errors::InternalError::{Failure, InvalidMVRName};
 use crate::key_server_options::KeyServerOptions;
 use crate::sui_rpc_client::SuiRpcClient;
 use crate::types::Network;
@@ -28,12 +28,13 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::str::FromStr;
 use sui_rpc::client::Client as SuiGrpcClient;
-use sui_sdk::rpc_types::SuiObjectDataOptions;
 use sui_sdk::SuiClientBuilder;
+use sui_sdk_types::{Address, StructTag as SdkStructTag, TypeTag as SdkTypeTag};
 use sui_types::base_types::ObjectID;
 use sui_types::collection_types::Table;
 use sui_types::dynamic_field::{DynamicFieldName, Field};
 use sui_types::TypeTag;
+use tonic::Code;
 
 const MVR_REGISTRY: &str = "0xe8417c530cde59eddf6dfb760e8a0e3e2c6f17c69ddaab5a73dd6a6e65fc463b";
 const MVR_CORE: &str = "0x62c1f5b1cb9e3bfc3dd1f73c95066487b662048a6358eabdbf67f6cdeca6db4b";
@@ -135,7 +136,10 @@ pub(crate) async fn mvr_forward_resolution(
                 .ok_or(Failure(format!(
                     "No package info ID for MVR name {mvr_name} on testnet"
                 )))?;
-            let package_info: PackageInfo = get_object(package_info_id, sui_rpc_client).await?;
+            let package_info: PackageInfo = sui_rpc_client
+                .get_object_bcs(package_info_id)
+                .await
+                .map_err(|_| Failure(format!("Failed to get object {package_info_id}")))?;
 
             // Check that the name in the package info matches the MVR name.
             let metadata: HashMap<_, _> = package_info.metadata.into();
@@ -159,22 +163,39 @@ async fn get_from_mvr_registry(
     mainnet_sui_rpc_client: &SuiRpcClient,
 ) -> Result<Field<Name, AppRecord>, InternalError> {
     let dynamic_field_name = dynamic_field_name(mvr_name)?;
-    let record_id = mainnet_sui_rpc_client
-        .get_dynamic_field_object(
-            ObjectID::from_str(MVR_REGISTRY).unwrap(),
-            dynamic_field_name.clone(),
-        )
-        .await
-        .map_err(|_| {
-            Failure(format!(
-                "Failed to get dynamic field object '{dynamic_field_name}' from MVR registry"
-            ))
-        })?
-        .object_id()
-        .map_err(|_| InvalidMVRName)?;
+    // Derive the dynamic field child ID to look up the record directly
+    let registry_id = ObjectID::from_str(MVR_REGISTRY).unwrap();
+    let registry_address = Address::from_bytes(registry_id.into_bytes())
+        .map_err(|_| Failure("Invalid registry address".to_string()))?;
 
-    // TODO: Is there a way to get the BCS data in the above call instead of making a second call?
-    get_object(record_id, mainnet_sui_rpc_client).await
+    // Serialize the dynamic field key for derivation
+    let parsed_name =
+        mvr_types::name::VersionedName::from_str(mvr_name).map_err(|_| InvalidMVRName)?;
+    let name_bcs = bcs::to_bytes(&parsed_name.name)
+        .map_err(|_| Failure("Failed to BCS-encode name".to_string()))?;
+    let name_type_tag = SdkTypeTag::Struct(Box::new(SdkStructTag::new(
+        Address::from_str(MVR_CORE).unwrap(),
+        "name".parse().unwrap(),
+        "Name".parse().unwrap(),
+        vec![],
+    )));
+
+    let child_id = registry_address.derive_dynamic_child_id(&name_type_tag, &name_bcs);
+    let child_object_id = ObjectID::from_bytes(child_id.as_bytes())
+        .map_err(|_| Failure("Invalid child object ID".to_string()))?;
+
+    mainnet_sui_rpc_client
+        .get_object_bcs::<Field<Name, AppRecord>>(child_object_id)
+        .await
+        .map_err(|e| {
+            if e.code == Some(Code::NotFound) {
+                InvalidMVRName
+            } else {
+                Failure(format!(
+                    "Failed to get dynamic field object '{dynamic_field_name}' from MVR registry"
+                ))
+            }
+        })
 }
 
 /// Construct a `DynamicFieldName` from an MVR name for use in the MVR registry.
@@ -194,21 +215,6 @@ fn dynamic_field_name(mvr_name: &str) -> Result<DynamicFieldName, InternalError>
         })),
         value: json!(parsed_name.name),
     })
-}
-
-async fn get_object<T: for<'a> Deserialize<'a>>(
-    object_id: ObjectID,
-    sui_rpc_client: &SuiRpcClient,
-) -> Result<T, InternalError> {
-    bcs::from_bytes(
-        sui_rpc_client
-            .get_object_with_options(object_id, SuiObjectDataOptions::new().with_bcs())
-            .await
-            .map_err(|_| Failure(format!("Failed to get object {object_id}")))?
-            .move_object_bcs()
-            .ok_or(Failure(format!("No BCS on response of object {object_id}")))?,
-    )
-    .map_err(|_| InvalidPackage)
 }
 
 #[cfg(test)]

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -168,8 +168,7 @@ async fn has_address_aliases(
     .map_err(|_| InternalError::InvalidSignature)?;
 
     // Convert ObjectID to Address for gRPC request
-    let address_id = Address::from_bytes(address_aliases_id.into_bytes())
-        .map_err(|_| InternalError::InvalidSignature)?;
+    let address_id = Address::new(address_aliases_id.into_bytes());
 
     let request = GetObjectRequest::default().with_object_id(address_id.to_string());
 

--- a/crates/key-server/src/sui_rpc_client.rs
+++ b/crates/key-server/src/sui_rpc_client.rs
@@ -40,11 +40,12 @@ impl RetriableError for sui_sdk::error::Error {
 /// Result type for RPC operations
 pub type RpcResult<T> = Result<T, RpcError>;
 
-/// Error type for RPC operations
+/// Error type for RPC operations.
 #[derive(Debug)]
 pub struct RpcError {
     #[allow(dead_code)]
     message: String,
+    /// `Some(code)` for gRPC transport errors; `None` for local post-processing failures (missing BCS, decode failure, wrong shape) — deterministic, never retried.
     pub(crate) code: Option<tonic::Code>,
 }
 
@@ -58,7 +59,7 @@ impl std::error::Error for RpcError {}
 
 impl RetriableError for RpcError {
     fn is_retriable_error(&self) -> bool {
-        // Only gRPC errors with specific status codes should be retried
+        // Retry only transient gRPC statuses; `code: None` (local decode failures) is deterministic.
         self.code.is_some_and(|code| {
             matches!(
                 code,
@@ -72,7 +73,7 @@ impl RetriableError for RpcError {
 }
 
 impl RpcError {
-    /// Helper to convert gRPC errors to RpcError
+    /// Wrap a gRPC status; produces `code: Some(...)`.
     fn from_grpc(e: tonic::Status) -> Self {
         Self {
             message: format!("gRPC error: {e}"),
@@ -80,7 +81,7 @@ impl RpcError {
         }
     }
 
-    /// Create a new RpcError with a message
+    /// Wrap a local post-processing failure (missing BCS, decode failure, wrong shape); produces `code: None`.
     pub(crate) fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),

--- a/crates/key-server/src/sui_rpc_client.rs
+++ b/crates/key-server/src/sui_rpc_client.rs
@@ -4,14 +4,18 @@
 use std::sync::Arc;
 
 use crate::{key_server_options::RetryConfig, metrics::KeyServerMetrics};
+use prost_types::FieldMask;
 use sui_rpc::client::Client as SuiGrpcClient;
+use sui_rpc::proto::sui::rpc::v2::{GetEpochRequest, GetObjectRequest};
 use sui_sdk::{
     error::SuiRpcResult,
     rpc_types::{DryRunTransactionBlockResponse, SuiObjectDataOptions, SuiObjectResponse},
     SuiClient,
 };
+use sui_sdk_types::{Address, Object};
 use sui_types::base_types::ObjectID;
-use sui_types::{dynamic_field::DynamicFieldName, transaction::TransactionData};
+use sui_types::transaction::TransactionData;
+use tonic::{Code, Status};
 
 /// Trait for determining if an error is retriable
 pub trait RetriableError {
@@ -44,8 +48,16 @@ pub type RpcResult<T> = Result<T, RpcError>;
 pub struct RpcError {
     #[allow(dead_code)]
     message: String,
-    code: Option<tonic::Code>,
+    pub(crate) code: Option<Code>,
 }
+
+impl std::fmt::Display for RpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for RpcError {}
 
 impl RetriableError for RpcError {
     fn is_retriable_error(&self) -> bool {
@@ -53,10 +65,10 @@ impl RetriableError for RpcError {
         self.code.is_some_and(|code| {
             matches!(
                 code,
-                tonic::Code::Unavailable
-                    | tonic::Code::DeadlineExceeded
-                    | tonic::Code::ResourceExhausted
-                    | tonic::Code::Aborted
+                Code::Unavailable
+                    | Code::DeadlineExceeded
+                    | Code::ResourceExhausted
+                    | Code::Aborted
             )
         })
     }
@@ -64,7 +76,7 @@ impl RetriableError for RpcError {
 
 impl RpcError {
     /// Helper to convert gRPC errors to RpcError
-    fn from_grpc(e: tonic::Status) -> Self {
+    fn from_grpc(e: Status) -> Self {
         Self {
             message: format!("gRPC error: {e}"),
             code: Some(e.code()),
@@ -215,7 +227,8 @@ impl SuiRpcClient {
         .await
     }
 
-    /// Returns an object with the given options.
+    /// Returns an object with the given options (JSON RPC).
+    #[allow(dead_code)]
     pub async fn get_object_with_options(
         &self,
         object_id: ObjectID,
@@ -235,7 +248,92 @@ impl SuiRpcClient {
         .await
     }
 
-    /// Returns the current reference gas price.
+    /// Fetches an object's BCS data via gRPC and deserializes it as type T.
+    pub async fn get_object_bcs<T: serde::de::DeserializeOwned>(
+        &self,
+        object_id: ObjectID,
+    ) -> RpcResult<T> {
+        sui_rpc_with_retries(
+            &self.rpc_retry_config,
+            "get_object_bcs",
+            self.metrics.clone(),
+            || {
+                let mut grpc_client = self.sui_grpc_client.clone();
+                async move {
+                    let address = Address::from_bytes(object_id.into_bytes())
+                        .map_err(|e| RpcError::new(format!("Invalid object ID: {e}")))?;
+
+                    let mut request = GetObjectRequest::default();
+                    request.object_id = Some(address.to_string());
+                    request.read_mask = Some(FieldMask {
+                        paths: vec!["bcs".to_string()],
+                    });
+
+                    let response = grpc_client
+                        .ledger_client()
+                        .get_object(request)
+                        .await
+                        .map(|r| r.into_inner())
+                        .map_err(RpcError::from_grpc)?;
+
+                    let bcs_bytes = response
+                        .object
+                        .and_then(|obj| obj.bcs)
+                        .and_then(|bcs| bcs.value)
+                        .map(|bytes| bytes.to_vec())
+                        .ok_or_else(|| RpcError::new("No BCS data in response"))?;
+
+                    let obj: Object = bcs::from_bytes(&bcs_bytes)
+                        .map_err(|e| RpcError::new(format!("Failed to deserialize Object: {e}")))?;
+                    let move_object = obj
+                        .as_struct()
+                        .ok_or_else(|| RpcError::new("Object is not a Move struct"))?;
+                    bcs::from_bytes(move_object.contents())
+                        .map_err(|e| RpcError::new(format!("Failed to deserialize contents: {e}")))
+                }
+            },
+        )
+        .await
+    }
+
+    /// Fetches a raw object's BCS bytes via gRPC.
+    pub async fn get_object_raw_bcs(&self, object_id: ObjectID) -> RpcResult<Vec<u8>> {
+        sui_rpc_with_retries(
+            &self.rpc_retry_config,
+            "get_object_raw_bcs",
+            self.metrics.clone(),
+            || {
+                let mut grpc_client = self.sui_grpc_client.clone();
+                async move {
+                    let address = Address::from_bytes(object_id.into_bytes())
+                        .map_err(|e| RpcError::new(format!("Invalid object ID: {e}")))?;
+
+                    let mut request = GetObjectRequest::default();
+                    request.object_id = Some(address.to_string());
+                    request.read_mask = Some(FieldMask {
+                        paths: vec!["bcs".to_string()],
+                    });
+
+                    let response = grpc_client
+                        .ledger_client()
+                        .get_object(request)
+                        .await
+                        .map(|r| r.into_inner())
+                        .map_err(RpcError::from_grpc)?;
+
+                    response
+                        .object
+                        .and_then(|obj| obj.bcs)
+                        .and_then(|bcs| bcs.value)
+                        .map(|bytes| bytes.to_vec())
+                        .ok_or_else(|| RpcError::new("No BCS data in response"))
+                }
+            },
+        )
+        .await
+    }
+
+    /// Returns the current reference gas price via gRPC.
     pub async fn get_reference_gas_price(&self) -> RpcResult<u64> {
         sui_rpc_with_retries(
             &self.rpc_retry_config,
@@ -245,8 +343,8 @@ impl SuiRpcClient {
                 let mut grpc_client = self.sui_grpc_client.clone();
                 async move {
                     let mut client = grpc_client.ledger_client();
-                    let mut request = sui_rpc::proto::sui::rpc::v2::GetEpochRequest::default();
-                    request.read_mask = Some(prost_types::FieldMask {
+                    let mut request = GetEpochRequest::default();
+                    request.read_mask = Some(FieldMask {
                         paths: vec!["reference_gas_price".to_string()],
                     });
                     client
@@ -255,26 +353,6 @@ impl SuiRpcClient {
                         .map(|r| r.into_inner().epoch().reference_gas_price())
                         .map_err(RpcError::from_grpc)
                 }
-            },
-        )
-        .await
-    }
-
-    /// Returns an object with the given dynamic field name.
-    pub async fn get_dynamic_field_object(
-        &self,
-        object_id: ObjectID,
-        dynamic_field_name: DynamicFieldName,
-    ) -> SuiRpcResult<SuiObjectResponse> {
-        sui_rpc_with_retries(
-            &self.rpc_retry_config,
-            "get_dynamic_field_object",
-            self.metrics.clone(),
-            || async {
-                self.sui_client
-                    .read_api()
-                    .get_dynamic_field_object(object_id, dynamic_field_name.clone())
-                    .await
             },
         )
         .await

--- a/crates/key-server/src/sui_rpc_client.rs
+++ b/crates/key-server/src/sui_rpc_client.rs
@@ -6,16 +6,13 @@ use std::sync::Arc;
 use crate::{key_server_options::RetryConfig, metrics::KeyServerMetrics};
 use prost_types::FieldMask;
 use sui_rpc::client::Client as SuiGrpcClient;
-use sui_rpc::proto::sui::rpc::v2::{GetEpochRequest, GetObjectRequest};
-use sui_sdk::{
-    error::SuiRpcResult,
-    rpc_types::{DryRunTransactionBlockResponse, SuiObjectDataOptions, SuiObjectResponse},
-    SuiClient,
-};
-use sui_sdk_types::{Address, Object};
+use sui_rpc::proto::sui::rpc::v2::{GetEpochRequest, GetObjectRequest, GetObjectResponse};
+use sui_sdk::{error::SuiRpcResult, rpc_types::DryRunTransactionBlockResponse, SuiClient};
+use sui_sdk_types::Address;
 use sui_types::base_types::ObjectID;
+use sui_types::move_package::MovePackage;
+use sui_types::object::{Data, Object as SuiObject};
 use sui_types::transaction::TransactionData;
-use tonic::{Code, Status};
 
 /// Trait for determining if an error is retriable
 pub trait RetriableError {
@@ -48,7 +45,7 @@ pub type RpcResult<T> = Result<T, RpcError>;
 pub struct RpcError {
     #[allow(dead_code)]
     message: String,
-    pub(crate) code: Option<Code>,
+    pub(crate) code: Option<tonic::Code>,
 }
 
 impl std::fmt::Display for RpcError {
@@ -65,10 +62,10 @@ impl RetriableError for RpcError {
         self.code.is_some_and(|code| {
             matches!(
                 code,
-                Code::Unavailable
-                    | Code::DeadlineExceeded
-                    | Code::ResourceExhausted
-                    | Code::Aborted
+                tonic::Code::Unavailable
+                    | tonic::Code::DeadlineExceeded
+                    | tonic::Code::ResourceExhausted
+                    | tonic::Code::Aborted
             )
         })
     }
@@ -76,7 +73,7 @@ impl RetriableError for RpcError {
 
 impl RpcError {
     /// Helper to convert gRPC errors to RpcError
-    fn from_grpc(e: Status) -> Self {
+    fn from_grpc(e: tonic::Status) -> Self {
         Self {
             message: format!("gRPC error: {e}"),
             code: Some(e.code()),
@@ -89,6 +86,27 @@ impl RpcError {
             message: message.into(),
             code: None,
         }
+    }
+}
+
+fn extract_object(response: GetObjectResponse) -> RpcResult<SuiObject> {
+    let bcs_bytes = response
+        .object
+        .and_then(|obj| obj.bcs)
+        .and_then(|bcs| bcs.value)
+        .map(|bytes| bytes.to_vec())
+        .ok_or_else(|| RpcError::new("No BCS data in response"))?;
+    bcs::from_bytes(&bcs_bytes)
+        .map_err(|e| RpcError::new(format!("Failed to deserialize Object: {e}")))
+}
+
+fn extract_package(response: GetObjectResponse) -> RpcResult<MovePackage> {
+    match extract_object(response)?.into_inner().data {
+        Data::Package(p) => Ok(p),
+        _ => Err(RpcError {
+            message: "Object is not a package".to_string(),
+            code: Some(tonic::Code::NotFound),
+        }),
     }
 }
 
@@ -227,41 +245,19 @@ impl SuiRpcClient {
         .await
     }
 
-    /// Returns an object with the given options (JSON RPC).
-    #[allow(dead_code)]
-    pub async fn get_object_with_options(
-        &self,
-        object_id: ObjectID,
-        options: SuiObjectDataOptions,
-    ) -> SuiRpcResult<SuiObjectResponse> {
-        sui_rpc_with_retries(
-            &self.rpc_retry_config,
-            "get_object_with_options",
-            self.metrics.clone(),
-            || async {
-                self.sui_client
-                    .read_api()
-                    .get_object_with_options(object_id, options.clone())
-                    .await
-            },
-        )
-        .await
-    }
-
-    /// Fetches an object's BCS data via gRPC and deserializes it as type T.
-    pub async fn get_object_bcs<T: serde::de::DeserializeOwned>(
+    /// Fetches a Move object via gRPC and deserializes its contents as type T.
+    pub async fn get_object<T: serde::de::DeserializeOwned>(
         &self,
         object_id: ObjectID,
     ) -> RpcResult<T> {
         sui_rpc_with_retries(
             &self.rpc_retry_config,
-            "get_object_bcs",
+            "get_object",
             self.metrics.clone(),
             || {
                 let mut grpc_client = self.sui_grpc_client.clone();
                 async move {
-                    let address = Address::from_bytes(object_id.into_bytes())
-                        .map_err(|e| RpcError::new(format!("Invalid object ID: {e}")))?;
+                    let address = Address::new(object_id.into_bytes());
 
                     let mut request = GetObjectRequest::default();
                     request.object_id = Some(address.to_string());
@@ -276,18 +272,11 @@ impl SuiRpcClient {
                         .map(|r| r.into_inner())
                         .map_err(RpcError::from_grpc)?;
 
-                    let bcs_bytes = response
-                        .object
-                        .and_then(|obj| obj.bcs)
-                        .and_then(|bcs| bcs.value)
-                        .map(|bytes| bytes.to_vec())
-                        .ok_or_else(|| RpcError::new("No BCS data in response"))?;
-
-                    let obj: Object = bcs::from_bytes(&bcs_bytes)
-                        .map_err(|e| RpcError::new(format!("Failed to deserialize Object: {e}")))?;
-                    let move_object = obj
-                        .as_struct()
-                        .ok_or_else(|| RpcError::new("Object is not a Move struct"))?;
+                    let obj = extract_object(response)?;
+                    let move_object = match &obj.data {
+                        Data::Move(m) => m,
+                        _ => return Err(RpcError::new("Object is not a Move struct")),
+                    };
                     bcs::from_bytes(move_object.contents())
                         .map_err(|e| RpcError::new(format!("Failed to deserialize contents: {e}")))
                 }
@@ -296,17 +285,16 @@ impl SuiRpcClient {
         .await
     }
 
-    /// Fetches a raw object's BCS bytes via gRPC.
-    pub async fn get_object_raw_bcs(&self, object_id: ObjectID) -> RpcResult<Vec<u8>> {
+    /// Fetches a Move package via gRPC.
+    pub async fn get_package(&self, object_id: ObjectID) -> RpcResult<MovePackage> {
         sui_rpc_with_retries(
             &self.rpc_retry_config,
-            "get_object_raw_bcs",
+            "get_package",
             self.metrics.clone(),
             || {
                 let mut grpc_client = self.sui_grpc_client.clone();
                 async move {
-                    let address = Address::from_bytes(object_id.into_bytes())
-                        .map_err(|e| RpcError::new(format!("Invalid object ID: {e}")))?;
+                    let address = Address::new(object_id.into_bytes());
 
                     let mut request = GetObjectRequest::default();
                     request.object_id = Some(address.to_string());
@@ -321,12 +309,7 @@ impl SuiRpcClient {
                         .map(|r| r.into_inner())
                         .map_err(RpcError::from_grpc)?;
 
-                    response
-                        .object
-                        .and_then(|obj| obj.bcs)
-                        .and_then(|bcs| bcs.value)
-                        .map(|bytes| bytes.to_vec())
-                        .ok_or_else(|| RpcError::new("No BCS data in response"))
+                    extract_package(response)
                 }
             },
         )

--- a/crates/key-server/src/tests/mod.rs
+++ b/crates/key-server/src/tests/mod.rs
@@ -14,9 +14,9 @@ use crypto::ibe::public_key_from_master_key;
 use fastcrypto::ed25519::Ed25519KeyPair;
 use fastcrypto::encoding::Encoding;
 use fastcrypto::serde_helpers::ToFromByteArray;
-use futures::future::join_all;
 use move_package_alt::PackageLoader;
 use rand::thread_rng;
+use seal_committee::grpc_helper::fetch_key_server_by_id;
 use semver::VersionReq;
 use serde_json::json;
 use std::collections::HashMap;
@@ -25,9 +25,10 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use sui_move_build::BuildConfig;
+use sui_rpc::proto::sui::rpc::v2::GetServiceInfoRequest;
 use sui_rpc_api::client::ExecutedTransaction;
 use sui_sdk::json::SuiJsonValue;
-use sui_sdk::rpc_types::{SuiData, SuiObjectDataOptions};
+use sui_sdk_types::Address;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::crypto::get_key_pair_from_rng;
 use sui_types::effects::TransactionEffectsAPI;
@@ -288,13 +289,16 @@ impl SealTestCluster {
     ) -> (ObjectID, ObjectID) {
         // Use ephemeral package loader. This skips Published.toml and uses an ephemeral publication
         // file instead.
-        #[allow(deprecated)]
-        let chain_id = cluster
-            .sui_client()
-            .read_api()
-            .get_chain_identifier()
-            .await
-            .unwrap_or_else(|_| "localnet".to_string());
+        let chain_id = {
+            let mut grpc = cluster.grpc_client().into_inner();
+            let info = grpc
+                .ledger_client()
+                .get_service_info(GetServiceInfoRequest::default())
+                .await
+                .ok()
+                .and_then(|r| r.into_inner().chain_id);
+            info.unwrap_or_else(|| "localnet".to_string())
+        };
 
         let ephemeral_pub_file = PathBuf::from(format!("Published.test.{}.toml", chain_id));
 
@@ -445,63 +449,18 @@ impl SealTestCluster {
 
     /// Get the public keys of the key servers v2 with the given Object IDs.
     pub async fn get_public_keys(&self, object_ids: &[ObjectID]) -> Vec<ibe::PublicKey> {
-        #[allow(deprecated)]
-        let futures = object_ids.iter().map(|id| {
-            self.cluster
-                .sui_client()
-                .read_api()
-                .get_dynamic_fields(*id, None, None)
-        });
-
-        let res = join_all(futures).await;
-
-        // filter df that has type KeyServerV2
-        let object_ids = res
-            .into_iter()
-            .filter_map(|page| {
-                page.ok().and_then(|p| {
-                    p.data
-                        .into_iter()
-                        .find(|df| df.object_type.ends_with("::key_server::KeyServerV2"))
-                        .map(|df| df.object_id)
-                })
-            })
-            .collect::<Vec<_>>();
-        #[allow(deprecated)]
-        let objects = self
-            .cluster
-            .sui_client()
-            .read_api()
-            .multi_get_object_with_options(object_ids, SuiObjectDataOptions::full_content())
-            .await
-            .unwrap();
-        objects
-            .into_iter()
-            .map(|o| {
-                let value = o
-                    .data
-                    .unwrap()
-                    .content
-                    .unwrap()
-                    .try_as_move()
-                    .unwrap()
-                    .fields
-                    .field_value("value")
-                    .unwrap()
-                    .to_json_value();
-                let pk = value
-                    .as_object()
-                    .unwrap()
-                    .get("pk")
-                    .unwrap()
-                    .as_array()
-                    .unwrap();
-                pk.iter()
-                    .map(|v| v.as_u64().unwrap() as u8)
-                    .collect::<Vec<_>>()
-            })
-            .map(|v| ibe::PublicKey::from_byte_array(&v.try_into().unwrap()).unwrap())
-            .collect()
+        let mut pks = Vec::new();
+        for id in object_ids {
+            let mut grpc_client = self.cluster.grpc_client().into_inner();
+            let address = Address::from_bytes(id.into_bytes()).unwrap();
+            let key_server_v2 = fetch_key_server_by_id(&mut grpc_client, &address)
+                .await
+                .unwrap();
+            pks.push(
+                ibe::PublicKey::from_byte_array(&key_server_v2.pk.try_into().unwrap()).unwrap(),
+            );
+        }
+        pks
     }
 }
 

--- a/crates/key-server/src/tests/mod.rs
+++ b/crates/key-server/src/tests/mod.rs
@@ -452,7 +452,7 @@ impl SealTestCluster {
         let mut pks = Vec::new();
         for id in object_ids {
             let mut grpc_client = self.cluster.grpc_client().into_inner();
-            let address = Address::from_bytes(id.into_bytes()).unwrap();
+            let address = Address::new(id.into_bytes());
             let key_server_v2 = fetch_key_server_by_id(&mut grpc_client, &address)
                 .await
                 .unwrap();

--- a/crates/key-server/src/valid_ptb.rs
+++ b/crates/key-server/src/valid_ptb.rs
@@ -5,9 +5,9 @@ use crate::return_err;
 use crate::KeyId;
 use crypto::create_full_id;
 use fastcrypto::encoding::{Base64, Encoding};
-use sui_sdk::types::transaction::{Argument, CallArg, Command, ProgrammableTransaction};
 use sui_types::base_types::ObjectID;
 use sui_types::transaction::ProgrammableMoveCall;
+use sui_types::transaction::{Argument, CallArg, Command, ProgrammableTransaction};
 use tracing::debug;
 
 ///
@@ -171,8 +171,8 @@ impl ValidPtb {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use sui_sdk::types::base_types::SuiAddress;
     use sui_types::base_types::ObjectID;
+    use sui_types::base_types::SuiAddress;
     use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
     use sui_types::Identifier;
 

--- a/crates/seal-committee/src/grpc_helper.rs
+++ b/crates/seal-committee/src/grpc_helper.rs
@@ -13,9 +13,10 @@ use crate::{
 use anyhow::{anyhow, bail, Result};
 use std::str::FromStr;
 use sui_rpc::client::Client;
-use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
-use sui_sdk_types::{Address, Object, StructTag, TypeTag};
+use sui_rpc::proto::sui::rpc::v2::{GetObjectRequest, GetObjectResponse};
+use sui_sdk_types::{Address, StructTag, TypeTag};
 use sui_types::base_types::ObjectID;
+use sui_types::object::{Data, Object};
 
 pub(crate) const EXPECTED_KEY_SERVER_VERSION: u64 = 2;
 
@@ -42,72 +43,38 @@ pub fn create_grpc_client(network: &Network) -> Result<Client> {
     create_grpc_client_with_url(network, None)
 }
 
-/// Fetch an object's BCS data and deserialize as type T.
-async fn fetch_and_deserialize_move_object<T: serde::de::DeserializeOwned>(
+fn extract_object(response: GetObjectResponse) -> Result<Object> {
+    let bcs_bytes = response
+        .object
+        .and_then(|obj| obj.bcs)
+        .and_then(|bcs| bcs.value)
+        .map(|bytes| bytes.to_vec())
+        .ok_or_else(|| anyhow!("No BCS data in response"))?;
+    Ok(bcs::from_bytes(&bcs_bytes)?)
+}
+
+async fn fetch_object<T: serde::de::DeserializeOwned>(
     grpc_client: &mut Client,
     object_id: &Address,
-    error_context: &str,
 ) -> Result<T> {
-    let mut ledger_client = grpc_client.ledger_client();
     let mut request = GetObjectRequest::default();
     request.object_id = Some(object_id.to_string());
     request.read_mask = Some(prost_types::FieldMask {
         paths: vec!["bcs".to_string()],
     });
 
-    let response = ledger_client
+    let response = grpc_client
+        .ledger_client()
         .get_object(request)
         .await
         .map(|r| r.into_inner())?;
 
-    let bcs_bytes = response
-        .object
-        .and_then(|obj| obj.bcs)
-        .and_then(|bcs| bcs.value)
-        .map(|bytes| bytes.to_vec())
-        .ok_or_else(|| anyhow!("No BCS data in {}", error_context))?;
-
-    let obj: Object = bcs::from_bytes(&bcs_bytes)?;
-    let move_object = obj
-        .as_struct()
-        .ok_or_else(|| anyhow!("Object is not a Move struct in {}", error_context))?;
-    bcs::from_bytes(move_object.contents())
-        .map_err(|e| anyhow!("Failed to deserialize {}: {}", error_context, e))
-}
-
-/// Fetch a field wrapper object and deserialize it.
-async fn fetch_field_wrapper<T: serde::de::DeserializeOwned>(
-    grpc_client: &mut Client,
-    field_wrapper_id: &Address,
-) -> Result<T> {
-    let mut ledger_client = grpc_client.ledger_client();
-    let mut fw_request = GetObjectRequest::default();
-    fw_request.object_id = Some(field_wrapper_id.to_string());
-    fw_request.read_mask = Some(prost_types::FieldMask {
-        paths: vec!["bcs".to_string()],
-    });
-
-    let fw_response = ledger_client
-        .get_object(fw_request)
-        .await
-        .map(|r| r.into_inner());
-
-    let fw_bcs = match fw_response {
-        Ok(response) => response
-            .object
-            .and_then(|obj| obj.bcs)
-            .and_then(|bcs| bcs.value)
-            .ok_or_else(|| anyhow!("Field wrapper object not found"))?,
-        Err(e) => return Err(anyhow!("Failed to fetch field wrapper: {}", e)),
+    let obj = extract_object(response)?;
+    let move_object = match &obj.data {
+        Data::Move(m) => m,
+        _ => bail!("Object is not a Move struct"),
     };
-
-    let fw_object: Object = bcs::from_bytes(&fw_bcs)?;
-    let fw_struct = fw_object
-        .as_struct()
-        .ok_or_else(|| anyhow!("Field wrapper is not a Move struct"))?;
-
-    let field_wrapper: T = bcs::from_bytes(fw_struct.contents())?;
-    Ok(field_wrapper)
+    Ok(bcs::from_bytes(move_object.contents())?)
 }
 
 /// Fetch seal Committee object onchain.
@@ -115,7 +82,7 @@ pub async fn fetch_committee_data(
     grpc_client: &mut Client,
     committee_id: &Address,
 ) -> Result<SealCommittee> {
-    fetch_and_deserialize_move_object(grpc_client, committee_id, "Committee object").await
+    fetch_object(grpc_client, committee_id).await
 }
 
 /// Fetch KeyServerV2 data directly from a KeyServer object ID.
@@ -132,13 +99,7 @@ pub async fn fetch_key_server_by_id(
     let key_server_v2_field_id =
         ks_obj_id.derive_dynamic_child_id(&sui_sdk_types::TypeTag::U64, &v2_field_name_bcs);
 
-    // Fetch and deserialize the Field<u64, KeyServerV2> object.
-    let field: Field<u64, KeyServerV2> = fetch_and_deserialize_move_object(
-        grpc_client,
-        &key_server_v2_field_id,
-        "KeyServerV2 Field object",
-    )
-    .await?;
+    let field: Field<u64, KeyServerV2> = fetch_object(grpc_client, &key_server_v2_field_id).await?;
 
     Ok(field.value)
 }
@@ -182,7 +143,7 @@ pub async fn fetch_key_server_by_committee(
         committee_id.derive_dynamic_child_id(&wrapper_type_tag, &wrapper_key_bcs);
 
     let field_wrapper: Field<Wrapper<Address>, Address> =
-        fetch_field_wrapper(grpc_client, &field_wrapper_id).await?;
+        fetch_object(grpc_client, &field_wrapper_id).await?;
     let ks_obj_id = field_wrapper.value;
 
     let key_server_v2 = fetch_key_server_by_id(grpc_client, &ks_obj_id).await?;
@@ -251,7 +212,7 @@ pub async fn fetch_committee_from_key_server(
 
     // Fetch field wrapper to extract committee ID.
     let field: Field<Wrapper<Address>, Address> =
-        fetch_field_wrapper(grpc_client, &field_wrapper_id).await?;
+        fetch_object(grpc_client, &field_wrapper_id).await?;
     let committee_id = field.name.name;
 
     // Fetch committee object to get the correct package ID.
@@ -343,13 +304,11 @@ pub async fn fetch_upgrade_manager(
 
     // Fetch field wrapper.
     let field_wrapper: crate::move_types::FieldWrapper<UpgradeManagerKey, Address> =
-        fetch_field_wrapper(grpc_client, &field_wrapper_id).await?;
+        fetch_object(grpc_client, &field_wrapper_id).await?;
     let upgrade_manager_id = field_wrapper.value;
 
     // Fetch the UpgradeManager object.
-    let upgrade_manager: UpgradeManager =
-        fetch_and_deserialize_move_object(grpc_client, &upgrade_manager_id, "UpgradeManager")
-            .await?;
+    let upgrade_manager: UpgradeManager = fetch_object(grpc_client, &upgrade_manager_id).await?;
 
     Ok(upgrade_manager)
 }

--- a/deny.toml
+++ b/deny.toml
@@ -43,6 +43,12 @@ ignore = [
     "RUSTSEC-2026-0002",
     # bincode is unmaintained
     "RUSTSEC-2025-0141",
+    # RUSTSEC-2026-0097 still fires on rand 0.7.3 (transitively pulled in by
+    # `fail v0.4.0`, a dev-dep of move-vm-runtime from Sui) — no fix on 0.7.x.
+    # Vulnerability requires custom logger + trace logging + ThreadRng reseed,
+    # which doesn't apply to this dev-only path. Other rand versions (0.8/0.9/0.10)
+    # have been updated to fixed releases.
+    { id = "RUSTSEC-2026-0097", reason = "unresolved on rand 0.7.3 (dev-dep only via move-vm-runtime)" },
 ]
 
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score


### PR DESCRIPTION
  Description

  Switch get_object calls from JSON RPC to gRPC.

  Methods:
``` 
- SuiClient::read_api().get_object_with_options() → Client::ledger_client().get_object() + BCS deserialize
- SuiClient::read_api().get_dynamic_field_object() → Address::derive_dynamic_child_id() + Client::ledger_client().get_object()
- SuiClient::read_api().get_chain_identifier() → Client::ledger_client().get_service_info()
- SuiClient::read_api().get_dynamic_fields() + multi_get_object_with_options() → fetch_key_server_by_id() (existing gRPC helper)
 ```
## Test plan 

How did you test the new or updated feature?