### PR TITLE
[aggregator] error handling changes and tests

### DIFF
--- a/crates/key-server/src/aggregator/server.rs
+++ b/crates/key-server/src/aggregator/server.rs
@@ -30,6 +30,8 @@ use key_server::errors::InternalError::{
 use key_server::errors::{ErrorResponse, InternalError};
 use key_server::metrics::{aggregator_metrics_middleware, uptime_metric, AggregatorMetrics};
 use key_server::metrics_push::{create_push_client, push_metrics, MetricsPushConfig};
+#[cfg(test)]
+use key_server::valid_ptb::ValidPtb;
 use mysten_service::metrics::start_basic_prometheus_server;
 use mysten_service::{get_mysten_service, package_name, package_version};
 use prometheus::Registry;
@@ -42,6 +44,8 @@ use std::env;
 use std::sync::Arc;
 use sui_rpc::client::Client as SuiGrpcClient;
 use sui_sdk_types::Address;
+#[cfg(test)]
+use sui_types::base_types::ObjectID;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio::time::{interval, Duration};
@@ -137,9 +141,16 @@ struct AppState {
     aggregator_metrics: Arc<AggregatorMetrics>,
     grpc_client: SuiGrpcClient,
     http_client: reqwest::Client,
-    threshold: Arc<RwLock<u16>>,
-    committee_members: Arc<RwLock<Vec<PartialKeyServer>>>,
+    committee: Arc<RwLock<CommitteeSnapshot>>,
+    #[cfg(test)]
+    first_pkg_id_override: Option<ObjectID>,
     options: AggregatorOptions,
+}
+
+#[derive(Clone)]
+struct CommitteeSnapshot {
+    threshold: u16,
+    members: Vec<PartialKeyServer>,
 }
 
 fn validate_client_sdk_version(
@@ -185,6 +196,16 @@ fn validate_client_sdk_headers<'a>(
     validate_client_sdk_version(version_str, sdk_type, ts_requirement, rust_requirement)?;
 
     Ok((sdk_type, version_str))
+}
+
+async fn expected_full_ids(state: &AppState, ptb: &str) -> Result<HashSet<Vec<u8>>, InternalError> {
+    #[cfg(test)]
+    if let Some(first_pkg_id) = &state.first_pkg_id_override {
+        let valid_ptb = ValidPtb::try_from_base64(ptb)?;
+        return Ok(valid_ptb.full_ids(first_pkg_id).into_iter().collect());
+    }
+
+    get_expected_full_ids(&mut state.grpc_client.clone(), ptb).await
 }
 
 #[tokio::main]
@@ -243,10 +264,11 @@ async fn main() -> Result<()> {
         });
     }
 
+    let committee = state.committee.read().await.clone();
     info!(
         "Loaded committee with {} members, threshold {}",
-        state.committee_members.read().await.len(),
-        *state.threshold.read().await
+        committee.members.len(),
+        committee.threshold
     );
 
     let port: u16 = env::var("PORT")
