### PR TITLE
docs: Log user-agent on feedback events for agent identification

### DIFF
--- a/docs/site/src/client/pushfeedback-toc.js
+++ b/docs/site/src/client/pushfeedback-toc.js
@@ -87,8 +87,24 @@ function injectIntoTOC() {
   ul.appendChild(buildLI());
 }
 
+function listenForFeedback() {
+  if (document.__pfListenerAttached) return;
+  document.__pfListenerAttached = true;
+  document.addEventListener("feedbackSent", () => {
+    try {
+      window.plausible?.("Feedback", {
+        props: {
+          user_agent: navigator.userAgent.substring(0, 150),
+          page: window.location.pathname,
+        },
+      });
+    } catch (_) {}
+  });
+}
+
 export function onRouteDidUpdate() {
   ensurePushFeedbackScript();
+  listenForFeedback();
 
   // Try a few times to survive async TOC hydration/re-render
   const tries = [0, 100, 300, 700];


### PR DESCRIPTION
## Summary
- Fires a Plausible custom event (`Feedback`) with `user_agent` and `page` props when the PushFeedback widget submits
- Enables identifying which AI agents are interacting with the feedback widget

## Test plan
- [ ] Verify docs site builds
- [ ] Submit feedback and confirm `Feedback` event appears in Plausible with `user_agent` prop

🤖 Generated with [Claude Code](https://claude.com/claude-code)