### PR TITLE
docs: fix Plausible AI agent tracking

### DIFF
--- a/docs/site/middleware.js
+++ b/docs/site/middleware.js
@@ -1,0 +1,48 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+const AI_AGENT_PATTERN = /claude[-_]?code|anthropic|cursor|copilot|chatgpt|openai|gptbot|perplexity|cohere|codeium|windsurf|tabnine|sourcegraph|cody/i;
+
+function detectServerVisitorType(request) {
+	const ua = request.headers.get('user-agent') || '';
+	const accept = request.headers.get('accept') || '';
+	if (AI_AGENT_PATTERN.test(ua)) return 'agent';
+	if (accept.includes('text/markdown')) return 'agent';
+	return null;
+}
+
+function trackPlausibleEvent(request, visitorType) {
+	const url = new URL(request.url);
+	const ua = request.headers.get('user-agent') || '';
+	const ip = request.headers.get('x-forwarded-for') || request.headers.get('x-real-ip') || '';
+
+	fetch('https://plausible.io/api/event', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+			'User-Agent': ua,
+			'X-Forwarded-For': ip,
+		},
+		body: JSON.stringify({
+			name: 'pageview',
+			domain: 'seal-docs.wal.app',
+			url: url.toString(),
+			referrer: request.headers.get('referer') || '',
+			props: { visitor_type: visitorType },
+		}),
+	}).catch(() => {});
+}
+
+export const config = {
+	matcher: [
+		'/((?!_next|api|static|img|fonts|favicon).*)',
+	],
+};
+
+export default async function middleware(request) {
+	const visitorType = detectServerVisitorType(request);
+	if (visitorType === 'agent') {
+		trackPlausibleEvent(request, visitorType);
+	}
+	return;
+}

--- a/docs/site/src/shared/plugins/plausible/client/index.ts
+++ b/docs/site/src/shared/plugins/plausible/client/index.ts
@@ -13,12 +13,14 @@ declare global {
   }
 }
 
+const AI_AGENT_PATTERNS = /claude[-_]?code|anthropic|cursor|copilot|chatgpt|openai|gptbot|perplexity|cohere|codeium|windsurf|tabnine|sourcegraph|cody/i;
 const BOT_PATTERNS = /bot|crawler|spider|crawling|headless|puppet|phantom|selenium|playwright|archiver|fetcher|slurp|mediapartners/i;
 
-function detectVisitorType(): "agent" | "human" {
+function detectVisitorType(): "agent" | "bot" | "human" {
   const ua = navigator.userAgent || "";
-  if (BOT_PATTERNS.test(ua)) return "agent";
-  if ((navigator as any).webdriver) return "agent";
+  if (AI_AGENT_PATTERNS.test(ua)) return "agent";
+  if (BOT_PATTERNS.test(ua)) return "bot";
+  if ((navigator as any).webdriver) return "bot";
   return "human";
 }
 


### PR DESCRIPTION
## Summary
- Adds server-side Vercel Edge Middleware to track AI coding agent visits (Claude Code, Cursor, Copilot, etc.) via Plausible Events API
- Updates client-side detection to distinguish three visitor types: `agent` (AI tools), `bot` (crawlers), and `human`

## Test plan
- [ ] Verify docs site builds successfully
- [ ] Confirm `visitor_type` prop appears in Plausible dashboard with agent/bot/human values

🤖 Generated with [Claude Code](https://claude.com/claude-code)