### PR TITLE
docs: Add Kapa.ai bot widget

### DIFF
--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -55,7 +55,7 @@ const config = {
   scripts: [
     {
       src: "https://widget.kapa.ai/kapa-widget.bundle.js",
-      "data-website-id": "PLACEHOLDER_SEAL_KAPA_ID",
+      "data-website-id": "91d6cd50-0276-4125-b8c1-3fe897e8fe47",
       "data-project-name": "Seal Knowledge",
       "data-project-color": "#92a4ff",
       "data-button-hide": "true",
@@ -69,7 +69,10 @@ const config = {
       "data-answer-feedback-button-bg-color": "#FFFFFF",
       "data-answer-copy-button-bg-color": "#FFFFFF",
       "data-thread-clear-button-bg-color": "#FFFFFF",
-      "data-modal-image": `${process.env.DOCUSAURUS_BASE_URL || '/'}img/logo.svg`,
+      "data-modal-image": "/img/logo.svg",
+      "data-mcp-enabled": "true",
+      "data-mcp-server-url": "https://sui.mcp.kapa.ai",
+      "data-mcp-button-text": "Use Seal MCP Server",
       async: true,
     },
   ],

--- a/docs/site/docusaurus.config.js
+++ b/docs/site/docusaurus.config.js
@@ -52,7 +52,32 @@ const config = {
     mermaid: true,
   },
 
-  clientModules: [require.resolve("./src/client/pushfeedback-toc.js")],
+  scripts: [
+    {
+      src: "https://widget.kapa.ai/kapa-widget.bundle.js",
+      "data-website-id": "PLACEHOLDER_SEAL_KAPA_ID",
+      "data-project-name": "Seal Knowledge",
+      "data-project-color": "#92a4ff",
+      "data-button-hide": "true",
+      "data-modal-title": "Ask Seal AI",
+      "data-modal-ask-ai-input-placeholder": "Ask me anything about Seal!",
+      "data-modal-example-questions":
+        "How do I encrypt data with Seal?,What is threshold encryption?,How do I create an access policy?,What are key servers?",
+      "data-modal-body-bg-color": "#E0E2E6",
+      "data-source-link-bg-color": "#FFFFFF",
+      "data-source-link-border": "#92a4ff",
+      "data-answer-feedback-button-bg-color": "#FFFFFF",
+      "data-answer-copy-button-bg-color": "#FFFFFF",
+      "data-thread-clear-button-bg-color": "#FFFFFF",
+      "data-modal-image": `${process.env.DOCUSAURUS_BASE_URL || '/'}img/logo.svg`,
+      async: true,
+    },
+  ],
+
+  clientModules: [
+    require.resolve("./src/client/pushfeedback-toc.js"),
+    require.resolve("./src/client/kapa-navbar.js"),
+  ],
   
   plugins: [
     function markdownHeadersPlugin() {

--- a/docs/site/src/client/kapa-navbar.js
+++ b/docs/site/src/client/kapa-navbar.js
@@ -1,0 +1,37 @@
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+function getBaseUrl() {
+  const meta = document.querySelector('meta[name="docusaurus_baseUrl"]');
+  return (meta && meta.content) || "/";
+}
+
+function injectKapaButton() {
+  if (document.getElementById("__kapa_navbar_btn")) return;
+
+  const rightItems =
+    document.querySelector(".navbar__items--right") ||
+    document.querySelector(".navbar__items:last-child");
+  if (!rightItems) return;
+
+  const baseUrl = getBaseUrl();
+  const btn = document.createElement("button");
+  btn.id = "__kapa_navbar_btn";
+  btn.type = "button";
+  btn.className = "kapa-trigger-btn";
+  btn.innerHTML =
+    '<img src="' + baseUrl + 'img/logo.svg" alt="" width="23" height="23" />' +
+    '<span class="kapa-label">Ask Seal AI</span>';
+  btn.addEventListener("click", () => {
+    if (typeof window !== "undefined" && window.Kapa) {
+      window.Kapa.open();
+    }
+  });
+
+  rightItems.appendChild(btn);
+}
+
+export function onRouteDidUpdate() {
+  const tries = [0, 100, 300];
+  tries.forEach((t) => setTimeout(injectKapaButton, t));
+}

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -266,3 +266,42 @@ html[data-theme='dark'] {
   align-items: center;
   gap: 0.35rem;
 }
+
+/* Kapa AI button */
+.navbar .kapa-trigger-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  background: #fff;
+  color: #111;
+  font-weight: 600;
+  font-size: 0.875rem;
+  padding: 0.5rem 1.25rem;
+  border-radius: 9999px;
+  border: 1px solid #e0e0e0;
+  transition: background 0.15s;
+  white-space: nowrap;
+  margin-left: 0.5rem;
+}
+.navbar .kapa-trigger-btn:hover {
+  background: #f5f5f5;
+}
+[data-theme="dark"] .navbar .kapa-trigger-btn {
+  background: #1e1e2e;
+  color: #e0e0e0;
+  border-color: #444;
+}
+[data-theme="dark"] .navbar .kapa-trigger-btn:hover {
+  background: #2a2a3e;
+}
+
+@media (max-width: 996px) {
+  .navbar .kapa-trigger-btn .kapa-label {
+    display: none;
+  }
+  .navbar .kapa-trigger-btn {
+    padding: 0.4rem;
+    border-radius: 50%;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the Kapa AI assistant widget to Seal docs, matching the implementation on Sui and Walrus docs
- Swizzles the navbar to add a custom "Ask Seal AI" button that opens the Kapa modal
- Includes responsive CSS (icon-only on mobile, full button on desktop)

> **Note:** The `data-website-id` in `docusaurus.config.js` is set to `PLACEHOLDER_SEAL_KAPA_ID` — replace with the actual Seal project ID from Kapa once provisioned.

## Test plan
- [ ] Replace placeholder Kapa ID with real project ID
- [ ] Verify docs site builds successfully
- [ ] Confirm "Ask Seal AI" button appears in navbar
- [ ] Confirm clicking the button opens the Kapa modal
- [ ] Check dark mode styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)