@@ -337,8 +359,12 @@ async fn handle_fetch_key(
 
     // Parse the PTB and build the set of expected full ids every honest committee member should
     // return.
-    let expected_full_ids_owned =
-        get_expected_full_ids(&mut state.grpc_client.clone(), &request.ptb).await?;
+    let expected_full_ids_owned = expected_full_ids(&state, &request.ptb).await?;
+    if expected_full_ids_owned.is_empty() {
+        let err = InternalError::InvalidPTB("Empty key ids".to_string());
+        state.aggregator_metrics.observe_error(err.as_str());
+        return Err(err.into());
+    }
     let expected_full_ids: HashSet<_> = expected_full_ids_owned
         .iter()
         .map(|id| id.as_slice())
@@ -351,10 +377,9 @@ async fn handle_fetch_key(
     let metrics = state.aggregator_metrics.clone();
     let http_client = state.http_client.clone();
     let expected_full_ids = &expected_full_ids;
-    let mut fetch_tasks: FuturesUnordered<_> = state
-        .committee_members
-        .read()
-        .await
+    let CommitteeSnapshot { threshold, members } = state.committee.read().await.clone();
+    let total_committee_members = members.len();
+    let mut fetch_tasks: FuturesUnordered<_> = members
         .iter()
         .map(|member| {
             let request = request.clone();
@@ -403,9 +428,7 @@ async fn handle_fetch_key(
         })
         .collect();
 
-    // Collect responses until we have threshold, then abort remaining.
-    let threshold = *state.threshold.read().await;
-    let total_committee_members = state.committee_members.read().await.len();
+    // Collect responses until we have threshold or threshold becomes impossible.
     let mut responses = Vec::new();
     let mut errors = Vec::new();
     let mut completed = 0;
@@ -465,10 +488,9 @@ async fn handle_fetch_key(
         })?;
 
     // Log successful aggregation
-    let committee_size = state.committee_members.read().await.len();
     info!(
         "Aggregation successful - req_id: {}, threshold: {}/{}, user: {:?}",
-        req_id, threshold, committee_size, request.certificate.user
+        req_id, threshold, total_committee_members, request.certificate.user
     );
 
     Ok(Json(aggregated_response))
@@ -499,7 +521,6 @@ async fn fetch_from_member(
         .header("Request-Id", req_id)
         .header("Content-Type", "application/json")
         .header(&api_credentials.api_key_name, &api_credentials.api_key);
-
     let response = request_builder
         .body(request.to_json_string().expect("should not fail"))
         .timeout(Duration::from_secs(timeout_secs))
@@ -567,9 +588,11 @@ fn validate_key_server_version(
     ks_version_req: &VersionReq,
 ) -> Result<(), InternalError> {
     let version = version
-        .ok_or(InternalError::MissingRequiredHeader(
-            HEADER_KEYSERVER_VERSION.to_string(),
-        ))
+        .ok_or_else(|| {
+            let msg = format!("Missing key server version header: {HEADER_KEYSERVER_VERSION}");
+            warn!("{}", msg);
+            InternalError::Failure(msg)
+        })
         .and_then(|v| {
             v.to_str().map_err(|_| {
                 let msg = "Invalid key server version header".to_string();
@@ -695,16 +718,18 @@ async fn load_committee_state(
     let key_server_v2 =
         fetch_key_server_by_id(&mut grpc_client, &options.key_server_object_id).await?;
     let (threshold, members) = key_server_v2.extract_committee_info()?;
+    let committee = CommitteeSnapshot { threshold, members };
 
     // Check and warn about missing API credentials for current committee.
-    check_missing_api_credentials(&members, &options.api_credentials);
+    check_missing_api_credentials(&committee.members, &options.api_credentials);
 
     Ok(AppState {
         aggregator_metrics: metrics,
         grpc_client,
         http_client: reqwest::Client::new(),
-        committee_members: Arc::new(RwLock::new(members)),
-        threshold: Arc::new(RwLock::new(threshold)),
+        committee: Arc::new(RwLock::new(committee)),
+        #[cfg(test)]
+        first_pkg_id_override: None,
         options,
     })
 }
@@ -723,14 +748,14 @@ async fn monitor_members_update(mut state: AppState) {
         ticker.tick().await;
 
         // Fetch the current state from onchain.
-        let (threshold, members) = match fetch_key_server_by_id(
+        let committee = match fetch_key_server_by_id(
             &mut state.grpc_client,
             &state.options.key_server_object_id,
         )
         .await
         .and_then(|ks| ks.extract_committee_info())
         {
-            Ok(info) => info,
+            Ok((threshold, members)) => CommitteeSnapshot { threshold, members },
             Err(e) => {
                 warn!(
                     "Committee refresh failed: {} - will retry in {}s",
@@ -741,11 +766,16 @@ async fn monitor_members_update(mut state: AppState) {
         };
 
         // Check for new members' API credentials by comparing with current state.
-        let member_count = members.len();
+        let member_count = committee.members.len();
+        let threshold = committee.threshold;
         let current_names: HashSet<String> = {
             // Read lock and drop after.
-            let current_members = state.committee_members.read().await;
-            current_members.iter().map(|m| m.name.clone()).collect()
+            let current_committee = state.committee.read().await;
+            current_committee
+                .members
+                .iter()
+                .map(|m| m.name.clone())
+                .collect()
         };
 
         info!(
@@ -753,7 +783,7 @@ async fn monitor_members_update(mut state: AppState) {
             member_count,
             current_names.len()
         );
-        for member in &members {
+        for member in &committee.members {
             if !current_names.contains(&member.name)
                 && !state.options.api_credentials.contains_key(&member.name)
             {
@@ -764,9 +794,8 @@ async fn monitor_members_update(mut state: AppState) {
             }
         }
 
-        // Update members and threshold in state.
-        *state.committee_members.write().await = members;
-        *state.threshold.write().await = threshold;
+        // Update members and threshold in one snapshot.
+        *state.committee.write().await = committee;
 
         info!(
             "Committee refreshed: {} members, threshold {}",
@@ -908,8 +937,11 @@ mod tests {
             aggregator_metrics: metrics,
             grpc_client,
             http_client,
-            threshold: Arc::new(RwLock::new(threshold)),
-            committee_members: Arc::new(RwLock::new(committee_contents)),
+            committee: Arc::new(RwLock::new(CommitteeSnapshot {
+                threshold,
+                members: committee_contents,
+            })),
+            first_pkg_id_override: Some(test_valid_ptb().3),
             options,
         }
     }
@@ -1083,6 +1115,39 @@ mod tests {
                     assert_eq!(error.error, "Failure");
                 }
                 Ok(_) => panic!("Expected error for deprecated key server version"),
+            }
+        }
+
+        // Test 2b: Missing key server version is an upstream/internal failure, not a client
+        // MissingRequiredHeader error.
+        {
+            let server_missing_version = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/v1/fetch_key"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .insert_header(HEADER_KEYSERVER_GIT_VERSION, "git-missing-version")
+                        .set_body_json(json!({
+                            "decryption_keys": []
+                        })),
+                )
+                .mount(&server_missing_version)
+                .await;
+
+            let state =
+                create_test_app_state(&[server_missing_version], 1, vec![G2Element::zero()]);
+            let (request, _, _) = create_test_fetch_key_request(&mut thread_rng());
+
+            let mut headers = HeaderMap::new();
+            headers.insert(HEADER_CLIENT_SDK_TYPE, "typescript".parse().unwrap());
+            headers.insert(HEADER_CLIENT_SDK_VERSION, "0.9.6".parse().unwrap());
+            let result = handle_fetch_key(State(state), headers, Json(request)).await;
+
+            match result {
+                Err(error) => {
+                    assert_eq!(error.error, "Failure");
+                }
+                Ok(_) => panic!("Expected error for missing key server version"),
             }
         }
 
@@ -1278,6 +1343,64 @@ mod tests {
         let response =
             result.expect("aggregation should succeed with 2 of 3 good responses at threshold=2");
         assert_eq!(response.decryption_keys.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_key_server_error_not_counted_toward_threshold() {
+        // 2 out of 2 committee: one valid response and one upstream error must fail.
+        let mut rng = thread_rng();
+
+        let master_0 = crypto::ibe::MasterKey::rand(&mut rng);
+        let partial_pk_0 = crypto::ibe::public_key_from_master_key(&master_0);
+        let (request, enc_key, _) = create_test_fetch_key_request(&mut rng);
+        let valid_ptb = ValidPtb::try_from_base64(&request.ptb).unwrap();
+        let (_, _, _, first_pkg_id) = test_valid_ptb();
+        let full_id = valid_ptb.full_ids(&first_pkg_id).remove(0);
+        let encrypted_key = crypto::elgamal::encrypt(
+            &mut rng,
+            &crypto::ibe::extract(&master_0, &full_id),
+            &enc_key,
+        );
+        let good_body = seal_sdk::FetchKeyResponse {
+            decryption_keys: vec![seal_sdk::types::DecryptionKey {
+                id: full_id,
+                encrypted_key,
+            }],
+        };
+
+        let server_good = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/fetch_key"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header(HEADER_KEYSERVER_VERSION, package_version!())
+                    .insert_header(HEADER_KEYSERVER_GIT_VERSION, "git-good")
+                    .set_body_json(serde_json::to_value(&good_body).unwrap()),
+            )
+            .mount(&server_good)
+            .await;
+
+        let server_error = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/v1/fetch_key"))
+            .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+                "error": "NoAccess",
+                "message": "Access denied"
+            })))
+            .mount(&server_error)
+            .await;
+
+        let state = create_test_app_state(
+            &[server_good, server_error],
+            2,
+            vec![partial_pk_0, G2Element::generator()],
+        );
+
+        let mut headers = HeaderMap::new();
+        headers.insert(HEADER_CLIENT_SDK_TYPE, "typescript".parse().unwrap());
+        headers.insert(HEADER_CLIENT_SDK_VERSION, "0.9.6".parse().unwrap());
+        let result = handle_fetch_key(State(state), headers, Json(request)).await;
+        assert_eq!(result.err().unwrap().error, "NoAccess");
     }
 
     #[tokio::test]

--- a/crates/key-server/src/aggregator/server.rs
+++ b/crates/key-server/src/aggregator/server.rs
@@ -1064,12 +1064,8 @@ mod tests {
             headers.insert(HEADER_CLIENT_SDK_VERSION, "0.3.0".parse().unwrap()); // Too old
             let result = handle_fetch_key(State(state), headers, Json(request)).await;
 
-            match result {
-                Err(error) => {
-                    assert_eq!(error.error, "DeprecatedSDKVersion");
-                }
-                Ok(_) => panic!("Expected error for deprecated SDK version"),
-            }
+            let error = result.err().unwrap();
+            assert_eq!(error.error, "DeprecatedSDKVersion");
         }
 
         // Test 2: Aggregator rejects key server response if version is too old
@@ -1096,12 +1092,8 @@ mod tests {
             headers.insert(HEADER_CLIENT_SDK_VERSION, "0.9.6".parse().unwrap());
             let result = handle_fetch_key(State(state), headers, Json(request)).await;
 
-            match result {
-                Err(error) => {
-                    assert_eq!(error.error, "Failure");
-                }
-                Ok(_) => panic!("Expected error for deprecated key server version"),
-            }
+            let error = result.err().unwrap();
+            assert_eq!(error.error, "Failure");
         }
 
         // Test 3: Missing key server version in key server response to aggregator, returns internal failure
@@ -1128,12 +1120,8 @@ mod tests {
             headers.insert(HEADER_CLIENT_SDK_VERSION, "0.9.6".parse().unwrap());
             let result = handle_fetch_key(State(state), headers, Json(request)).await;
 
-            match result {
-                Err(error) => {
-                    assert_eq!(error.error, "Failure");
-                }
-                Ok(_) => panic!("Expected error for missing key server version"),
-            }
+            let error = result.err().unwrap();
+            assert_eq!(error.error, "Failure");
         }
 
         // Test 4: If key server responses are good, return aggregator's own version to client
@@ -1240,18 +1228,10 @@ mod tests {
         headers.insert(HEADER_CLIENT_SDK_TYPE, "typescript".parse().unwrap());
         headers.insert(HEADER_CLIENT_SDK_VERSION, "0.9.6".parse().unwrap());
         let result = handle_fetch_key(State(state), headers, Json(request)).await;
-        match result {
-            Err(error) => {
-                // Either error can be the majority depending on which 3 errors arrive first. Both
-                // are valid.
-                assert!(
-                    error.error == "InvalidPTB" || error.error == "NoAccess",
-                    "Expected InvalidPTB or NoAccess, got: {}",
-                    error.error
-                );
-            }
-            Ok(_) => panic!("Expected error but got success"),
-        }
+        let error = result.err().unwrap();
+        // Either error can be the majority depending on which 3 errors arrive first. Both
+        // are valid.
+        assert!(error.error == "InvalidPTB" || error.error == "NoAccess");
     }
 
     #[tokio::test]

--- a/crates/key-server/src/aggregator/server.rs
+++ b/crates/key-server/src/aggregator/server.rs
@@ -30,8 +30,6 @@ use key_server::errors::InternalError::{
 use key_server::errors::{ErrorResponse, InternalError};
 use key_server::metrics::{aggregator_metrics_middleware, uptime_metric, AggregatorMetrics};
 use key_server::metrics_push::{create_push_client, push_metrics, MetricsPushConfig};
-#[cfg(test)]
-use key_server::valid_ptb::ValidPtb;
 use mysten_service::metrics::start_basic_prometheus_server;
 use mysten_service::{get_mysten_service, package_name, package_version};
 use prometheus::Registry;
@@ -44,8 +42,6 @@ use std::env;
 use std::sync::Arc;
 use sui_rpc::client::Client as SuiGrpcClient;
 use sui_sdk_types::Address;
-#[cfg(test)]
-use sui_types::base_types::ObjectID;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio::time::{interval, Duration};
@@ -142,8 +138,6 @@ struct AppState {
     grpc_client: SuiGrpcClient,
     http_client: reqwest::Client,
     committee: Arc<RwLock<CommitteeSnapshot>>,
-    #[cfg(test)]
-    first_pkg_id_override: Option<ObjectID>,
     options: AggregatorOptions,
 }
 
@@ -196,16 +190,6 @@ fn validate_client_sdk_headers<'a>(
     validate_client_sdk_version(version_str, sdk_type, ts_requirement, rust_requirement)?;
 
     Ok((sdk_type, version_str))
-}
-
-async fn expected_full_ids(state: &AppState, ptb: &str) -> Result<HashSet<Vec<u8>>, InternalError> {
-    #[cfg(test)]
-    if let Some(first_pkg_id) = &state.first_pkg_id_override {
-        let valid_ptb = ValidPtb::try_from_base64(ptb)?;
-        return Ok(valid_ptb.full_ids(first_pkg_id).into_iter().collect());
-    }
-
-    get_expected_full_ids(&mut state.grpc_client.clone(), ptb).await
 }
 
 #[tokio::main]
@@ -359,7 +343,8 @@ async fn handle_fetch_key(
 
     // Parse the PTB and build the set of expected full ids every honest committee member should
     // return.
-    let expected_full_ids_owned = expected_full_ids(&state, &request.ptb).await?;
+    let expected_full_ids_owned =
+        get_expected_full_ids(&mut state.grpc_client.clone(), &request.ptb).await?;
     if expected_full_ids_owned.is_empty() {
         let err = InternalError::InvalidPTB("Empty key ids".to_string());
         state.aggregator_metrics.observe_error(err.as_str());
@@ -378,7 +363,7 @@ async fn handle_fetch_key(
     let http_client = state.http_client.clone();
     let expected_full_ids = &expected_full_ids;
     let CommitteeSnapshot { threshold, members } = state.committee.read().await.clone();
-    let total_committee_members = members.len();
+    let committee_size = members.len();
     let mut fetch_tasks: FuturesUnordered<_> = members
         .iter()
         .map(|member| {
@@ -428,7 +413,7 @@ async fn handle_fetch_key(
         })
         .collect();
 
-    // Collect responses until we have threshold or threshold becomes impossible.
+    // Collect responses until we have threshold, then abort remaining.
     let mut responses = Vec::new();
     let mut errors = Vec::new();
     let mut completed = 0;
@@ -448,7 +433,7 @@ async fn handle_fetch_key(
         }
 
         // Early termination: check if threshold is still achievable
-        let tasks_remaining = total_committee_members - completed;
+        let tasks_remaining = committee_size - completed;
         if responses.len() + tasks_remaining < threshold as usize {
             warn!(
                 "Cannot reach threshold {} with {} responses and {} tasks remaining (req_id: {})",
@@ -490,7 +475,7 @@ async fn handle_fetch_key(
     // Log successful aggregation
     info!(
         "Aggregation successful - req_id: {}, threshold: {}/{}, user: {:?}",
-        req_id, threshold, total_committee_members, request.certificate.user
+        req_id, threshold, committee_size, request.certificate.user
     );
 
     Ok(Json(aggregated_response))
@@ -521,6 +506,7 @@ async fn fetch_from_member(
         .header("Request-Id", req_id)
         .header("Content-Type", "application/json")
         .header(&api_credentials.api_key_name, &api_credentials.api_key);
+
     let response = request_builder
         .body(request.to_json_string().expect("should not fail"))
         .timeout(Duration::from_secs(timeout_secs))
@@ -728,8 +714,6 @@ async fn load_committee_state(
         grpc_client,
         http_client: reqwest::Client::new(),
         committee: Arc::new(RwLock::new(committee)),
-        #[cfg(test)]
-        first_pkg_id_override: None,
         options,
     })
 }
@@ -794,7 +778,7 @@ async fn monitor_members_update(mut state: AppState) {
             }
         }
 
-        // Update members and threshold in one snapshot.
+        // Update members and threshold in state.
         *state.committee.write().await = committee;
 
         info!(
@@ -813,6 +797,7 @@ mod tests {
     use fastcrypto::groups::bls12381::G1Element;
     use fastcrypto::groups::{bls12381::G2Element, GroupElement, Scalar};
     use fastcrypto::traits::{KeyPair, Signer, ToFromBytes};
+    use key_server::common::PACKAGE_ID_CACHE;
     use key_server::valid_ptb::ValidPtb;
     use rand::thread_rng;
     use seal_sdk::types::Certificate;
@@ -932,6 +917,8 @@ mod tests {
         let metrics = Arc::new(AggregatorMetrics::new(&registry));
         let grpc_client = SuiGrpcClient::new(options.node_url()).unwrap();
         let http_client = reqwest::Client::new();
+        let (_, pkg_id, _, first_pkg_id) = test_valid_ptb();
+        PACKAGE_ID_CACHE.insert(pkg_id, first_pkg_id);
 
         AppState {
             aggregator_metrics: metrics,
@@ -941,7 +928,6 @@ mod tests {
                 threshold,
                 members: committee_contents,
             })),
-            first_pkg_id_override: Some(test_valid_ptb().3),
             options,
         }
     }
@@ -1118,8 +1104,7 @@ mod tests {
             }
         }
 
-        // Test 2b: Missing key server version is an upstream/internal failure, not a client
-        // MissingRequiredHeader error.
+        // Test 3: Missing key server version in key server response to aggregator, returns internal failure
         {
             let server_missing_version = MockServer::start().await;
             Mock::given(method("POST"))
@@ -1134,8 +1119,8 @@ mod tests {
                 .mount(&server_missing_version)
                 .await;
 
-            let state =
-                create_test_app_state(&[server_missing_version], 1, vec![G2Element::zero()]);
+            let servers = vec![server_missing_version];
+            let state = create_test_app_state(&servers, 1, vec![G2Element::zero()]);
             let (request, _, _) = create_test_fetch_key_request(&mut thread_rng());
 
             let mut headers = HeaderMap::new();
@@ -1151,7 +1136,7 @@ mod tests {
             }
         }
 
-        // Test 3: If key server responses are good, return aggregator's own version to client
+        // Test 4: If key server responses are good, return aggregator's own version to client
         {
             let mut rng = thread_rng();
 
@@ -1389,12 +1374,10 @@ mod tests {
             })))
             .mount(&server_error)
             .await;
+        let mock_servers = vec![server_good, server_error];
 
-        let state = create_test_app_state(
-            &[server_good, server_error],
-            2,
-            vec![partial_pk_0, G2Element::generator()],
-        );
+        let state =
+            create_test_app_state(&mock_servers, 2, vec![partial_pk_0, G2Element::generator()]);
 
         let mut headers = HeaderMap::new();
         headers.insert(HEADER_CLIENT_SDK_TYPE, "typescript".parse().unwrap());

--- a/crates/key-server/src/aggregator/utils.rs
+++ b/crates/key-server/src/aggregator/utils.rs
@@ -1,8 +1,8 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::errors::InternalError;
 use crate::valid_ptb::ValidPtb;
+use crate::{common::fetch_first_pkg_id, errors::InternalError};
 use crypto::{elgamal, ibe::verify_encrypted_signature};
 use fastcrypto::{
     encoding::{Encoding, Hex},
@@ -23,16 +23,7 @@ pub async fn get_expected_full_ids(
     ptb_b64: &str,
 ) -> Result<HashSet<Vec<u8>>, InternalError> {
     let valid_ptb = ValidPtb::try_from_base64(ptb_b64)?;
-    let first_pkg_id = crate::common::fetch_first_pkg_id(grpc_client, &valid_ptb.pkg_id())
-        .await
-        .map_err(|error| {
-            if error.downcast_ref::<tonic::Status>().is_some() {
-                // tonic::Status means a fullnode/gRPC failure
-                InternalError::Failure(format!("Failed to resolve package id: {error}"))
-            } else {
-                InternalError::InvalidPackage
-            }
-        })?;
+    let first_pkg_id = fetch_first_pkg_id(grpc_client, &valid_ptb.pkg_id()).await?;
     Ok(valid_ptb.full_ids(&first_pkg_id).into_iter().collect())
 }
 

--- a/crates/key-server/src/aggregator/utils.rs
+++ b/crates/key-server/src/aggregator/utils.rs
@@ -9,14 +9,12 @@ use fastcrypto::{
     error::{FastCryptoError, FastCryptoResult},
     groups::bls12381::G2Element,
 };
-use seal_committee::fetch_first_pkg_id;
 use seal_sdk::{
     types::{DecryptionKey, ElgamalEncryption, ElgamalVerificationKey},
     FetchKeyResponse,
 };
 use std::collections::{HashMap, HashSet};
 use sui_rpc::client::Client as SuiGrpcClient;
-use sui_sdk_types::Address;
 use tracing::info;
 
 /// Parse PTB, resolve its pkg id to the first pkg id via grpc, and return the set of full key ids.
@@ -25,20 +23,17 @@ pub async fn get_expected_full_ids(
     ptb_b64: &str,
 ) -> Result<HashSet<Vec<u8>>, InternalError> {
     let valid_ptb = ValidPtb::try_from_base64(ptb_b64)?;
-    let first_pkg_id =
-        fetch_first_pkg_id(grpc_client, &Address::new(valid_ptb.pkg_id().into_bytes()))
-            .await
-            .map_err(classify_package_resolution_error)?;
+    let first_pkg_id = crate::common::fetch_first_pkg_id(grpc_client, &valid_ptb.pkg_id())
+        .await
+        .map_err(|error| {
+            if error.downcast_ref::<tonic::Status>().is_some() {
+                // tonic::Status means a fullnode/gRPC failure
+                InternalError::Failure(format!("Failed to resolve package id: {error}"))
+            } else {
+                InternalError::InvalidPackage
+            }
+        })?;
     Ok(valid_ptb.full_ids(&first_pkg_id).into_iter().collect())
-}
-
-fn classify_package_resolution_error(error: anyhow::Error) -> InternalError {
-    if error.downcast_ref::<tonic::Status>().is_some() {
-        // tonic::Status indicates a fullnode/gRPC failure, not an invalid package id.
-        InternalError::Failure(format!("Failed to resolve package id: {error}"))
-    } else {
-        InternalError::InvalidPackage
-    }
 }
 
 /// Aggregate verified encrypted responses into a single response. Each response is expected to have

--- a/crates/key-server/src/aggregator/utils.rs
+++ b/crates/key-server/src/aggregator/utils.rs
@@ -28,8 +28,17 @@ pub async fn get_expected_full_ids(
     let first_pkg_id =
         fetch_first_pkg_id(grpc_client, &Address::new(valid_ptb.pkg_id().into_bytes()))
             .await
-            .map_err(|_| InternalError::InvalidPackage)?;
+            .map_err(classify_package_resolution_error)?;
     Ok(valid_ptb.full_ids(&first_pkg_id).into_iter().collect())
+}
+
+fn classify_package_resolution_error(error: anyhow::Error) -> InternalError {
+    if error.downcast_ref::<tonic::Status>().is_some() {
+        // tonic::Status indicates a fullnode/gRPC failure, not an invalid package id.
+        InternalError::Failure(format!("Failed to resolve package id: {error}"))
+    } else {
+        InternalError::InvalidPackage
+    }
 }
 
 /// Aggregate verified encrypted responses into a single response. Each response is expected to have
@@ -172,6 +181,27 @@ mod tests {
     }
 
     #[test]
+    fn aggregate_errors_when_party_ids_are_duplicate() {
+        let responses = vec![
+            (
+                0u16,
+                FetchKeyResponse {
+                    decryption_keys: vec![dk_for_testing(b"a")],
+                },
+            ),
+            (
+                0u16,
+                FetchKeyResponse {
+                    decryption_keys: vec![dk_for_testing(b"a")],
+                },
+            ),
+        ];
+
+        let result = aggregate_verified_encrypted_responses(2, responses);
+        assert!(matches!(result, Err(FastCryptoError::InvalidInput)));
+    }
+
+    #[test]
     fn verify_rejects_too_few_keys() {
         let (partial_pk, eg_vk) = partial_pk_and_eph_vk_for_testing();
         let expected_owned: HashSet<_> = [full_id_for_testing(b"a"), full_id_for_testing(b"b")]
@@ -225,6 +255,17 @@ mod tests {
             .collect();
         let expected: HashSet<_> = expected_owned.iter().map(|id| id.as_slice()).collect();
         let keys = vec![dk_for_testing(b"a"), dk_for_testing(b"a")];
+        let result = verify_decryption_keys(&keys, &partial_pk, &eg_vk, 0, &expected);
+        assert!(matches!(result, Err(InternalError::Failure(_))));
+    }
+
+    #[test]
+    fn verify_rejects_invalid_encrypted_signature() {
+        let (partial_pk, eg_vk) = partial_pk_and_eph_vk_for_testing();
+        let expected_owned: HashSet<_> = [full_id_for_testing(b"a")].into_iter().collect();
+        let expected: HashSet<_> = expected_owned.iter().map(|id| id.as_slice()).collect();
+        let keys = vec![dk_for_testing(b"a")];
+
         let result = verify_decryption_keys(&keys, &partial_pk, &eg_vk, 0, &expected);
         assert!(matches!(result, Err(InternalError::Failure(_))));
     }

--- a/crates/key-server/src/common.rs
+++ b/crates/key-server/src/common.rs
@@ -1,12 +1,22 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{anyhow, bail, Result};
 use axum::http::HeaderValue;
 use axum::response::Response;
+use moka::sync::Cache;
+use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
+use sui_rpc::client::Client as SuiGrpcClient;
+use sui_rpc::proto::sui::rpc::v2::{GetObjectRequest, GetObjectResponse};
+use sui_sdk_types::Address;
 use sui_types::base_types::ObjectID;
+use sui_types::object::{Data, Object};
 
+use crate::cache::default_lru_cache;
 use crate::errors::InternalError;
+
+pub static PACKAGE_ID_CACHE: Lazy<Cache<ObjectID, ObjectID>> = Lazy::new(default_lru_cache);
 
 /// Network configuration.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -30,6 +40,48 @@ impl Network {
             Network::Mainnet => "https://fullnode.mainnet.sui.io:443",
             #[cfg(test)]
             Network::TestCluster { .. } => panic!(), // Currently not used, but can be found from cluster.rpc_url() if needed
+        }
+    }
+}
+
+fn extract_object(response: GetObjectResponse) -> Result<Object> {
+    let bcs_bytes = response
+        .object
+        .and_then(|obj| obj.bcs)
+        .and_then(|bcs| bcs.value)
+        .map(|bytes| bytes.to_vec())
+        .ok_or_else(|| anyhow!("No BCS data in response"))?;
+    Ok(bcs::from_bytes(&bcs_bytes)?)
+}
+
+/// Fetch the first package id for `pkg_id`, using the shared package id cache.
+pub async fn fetch_first_pkg_id(
+    grpc_client: &mut SuiGrpcClient,
+    pkg_id: &ObjectID,
+) -> Result<ObjectID> {
+    match PACKAGE_ID_CACHE.get(pkg_id) {
+        Some(first) => Ok(first),
+        None => {
+            let mut request = GetObjectRequest::default();
+            request.object_id = Some(Address::new(pkg_id.into_bytes()).to_string());
+            request.read_mask = Some(prost_types::FieldMask {
+                paths: vec!["bcs".to_string()],
+            });
+
+            let response = grpc_client
+                .ledger_client()
+                .get_object(request)
+                .await
+                .map(|r| r.into_inner())?;
+
+            let obj = extract_object(response)?;
+            let first = match &obj.data {
+                Data::Package(p) => p.original_package_id(),
+                _ => bail!("Object is not a package"),
+            };
+
+            PACKAGE_ID_CACHE.insert(*pkg_id, first);
+            Ok(first)
         }
     }
 }

--- a/crates/key-server/src/common.rs
+++ b/crates/key-server/src/common.rs
@@ -1,17 +1,18 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::Result;
 use axum::http::HeaderValue;
 use axum::response::Response;
 use moka::sync::Cache;
 use once_cell::sync::Lazy;
+use seal_committee::grpc_helper::extract_object;
 use serde::{Deserialize, Serialize};
 use sui_rpc::client::Client as SuiGrpcClient;
-use sui_rpc::proto::sui::rpc::v2::{GetObjectRequest, GetObjectResponse};
+use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
 use sui_sdk_types::Address;
 use sui_types::base_types::ObjectID;
-use sui_types::object::{Data, Object};
+use sui_types::object::Data;
 
 use crate::cache::default_lru_cache;
 use crate::errors::InternalError;
@@ -44,46 +45,41 @@ impl Network {
     }
 }
 
-fn extract_object(response: GetObjectResponse) -> Result<Object> {
-    let bcs_bytes = response
-        .object
-        .and_then(|obj| obj.bcs)
-        .and_then(|bcs| bcs.value)
-        .map(|bytes| bytes.to_vec())
-        .ok_or_else(|| anyhow!("No BCS data in response"))?;
-    Ok(bcs::from_bytes(&bcs_bytes)?)
-}
-
 /// Fetch the first package id for `pkg_id`, using the shared package id cache.
+/// Returns `InternalError::Failure` for grpc errors and `InternalError::InvalidPackage`
+/// when the package cannot resolve.
 pub async fn fetch_first_pkg_id(
     grpc_client: &mut SuiGrpcClient,
     pkg_id: &ObjectID,
-) -> Result<ObjectID> {
-    match PACKAGE_ID_CACHE.get(pkg_id) {
-        Some(first) => Ok(first),
-        None => {
-            let mut request = GetObjectRequest::default();
-            request.object_id = Some(Address::new(pkg_id.into_bytes()).to_string());
-            request.read_mask = Some(prost_types::FieldMask {
-                paths: vec!["bcs".to_string()],
-            });
-
-            let response = grpc_client
-                .ledger_client()
-                .get_object(request)
-                .await
-                .map(|r| r.into_inner())?;
-
-            let obj = extract_object(response)?;
-            let first = match &obj.data {
-                Data::Package(p) => p.original_package_id(),
-                _ => bail!("Object is not a package"),
-            };
-
-            PACKAGE_ID_CACHE.insert(*pkg_id, first);
-            Ok(first)
-        }
+) -> Result<ObjectID, InternalError> {
+    if let Some(first) = PACKAGE_ID_CACHE.get(pkg_id) {
+        return Ok(first);
     }
+
+    let mut request = GetObjectRequest::default();
+    request.object_id = Some(Address::new(pkg_id.into_bytes()).to_string());
+    request.read_mask = Some(prost_types::FieldMask {
+        paths: vec!["bcs".to_string()],
+    });
+
+    let response = grpc_client
+        .ledger_client()
+        .get_object(request)
+        .await
+        .map_err(|e| match e.code() {
+            tonic::Code::NotFound => InternalError::InvalidPackage,
+            _ => InternalError::Failure(format!("Failed to resolve package id: {e}")),
+        })?
+        .into_inner();
+
+    let obj = extract_object(response).map_err(|_| InternalError::InvalidPackage)?;
+    let first = match &obj.data {
+        Data::Package(p) => p.original_package_id(),
+        _ => return Err(InternalError::InvalidPackage),
+    };
+
+    PACKAGE_ID_CACHE.insert(*pkg_id, first);
+    Ok(first)
 }
 
 /// HTTP header name for client SDK version.

--- a/crates/key-server/src/externals.rs
+++ b/crates/key-server/src/externals.rs
@@ -9,23 +9,11 @@ use crate::sui_rpc_client::RpcResult;
 use crate::sui_rpc_client::SuiRpcClient;
 use moka::sync::Cache;
 use once_cell::sync::Lazy;
-use sui_sdk_types::Address;
 use sui_types::base_types::ObjectID;
 use tap::TapFallible;
 use tracing::{debug, warn};
 
-static CACHE: Lazy<Cache<ObjectID, ObjectID>> = Lazy::new(default_lru_cache);
 static MVR_CACHE: Lazy<Cache<String, ObjectID>> = Lazy::new(default_lru_cache);
-
-#[cfg(test)]
-pub(crate) fn add_package(pkg_id: ObjectID) {
-    CACHE.insert(pkg_id, pkg_id);
-}
-
-#[cfg(test)]
-pub(crate) fn add_upgraded_package(pkg_id: ObjectID, new_pkg_id: ObjectID) {
-    CACHE.insert(new_pkg_id, pkg_id);
-}
 
 pub(crate) async fn check_mvr_package_id(
     mvr_name: &Option<String>,
@@ -63,24 +51,6 @@ pub(crate) async fn check_mvr_package_id(
     Ok(())
 }
 
-pub(crate) async fn fetch_first_pkg_id(
-    pkg_id: &ObjectID,
-    sui_rpc_client: &SuiRpcClient,
-) -> Result<ObjectID, InternalError> {
-    match CACHE.get(pkg_id) {
-        Some(first) => Ok(first),
-        None => {
-            let mut grpc = sui_rpc_client.sui_grpc_client();
-            let first =
-                seal_committee::fetch_first_pkg_id(&mut grpc, &Address::new(pkg_id.into_bytes()))
-                    .await
-                    .map_err(|_| InternalError::InvalidPackage)?;
-            CACHE.insert(*pkg_id, first);
-            Ok(first)
-        }
-    }
-}
-
 pub(crate) fn insert_mvr_cache(mvr_name: &str, package_id: ObjectID) {
     MVR_CACHE.insert(mvr_name.to_string(), package_id);
 }
@@ -97,7 +67,7 @@ pub(crate) async fn get_reference_gas_price(sui_rpc_client: SuiRpcClient) -> Rpc
 
 #[cfg(test)]
 mod tests {
-    use crate::externals::fetch_first_pkg_id;
+    use crate::common::fetch_first_pkg_id;
     use crate::key_server_options::RetryConfig;
     use crate::sui_rpc_client::SuiRpcClient;
     use crate::types::Network;
@@ -131,7 +101,8 @@ mod tests {
             RetryConfig::default(),
             None,
         );
-        match fetch_first_pkg_id(&address, &sui_rpc_client).await {
+        let mut grpc_client = sui_rpc_client.sui_grpc_client();
+        match fetch_first_pkg_id(&mut grpc_client, &address).await {
             Ok(first) => {
                 assert_eq!(
                     first.to_hex_literal(),
@@ -159,7 +130,10 @@ mod tests {
             RetryConfig::default(),
             None,
         );
-        let result = fetch_first_pkg_id(&invalid_address, &sui_rpc_client).await;
+        let mut grpc_client = sui_rpc_client.sui_grpc_client();
+        let result = fetch_first_pkg_id(&mut grpc_client, &invalid_address)
+            .await
+            .map_err(|_| InternalError::InvalidPackage);
         assert!(matches!(result, Err(InternalError::InvalidPackage)));
     }
 

--- a/crates/key-server/src/externals.rs
+++ b/crates/key-server/src/externals.rs
@@ -15,6 +15,16 @@ use tracing::{debug, warn};
 
 static MVR_CACHE: Lazy<Cache<String, ObjectID>> = Lazy::new(default_lru_cache);
 
+#[cfg(test)]
+pub(crate) fn add_package(pkg_id: ObjectID) {
+    crate::common::PACKAGE_ID_CACHE.insert(pkg_id, pkg_id);
+}
+
+#[cfg(test)]
+pub(crate) fn add_upgraded_package(pkg_id: ObjectID, new_pkg_id: ObjectID) {
+    crate::common::PACKAGE_ID_CACHE.insert(new_pkg_id, pkg_id);
+}
+
 pub(crate) async fn check_mvr_package_id(
     mvr_name: &Option<String>,
     sui_rpc_client: &SuiRpcClient,
@@ -131,9 +141,7 @@ mod tests {
             None,
         );
         let mut grpc_client = sui_rpc_client.sui_grpc_client();
-        let result = fetch_first_pkg_id(&mut grpc_client, &invalid_address)
-            .await
-            .map_err(|_| InternalError::InvalidPackage);
+        let result = fetch_first_pkg_id(&mut grpc_client, &invalid_address).await;
         assert!(matches!(result, Err(InternalError::InvalidPackage)));
     }
 

--- a/crates/key-server/src/lib.rs
+++ b/crates/key-server/src/lib.rs
@@ -4,6 +4,7 @@
 //! Shared modules for key-server and aggregator server binaries.
 
 pub mod aggregator;
+pub(crate) mod cache;
 pub mod common;
 pub mod errors;
 pub mod metrics;

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -531,7 +531,10 @@ impl Server {
         // Handle package upgrades: Use the first as the namespace
         let first_pkg_id =
             call_with_duration(metrics.map(|m| &m.fetch_pkg_ids_duration), || async {
-                externals::fetch_first_pkg_id(&valid_ptb.pkg_id(), &self.sui_rpc_client).await
+                let mut grpc = self.sui_rpc_client.sui_grpc_client();
+                common::fetch_first_pkg_id(&mut grpc, &valid_ptb.pkg_id())
+                    .await
+                    .map_err(|_| InternalError::InvalidPackage)
             })
             .await?;
 

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -532,9 +532,7 @@ impl Server {
         let first_pkg_id =
             call_with_duration(metrics.map(|m| &m.fetch_pkg_ids_duration), || async {
                 let mut grpc = self.sui_rpc_client.sui_grpc_client();
-                common::fetch_first_pkg_id(&mut grpc, &valid_ptb.pkg_id())
-                    .await
-                    .map_err(|_| InternalError::InvalidPackage)
+                common::fetch_first_pkg_id(&mut grpc, &valid_ptb.pkg_id()).await
             })
             .await?;
 

--- a/crates/key-server/src/sui_rpc_client.rs
+++ b/crates/key-server/src/sui_rpc_client.rs
@@ -5,15 +5,16 @@ use std::sync::Arc;
 
 use crate::{key_server_options::RetryConfig, metrics::KeyServerMetrics};
 use prost_types::FieldMask;
+use seal_committee::grpc_helper::extract_object;
 use sui_rpc::client::Client as SuiGrpcClient;
 use sui_rpc::proto::sui::rpc::v2::{
-    Bcs, GetEpochRequest, GetObjectRequest, GetObjectResponse, SimulateTransactionRequest,
+    Bcs, GetEpochRequest, GetObjectRequest, SimulateTransactionRequest,
     SimulateTransactionResponse, Transaction,
 };
 use sui_sdk::SuiClient;
 use sui_sdk_types::Address;
 use sui_types::base_types::ObjectID;
-use sui_types::object::{Data, Object as SuiObject};
+use sui_types::object::Data;
 use sui_types::transaction::TransactionData;
 
 /// Trait for determining if an error is retriable
@@ -92,17 +93,6 @@ impl RpcError {
             code: None,
         }
     }
-}
-
-fn extract_object(response: GetObjectResponse) -> RpcResult<SuiObject> {
-    let bcs_bytes = response
-        .object
-        .and_then(|obj| obj.bcs)
-        .and_then(|bcs| bcs.value)
-        .map(|bytes| bytes.to_vec())
-        .ok_or_else(|| RpcError::new("No BCS data in response"))?;
-    bcs::from_bytes(&bcs_bytes)
-        .map_err(|e| RpcError::new(format!("Failed to deserialize Object: {e}")))
 }
 
 /// Executes an async function with automatic retries for retriable errors
@@ -290,7 +280,7 @@ impl SuiRpcClient {
                         .map(|r| r.into_inner())
                         .map_err(RpcError::from_grpc)?;
 
-                    let obj = extract_object(response)?;
+                    let obj = extract_object(response).map_err(|e| RpcError::new(e.to_string()))?;
                     let move_object = match &obj.data {
                         Data::Move(m) => m,
                         _ => return Err(RpcError::new("Object is not a Move struct")),

--- a/crates/key-server/src/tests/e2e.rs
+++ b/crates/key-server/src/tests/e2e.rs
@@ -38,7 +38,9 @@ use std::sync::Arc;
 use sui_sdk_types::Address as NewObjectID;
 use sui_types::base_types::ObjectID;
 use sui_types::crypto::get_key_pair_from_rng;
-use sui_types::transaction::ProgrammableTransaction;
+use sui_types::programmable_transaction_builder::ProgrammableTransactionBuilder;
+use sui_types::transaction::{ObjectArg, ProgrammableTransaction, SharedObjectMutability};
+use sui_types::Identifier;
 use test_cluster::TestClusterBuilder;
 use tracing_test::traced_test;
 
@@ -832,6 +834,32 @@ async fn test_e2e_committee_mode_with_rotation() {
     .await
     .expect("Aggregation should succeed");
 
+    let second_inner_id = [whitelist.to_vec(), b"second-key".to_vec()].concat();
+    let multi_key_ptb = whitelist_create_multi_key_ptb(
+        package_id,
+        whitelist,
+        initial_shared_version,
+        vec![whitelist.to_vec(), second_inner_id.clone()],
+    );
+    let multi_key_usks = get_aggregated_key_from_committee(
+        &committee,
+        &selected_party_ids,
+        2,
+        &package_id,
+        multi_key_ptb,
+        &user_keypair,
+    )
+    .await
+    .expect("Multi-key aggregation should succeed");
+    assert!(multi_key_usks.contains_key(&create_full_id(
+        &package_id.into_bytes(),
+        &whitelist.to_vec()
+    )));
+    assert!(
+        multi_key_usks.contains_key(&create_full_id(&package_id.into_bytes(), &second_inner_id))
+    );
+    assert_eq!(multi_key_usks.len(), 2);
+
     // Compute the full_id for this encrypted object to look up the correct key.
     let full_id = create_full_id(&package_id.into_bytes(), &encryption.id);
     let aggregated_usk = aggregated_usks
@@ -932,6 +960,38 @@ async fn test_e2e_committee_mode_with_rotation() {
     )
     .unwrap();
     assert_eq!(new_decryption, message);
+}
+
+fn whitelist_create_multi_key_ptb(
+    package_id: ObjectID,
+    whitelist_id: ObjectID,
+    initial_shared_version: u64,
+    inner_ids: Vec<Vec<u8>>,
+) -> ProgrammableTransaction {
+    let mut builder = ProgrammableTransactionBuilder::new();
+    let ids = inner_ids
+        .into_iter()
+        .map(|inner_id| builder.pure(inner_id).unwrap())
+        .collect::<Vec<_>>();
+    let list = builder
+        .obj(ObjectArg::SharedObject {
+            id: whitelist_id,
+            initial_shared_version: initial_shared_version.into(),
+            mutability: SharedObjectMutability::Immutable,
+        })
+        .unwrap();
+
+    for id in ids {
+        builder.programmable_move_call(
+            package_id,
+            Identifier::new("whitelist").unwrap(),
+            Identifier::new("seal_approve").unwrap(),
+            vec![],
+            vec![id, list],
+        );
+    }
+
+    builder.finish()
 }
 
 /// Simulate a client with generated ephemeral ElGamal key pair and user keypair requesting

--- a/crates/key-server/src/tests/mod.rs
+++ b/crates/key-server/src/tests/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::common::PACKAGE_ID_CACHE;
+use crate::externals::{add_package, add_upgraded_package};
 use crate::key_server_options::{KeyServerOptions, RetryConfig, RpcConfig, ServerMode};
 use crate::master_keys::MasterKeys;
 use crate::sui_rpc_client::SuiRpcClient;
@@ -366,6 +366,8 @@ impl SealTestCluster {
             .expect("UpgradeCap should be created")
             .0;
 
+        add_package(package_id);
+
         (package_id, upgrade_cap)
     }
 
@@ -403,7 +405,8 @@ impl SealTestCluster {
             .expect("Upgraded package should be published")
             .0;
 
-        PACKAGE_ID_CACHE.insert(new_package_id, package_id);
+        // Add new package id to internal registry
+        add_upgraded_package(package_id, new_package_id);
 
         new_package_id
     }

--- a/crates/key-server/src/tests/mod.rs
+++ b/crates/key-server/src/tests/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::externals::{add_package, add_upgraded_package};
+use crate::common::PACKAGE_ID_CACHE;
 use crate::key_server_options::{KeyServerOptions, RetryConfig, RpcConfig, ServerMode};
 use crate::master_keys::MasterKeys;
 use crate::sui_rpc_client::SuiRpcClient;
@@ -366,8 +366,6 @@ impl SealTestCluster {
             .expect("UpgradeCap should be created")
             .0;
 
-        add_package(package_id);
-
         (package_id, upgrade_cap)
     }
 
@@ -405,8 +403,7 @@ impl SealTestCluster {
             .expect("Upgraded package should be published")
             .0;
 
-        // Add new package id to internal registry
-        add_upgraded_package(package_id, new_package_id);
+        PACKAGE_ID_CACHE.insert(new_package_id, package_id);
 
         new_package_id
     }

--- a/crates/seal-committee/src/grpc_helper.rs
+++ b/crates/seal-committee/src/grpc_helper.rs
@@ -77,27 +77,6 @@ async fn fetch_object<T: serde::de::DeserializeOwned>(
     Ok(bcs::from_bytes(move_object.contents())?)
 }
 
-/// Fetch the first package id for `pkg_id` via grpc.
-pub async fn fetch_first_pkg_id(grpc_client: &mut Client, pkg_id: &Address) -> Result<ObjectID> {
-    let mut request = GetObjectRequest::default();
-    request.object_id = Some(pkg_id.to_string());
-    request.read_mask = Some(prost_types::FieldMask {
-        paths: vec!["bcs".to_string()],
-    });
-
-    let response = grpc_client
-        .ledger_client()
-        .get_object(request)
-        .await
-        .map(|r| r.into_inner())?;
-
-    let obj = extract_object(response)?;
-    match &obj.data {
-        Data::Package(p) => Ok(p.original_package_id()),
-        _ => bail!("Object is not a package"),
-    }
-}
-
 /// Fetch seal Committee object onchain.
 pub async fn fetch_committee_data(
     grpc_client: &mut Client,

--- a/crates/seal-committee/src/grpc_helper.rs
+++ b/crates/seal-committee/src/grpc_helper.rs
@@ -43,7 +43,7 @@ pub fn create_grpc_client(network: &Network) -> Result<Client> {
     create_grpc_client_with_url(network, None)
 }
 
-fn extract_object(response: GetObjectResponse) -> Result<Object> {
+pub fn extract_object(response: GetObjectResponse) -> Result<Object> {
     let bcs_bytes = response
         .object
         .and_then(|obj| obj.bcs)

--- a/crates/seal-committee/src/lib.rs
+++ b/crates/seal-committee/src/lib.rs
@@ -8,9 +8,8 @@ pub mod utils;
 
 pub use grpc_helper::{
     create_grpc_client, create_grpc_client_with_url, fetch_committee_data,
-    fetch_committee_from_key_server, fetch_first_pkg_id, fetch_key_server_by_committee,
-    fetch_key_server_by_id, fetch_upgrade_manager, fetch_upgrade_proposal,
-    get_committee_rotation_info,
+    fetch_committee_from_key_server, fetch_key_server_by_committee, fetch_key_server_by_id,
+    fetch_upgrade_manager, fetch_upgrade_proposal, get_committee_rotation_info,
 };
 pub use move_types::{
     CommitteeState, FieldWrapper, KeyServerV2, MemberInfo, PackageDigest, ParsedMemberInfo,


### PR DESCRIPTION
## Description 
- Only verified successful key-server responses count toward threshold. Previously, a successful HTTP response could count before key IDs/signatures were fully validated.

- Uses a single committee snapshot so threshold and members update atomically.

- Adds validation for empty key IDs and missing/invalid upstream key-server version headers.

- Moves first-package-id lookup/cache into key-server::common so the aggregator can use it too.

- Adds tests for threshold counting, invalid responses, version validation, and multi-key aggregation.

## Test plan 

How did you test the new or updated feature?