### PR TITLE
[aggregator][key-server] consolidate sui_rpc_client with retry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8287,6 +8287,7 @@ dependencies = [
  "sui-sdk-types 0.3.0",
  "sui-types",
  "tokio",
+ "tonic 0.14.5",
 ]
 
 [[package]]

--- a/crates/key-server/src/aggregator/server.rs
+++ b/crates/key-server/src/aggregator/server.rs
@@ -30,10 +30,11 @@ use key_server::errors::InternalError::{
 use key_server::errors::{ErrorResponse, InternalError};
 use key_server::metrics::{aggregator_metrics_middleware, uptime_metric, AggregatorMetrics};
 use key_server::metrics_push::{create_push_client, push_metrics, MetricsPushConfig};
+use key_server::sui_rpc_client::{RpcConfig, RpcError, SuiRpcClient};
 use mysten_service::metrics::start_basic_prometheus_server;
 use mysten_service::{get_mysten_service, package_name, package_version};
 use prometheus::Registry;
-use seal_committee::{fetch_key_server_by_id, move_types::PartialKeyServer};
+use seal_committee::move_types::PartialKeyServer;
 use seal_sdk::{FetchKeyRequest, FetchKeyResponse};
 use semver::{Version, VersionReq};
 use serde::Deserialize;
@@ -41,6 +42,7 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::sync::Arc;
 use sui_rpc::client::Client as SuiGrpcClient;
+use sui_sdk::SuiClientBuilder;
 use sui_sdk_types::Address;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
@@ -116,6 +118,10 @@ struct AggregatorOptions {
     #[serde(default)]
     api_credentials: HashMap<String, ApiCredentials>,
 
+    /// The configuration for the Sui RPC client.
+    #[serde(default)]
+    rpc_config: RpcConfig,
+
     /// Optional metrics push configuration to send metrics to seal-proxy.
     #[serde(default)]
     metrics_push_config: Option<MetricsPushConfig>,
@@ -135,7 +141,7 @@ impl NetworkConfig for AggregatorOptions {
 #[derive(Clone)]
 struct AppState {
     aggregator_metrics: Arc<AggregatorMetrics>,
-    grpc_client: SuiGrpcClient,
+    sui_rpc_client: SuiRpcClient,
     http_client: reqwest::Client,
     committee: Arc<RwLock<CommitteeSnapshot>>,
     options: AggregatorOptions,
@@ -343,12 +349,11 @@ async fn handle_fetch_key(
 
     // Parse the PTB and build the set of expected full ids every honest committee member should
     // return.
-    let expected_full_ids_owned =
-        get_expected_full_ids(&mut state.grpc_client.clone(), &request.ptb)
-            .await
-            .inspect_err(|e| {
-                state.aggregator_metrics.observe_error(e.as_str());
-            })?;
+    let expected_full_ids_owned = get_expected_full_ids(&state.sui_rpc_client, &request.ptb)
+        .await
+        .inspect_err(|e| {
+            state.aggregator_metrics.observe_error(e.as_str());
+        })?;
     state
         .aggregator_metrics
         .expected_key_ids_per_request
@@ -713,11 +718,22 @@ async fn load_committee_state(
     options: AggregatorOptions,
     metrics: Arc<AggregatorMetrics>,
 ) -> Result<AppState> {
-    let mut grpc_client =
+    let grpc_client =
         SuiGrpcClient::new(options.node_url()).context("Failed to create SuiGrpcClient")?;
-    let key_server_v2 =
-        fetch_key_server_by_id(&mut grpc_client, &options.key_server_object_id).await?;
-    let (threshold, members) = key_server_v2.extract_committee_info()?;
+    let sui_client = SuiClientBuilder::default()
+        .build(&options.node_url())
+        .await
+        .context("Failed to build SuiClient")?;
+    let sui_rpc_client = SuiRpcClient::new(
+        sui_client,
+        grpc_client,
+        options.rpc_config.retry_config.clone(),
+        Some(metrics.sui_rpc_request_duration_millis.clone()),
+    );
+
+    let (threshold, members) = sui_rpc_client
+        .fetch_committee_info(&options.key_server_object_id)
+        .await?;
     let committee = CommitteeSnapshot { threshold, members };
 
     // Check and warn about missing API credentials for current committee.
@@ -725,7 +741,7 @@ async fn load_committee_state(
 
     Ok(AppState {
         aggregator_metrics: metrics,
-        grpc_client,
+        sui_rpc_client,
         http_client: reqwest::Client::new(),
         committee: Arc::new(RwLock::new(committee)),
         options,
@@ -734,7 +750,7 @@ async fn load_committee_state(
 
 /// Background task that periodically refreshes committee members from onchain.
 /// Polls every 30 seconds and updates the committee members.
-async fn monitor_members_update(mut state: AppState) {
+async fn monitor_members_update(state: AppState) {
     let mut ticker = interval(Duration::from_secs(REFRESH_INTERVAL_SECS));
 
     info!(
@@ -746,13 +762,14 @@ async fn monitor_members_update(mut state: AppState) {
         ticker.tick().await;
 
         // Fetch the current state from onchain.
-        let committee = match fetch_key_server_by_id(
-            &mut state.grpc_client,
-            &state.options.key_server_object_id,
-        )
-        .await
-        .and_then(|ks| ks.extract_committee_info())
-        {
+        let committee = match state
+            .sui_rpc_client
+            .fetch_key_server_by_id(&state.options.key_server_object_id)
+            .await
+            .and_then(|ks| {
+                ks.extract_committee_info()
+                    .map_err(|e| RpcError::new(&e.to_string()))
+            }) {
             Ok((threshold, members)) => CommitteeSnapshot { threshold, members },
             Err(e) => {
                 warn!(
@@ -891,7 +908,7 @@ mod tests {
     }
 
     /// Helper to create AppState for testing.
-    fn create_test_app_state(
+    async fn create_test_app_state(
         mock_servers: &[MockServer],
         threshold: u16,
         partial_pks: Vec<G2Element>,
@@ -925,18 +942,29 @@ mod tests {
             key_server_version_requirement: VersionReq::parse(">=0.5.14").unwrap(),
             key_server_timeout_secs: 8,
             api_credentials,
+            rpc_config: RpcConfig::default(),
             metrics_push_config: None,
         };
         let registry = Registry::new();
         let metrics = Arc::new(AggregatorMetrics::new(&registry));
         let grpc_client = SuiGrpcClient::new(options.node_url()).unwrap();
+        let sui_client = SuiClientBuilder::default()
+            .build(&options.node_url())
+            .await
+            .unwrap();
+        let sui_rpc_client = SuiRpcClient::new(
+            sui_client,
+            grpc_client,
+            options.rpc_config.retry_config.clone(),
+            None,
+        );
         let http_client = reqwest::Client::new();
         let (_, pkg_id, _, first_pkg_id) = test_valid_ptb();
         PACKAGE_ID_CACHE.insert(pkg_id, first_pkg_id);
 
         AppState {
             aggregator_metrics: metrics,
-            grpc_client,
+            sui_rpc_client,
             http_client,
             committee: Arc::new(RwLock::new(CommitteeSnapshot {
                 threshold,
@@ -1070,7 +1098,7 @@ mod tests {
                 .mount(&server1)
                 .await;
 
-            let state = create_test_app_state(&[server1], 1, vec![G2Element::zero()]);
+            let state = create_test_app_state(&[server1], 1, vec![G2Element::zero()]).await;
             let (request, _, _) = create_test_fetch_key_request(&mut thread_rng());
 
             let mut headers = HeaderMap::new();
@@ -1098,7 +1126,7 @@ mod tests {
                 .mount(&server2)
                 .await;
 
-            let state = create_test_app_state(&[server2], 1, vec![G2Element::zero()]);
+            let state = create_test_app_state(&[server2], 1, vec![G2Element::zero()]).await;
             let (request, _, _) = create_test_fetch_key_request(&mut thread_rng());
 
             let mut headers = HeaderMap::new();
@@ -1126,7 +1154,7 @@ mod tests {
                 .await;
 
             let servers = vec![server_missing_version];
-            let state = create_test_app_state(&servers, 1, vec![G2Element::zero()]);
+            let state = create_test_app_state(&servers, 1, vec![G2Element::zero()]).await;
             let (request, _, _) = create_test_fetch_key_request(&mut thread_rng());
 
             let mut headers = HeaderMap::new();
@@ -1172,7 +1200,7 @@ mod tests {
                 .mount(&server3)
                 .await;
 
-            let state = create_test_app_state(&[server3], 1, vec![partial_pk]);
+            let state = create_test_app_state(&[server3], 1, vec![partial_pk]).await;
 
             let mut headers = HeaderMap::new();
             headers.insert(HEADER_CLIENT_SDK_TYPE, "typescript".parse().unwrap());
@@ -1231,7 +1259,8 @@ mod tests {
             &mock_servers,
             3,
             vec![G2Element::zero(); mock_servers.len()],
-        );
+        )
+        .await;
 
         // Create a FetchKeyRequest for testing.
         let mut rng = thread_rng();
@@ -1313,7 +1342,8 @@ mod tests {
             &[s0, s1, s_bad],
             2,
             vec![partial_pk_0, partial_pk_1, G2Element::generator()],
-        );
+        )
+        .await;
 
         let mut headers = HeaderMap::new();
         headers.insert(HEADER_CLIENT_SDK_TYPE, "typescript".parse().unwrap());
@@ -1371,7 +1401,8 @@ mod tests {
         let mock_servers = vec![server_good, server_error];
 
         let state =
-            create_test_app_state(&mock_servers, 2, vec![partial_pk_0, G2Element::generator()]);
+            create_test_app_state(&mock_servers, 2, vec![partial_pk_0, G2Element::generator()])
+                .await;
 
         let mut headers = HeaderMap::new();
         headers.insert(HEADER_CLIENT_SDK_TYPE, "typescript".parse().unwrap());
@@ -1438,7 +1469,8 @@ mod tests {
             &[server_good, server_missing],
             2,
             vec![partial_pk_0, G2Element::generator()],
-        );
+        )
+        .await;
 
         let mut headers = HeaderMap::new();
         headers.insert(HEADER_CLIENT_SDK_TYPE, "typescript".parse().unwrap());

--- a/crates/key-server/src/aggregator/utils.rs
+++ b/crates/key-server/src/aggregator/utils.rs
@@ -1,8 +1,10 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::common::fetch_first_pkg_id;
+use crate::errors::InternalError;
+use crate::sui_rpc_client::SuiRpcClient;
 use crate::valid_ptb::ValidPtb;
-use crate::{common::fetch_first_pkg_id, errors::InternalError};
 use crypto::{elgamal, ibe::verify_encrypted_signature};
 use fastcrypto::{
     encoding::{Encoding, Hex},
@@ -14,16 +16,15 @@ use seal_sdk::{
     FetchKeyResponse,
 };
 use std::collections::{HashMap, HashSet};
-use sui_rpc::client::Client as SuiGrpcClient;
 use tracing::debug;
 
 /// Parse PTB, resolve its pkg id to the first pkg id via grpc, and return the set of full key ids.
 pub async fn get_expected_full_ids(
-    grpc_client: &mut SuiGrpcClient,
+    sui_rpc_client: &SuiRpcClient,
     ptb_b64: &str,
 ) -> Result<HashSet<Vec<u8>>, InternalError> {
     let valid_ptb = ValidPtb::try_from_base64(ptb_b64)?;
-    let first_pkg_id = fetch_first_pkg_id(grpc_client, &valid_ptb.pkg_id()).await?;
+    let first_pkg_id = fetch_first_pkg_id(sui_rpc_client, &valid_ptb.pkg_id()).await?;
     Ok(valid_ptb.full_ids(&first_pkg_id).into_iter().collect())
 }
 

--- a/crates/key-server/src/common.rs
+++ b/crates/key-server/src/common.rs
@@ -58,8 +58,7 @@ pub async fn fetch_first_pkg_id(
         .fetch_package_original_id(Address::new(pkg_id.into_bytes()))
         .await
         .map_err(|e| match e.code {
-            Some(tonic::Code::NotFound) => InternalError::InvalidPackage,
-            None if e.message == "Invalid package" => InternalError::InvalidPackage,
+            Some(tonic::Code::NotFound) | None => InternalError::InvalidPackage, // rpc not found error or failed to extract the package object.
             _ => InternalError::Failure(format!("Failed to resolve package id: {e}")),
         })?;
 

--- a/crates/key-server/src/common.rs
+++ b/crates/key-server/src/common.rs
@@ -6,16 +6,13 @@ use axum::http::HeaderValue;
 use axum::response::Response;
 use moka::sync::Cache;
 use once_cell::sync::Lazy;
-use seal_committee::grpc_helper::extract_object;
 use serde::{Deserialize, Serialize};
-use sui_rpc::client::Client as SuiGrpcClient;
-use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
 use sui_sdk_types::Address;
 use sui_types::base_types::ObjectID;
-use sui_types::object::Data;
 
 use crate::cache::default_lru_cache;
 use crate::errors::InternalError;
+use key_server::sui_rpc_client::SuiRpcClient;
 
 pub static PACKAGE_ID_CACHE: Lazy<Cache<ObjectID, ObjectID>> = Lazy::new(default_lru_cache);
 
@@ -47,37 +44,26 @@ impl Network {
 
 /// Fetch the first package id for `pkg_id`, using the shared package id cache.
 /// Returns `InternalError::Failure` for grpc errors and `InternalError::InvalidPackage`
-/// when the package cannot resolve.
+/// when the package cannot resolve. The underlying helper is retried on
+/// transient gRPC errors and observes `sui_rpc_request_duration_millis`.
 pub async fn fetch_first_pkg_id(
-    grpc_client: &mut SuiGrpcClient,
+    sui_rpc_client: &SuiRpcClient,
     pkg_id: &ObjectID,
 ) -> Result<ObjectID, InternalError> {
     if let Some(first) = PACKAGE_ID_CACHE.get(pkg_id) {
         return Ok(first);
     }
 
-    let mut request = GetObjectRequest::default();
-    request.object_id = Some(Address::new(pkg_id.into_bytes()).to_string());
-    request.read_mask = Some(prost_types::FieldMask {
-        paths: vec!["bcs".to_string()],
-    });
-
-    let response = grpc_client
-        .ledger_client()
-        .get_object(request)
+    let first_addr = sui_rpc_client
+        .fetch_package_original_id(Address::new(pkg_id.into_bytes()))
         .await
-        .map_err(|e| match e.code() {
-            tonic::Code::NotFound => InternalError::InvalidPackage,
+        .map_err(|e| match e.code {
+            Some(tonic::Code::NotFound) => InternalError::InvalidPackage,
+            None if e.message == "Invalid package" => InternalError::InvalidPackage,
             _ => InternalError::Failure(format!("Failed to resolve package id: {e}")),
-        })?
-        .into_inner();
+        })?;
 
-    let obj = extract_object(response).map_err(|_| InternalError::InvalidPackage)?;
-    let first = match &obj.data {
-        Data::Package(p) => p.original_package_id(),
-        _ => return Err(InternalError::InvalidPackage),
-    };
-
+    let first = ObjectID::new(first_addr.into_inner());
     PACKAGE_ID_CACHE.insert(*pkg_id, first);
     Ok(first)
 }

--- a/crates/key-server/src/externals.rs
+++ b/crates/key-server/src/externals.rs
@@ -5,8 +5,7 @@ use crate::cache::default_lru_cache;
 use crate::errors::InternalError;
 use crate::key_server_options::KeyServerOptions;
 use crate::mvr_forward_resolution;
-use crate::sui_rpc_client::RpcResult;
-use crate::sui_rpc_client::SuiRpcClient;
+use key_server::sui_rpc_client::{RpcResult, SuiRpcClient};
 use moka::sync::Cache;
 use once_cell::sync::Lazy;
 use sui_types::base_types::ObjectID;
@@ -78,13 +77,13 @@ pub(crate) async fn get_reference_gas_price(sui_rpc_client: SuiRpcClient) -> Rpc
 #[cfg(test)]
 mod tests {
     use crate::common::fetch_first_pkg_id;
-    use crate::key_server_options::RetryConfig;
-    use crate::sui_rpc_client::SuiRpcClient;
     use crate::types::Network;
     use crate::InternalError;
     use fastcrypto::ed25519::Ed25519KeyPair;
     use fastcrypto::secp256k1::Secp256k1KeyPair;
     use fastcrypto::secp256r1::Secp256r1KeyPair;
+    use key_server::sui_rpc_client::RetryConfig;
+    use key_server::sui_rpc_client::SuiRpcClient;
     use shared_crypto::intent::{Intent, IntentMessage, PersonalMessage};
     use std::str::FromStr;
     use sui_rpc::client::Client as SuiGrpcClient;
@@ -111,8 +110,7 @@ mod tests {
             RetryConfig::default(),
             None,
         );
-        let mut grpc_client = sui_rpc_client.sui_grpc_client();
-        match fetch_first_pkg_id(&mut grpc_client, &address).await {
+        match fetch_first_pkg_id(&sui_rpc_client, &address).await {
             Ok(first) => {
                 assert_eq!(
                     first.to_hex_literal(),
@@ -140,8 +138,7 @@ mod tests {
             RetryConfig::default(),
             None,
         );
-        let mut grpc_client = sui_rpc_client.sui_grpc_client();
-        let result = fetch_first_pkg_id(&mut grpc_client, &invalid_address).await;
+        let result = fetch_first_pkg_id(&sui_rpc_client, &invalid_address).await;
         assert!(matches!(result, Err(InternalError::InvalidPackage)));
     }
 

--- a/crates/key-server/src/key_server_options.rs
+++ b/crates/key-server/src/key_server_options.rs
@@ -71,47 +71,7 @@ pub enum ServerMode {
     },
 }
 
-/// Configuration for the RPC client.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RpcConfig {
-    /// The timeout for RPC requests.
-    pub timeout: Duration,
-
-    /// The retry configuration for RPC requests.
-    pub retry_config: RetryConfig,
-}
-
-impl Default for RpcConfig {
-    fn default() -> Self {
-        Self {
-            timeout: Duration::from_secs(60),
-            retry_config: RetryConfig::default(),
-        }
-    }
-}
-
-/// Configuration for the retry logic.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RetryConfig {
-    /// The maximum number of retries.
-    pub max_retries: u32,
-
-    /// The minimum delay between retries.
-    pub min_delay: Duration,
-
-    /// The maximum delay between retries.
-    pub max_delay: Duration,
-}
-
-impl Default for RetryConfig {
-    fn default() -> Self {
-        Self {
-            max_retries: 3,
-            min_delay: Duration::from_millis(100),
-            max_delay: Duration::from_secs(10),
-        }
-    }
-}
+pub use key_server::sui_rpc_client::RpcConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeyServerOptions {

--- a/crates/key-server/src/lib.rs
+++ b/crates/key-server/src/lib.rs
@@ -3,10 +3,14 @@
 
 //! Shared modules for key-server and aggregator server binaries.
 
+// Alias the crate as `key_server` inside itself so key server and aggregator can both use.
+extern crate self as key_server;
+
 pub mod aggregator;
 pub(crate) mod cache;
 pub mod common;
 pub mod errors;
 pub mod metrics;
 pub mod metrics_push;
+pub mod sui_rpc_client;
 pub mod valid_ptb;

--- a/crates/key-server/src/metrics.rs
+++ b/crates/key-server/src/metrics.rs
@@ -304,6 +304,9 @@ pub struct AggregatorMetrics {
 
     /// Number of expected key ids per request
     pub expected_key_ids_per_request: Histogram,
+
+    /// Sui RPC call duration and status, by gRPC method
+    pub sui_rpc_request_duration_millis: HistogramVec,
 }
 
 #[allow(dead_code)]
@@ -371,6 +374,14 @@ impl AggregatorMetrics {
                 "expected_key_ids_per_request",
                 "Number of expected key ids per aggregator request",
                 buckets(0.0, 10.0, 1.0),
+                registry
+            )
+            .unwrap(),
+            sui_rpc_request_duration_millis: register_histogram_vec_with_registry!(
+                "sui_rpc_request_duration_millis",
+                "Sui RPC request duration and status in milliseconds",
+                &["method", "status"],
+                default_fast_call_duration_buckets(),
                 registry
             )
             .unwrap(),

--- a/crates/key-server/src/mvr.rs
+++ b/crates/key-server/src/mvr.rs
@@ -16,8 +16,8 @@
 use crate::errors::InternalError;
 use crate::errors::InternalError::{Failure, InvalidMVRName, InvalidPackage};
 use crate::key_server_options::KeyServerOptions;
-use crate::sui_rpc_client::SuiRpcClient;
 use crate::types::Network;
+use key_server::sui_rpc_client::SuiRpcClient;
 use move_core_types::account_address::AccountAddress;
 use move_core_types::identifier::Identifier;
 use move_core_types::language_storage::StructTag;
@@ -120,7 +120,7 @@ pub(crate) async fn mvr_forward_resolution(
                     SuiGrpcClient::new(Network::Mainnet.default_node_url())
                         .expect("Failed to create SuiGrpcClient"),
                     key_server_options.rpc_config.retry_config.clone(),
-                    sui_rpc_client.get_metrics(),
+                    sui_rpc_client.request_duration_millis(),
                 ),
             )
             .await?
@@ -137,7 +137,7 @@ pub(crate) async fn mvr_forward_resolution(
                     "No package info ID for MVR name {mvr_name} on testnet"
                 )))?;
             let package_info: PackageInfo = sui_rpc_client
-                .get_object(package_info_id)
+                .get_object(Address::new(package_info_id.into_bytes()))
                 .await
                 .map_err(|e| match e.code {
                     // None = FN protocol violation (missing BCS / decode failure) — deterministic, not retryable.
@@ -179,10 +179,9 @@ async fn get_from_mvr_registry(
     )));
 
     let child_id = registry_address.derive_dynamic_child_id(&name_type_tag, &name_bcs);
-    let child_object_id = ObjectID::new(child_id.into_inner());
 
     mainnet_sui_rpc_client
-        .get_object::<Field<Name, AppRecord>>(child_object_id)
+        .get_object::<Field<Name, AppRecord>>(child_id)
         .await
         .map_err(|e| match e.code {
             Some(Code::NotFound) => InvalidMVRName,
@@ -215,10 +214,11 @@ fn dynamic_field_name(mvr_name: &str) -> Result<DynamicFieldName, InternalError>
 #[cfg(test)]
 mod tests {
     use crate::errors::InternalError::InvalidMVRName;
-    use crate::key_server_options::{KeyServerOptions, RetryConfig};
+    use crate::key_server_options::KeyServerOptions;
     use crate::mvr::mvr_forward_resolution;
-    use crate::sui_rpc_client::SuiRpcClient;
     use crate::types::Network;
+    use key_server::sui_rpc_client::RetryConfig;
+    use key_server::sui_rpc_client::SuiRpcClient;
     use mvr_types::name::VersionedName;
     use std::str::FromStr;
     use sui_rpc::client::Client as SuiGrpcClient;

--- a/crates/key-server/src/periodic_updater.rs
+++ b/crates/key-server/src/periodic_updater.rs
@@ -1,8 +1,7 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::sui_rpc_client::RpcResult;
-use crate::sui_rpc_client::SuiRpcClient;
+use key_server::sui_rpc_client::{RpcResult, SuiRpcClient};
 use std::time::Duration;
 use tokio::sync::watch::{channel, Receiver};
 use tokio::task::JoinHandle;

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -30,6 +30,7 @@ use fastcrypto::ed25519::{Ed25519PublicKey, Ed25519Signature};
 use fastcrypto::encoding::{Encoding, Hex};
 use fastcrypto::traits::VerifyingKey;
 use futures::future::pending;
+use key_server::sui_rpc_client::SuiRpcClient;
 use key_server_options::KeyServerOptions;
 use master_keys::{CommitteeKeyState, MasterKeys};
 use metrics::metrics_middleware;
@@ -40,11 +41,6 @@ use mysten_service::metrics::start_prometheus_server;
 use mysten_service::package_name;
 use mysten_service::package_version;
 use rand::thread_rng;
-use seal_committee::grpc_helper::fetch_upgrade_proposal;
-use seal_committee::grpc_helper::{
-    fetch_committee_from_key_server, fetch_committee_server_version,
-    fetch_partial_key_server_for_member,
-};
 use seal_committee::move_types::CommitteeRotationInitiatedEvent;
 use seal_sdk::types::{DecryptionKey, ElGamalPublicKey, ElgamalVerificationKey, KeyId};
 use seal_sdk::{signed_message, FetchKeyResponse};
@@ -58,8 +54,6 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use sui_rpc::client::Client as SuiGrpcClient;
 use sui_rpc::proto::sui::rpc::v2::execution_error::ExecutionErrorKind;
-use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
-use sui_rpc_client::{RpcError, SuiRpcClient};
 use sui_sdk::rpc_types::EventFilter;
 use sui_sdk::types::base_types::{ObjectID, SuiAddress};
 use sui_sdk::types::signature::GenericSignature;
@@ -83,7 +77,6 @@ mod common;
 mod errors;
 mod externals;
 mod signed_message;
-mod sui_rpc_client;
 mod types;
 mod utils;
 mod valid_ptb;
@@ -147,7 +140,7 @@ struct Server {
 }
 
 async fn has_address_aliases(
-    client: &mut SuiGrpcClient,
+    sui_rpc_client: &SuiRpcClient,
     address: SuiAddress,
 ) -> Result<bool, InternalError> {
     let alias_key_type = TypeTag::Struct(Box::new(StructTag {
@@ -165,19 +158,10 @@ async fn has_address_aliases(
     )
     .map_err(|_| InternalError::InvalidSignature)?;
 
-    // Convert ObjectID to Address for gRPC request
-    let address_id = Address::new(address_aliases_id.into_bytes());
-
-    let request = GetObjectRequest::default().with_object_id(address_id.to_string());
-
-    match client.ledger_client().get_object(request).await {
-        Ok(_) => Ok(true),
-        Err(e) if e.code() == Code::NotFound => Ok(false),
-        Err(e) => Err(InternalError::Failure(format!(
-            "Failed to check address aliases: {}",
-            e
-        ))),
-    }
+    sui_rpc_client
+        .object_exists(Address::new(address_aliases_id.into_bytes()))
+        .await
+        .map_err(|e| InternalError::Failure(format!("Failed to check address aliases: {}", e)))
 }
 
 async fn fetch_and_validate_committee_partial_pk(
@@ -186,10 +170,9 @@ async fn fetch_and_validate_committee_partial_pk(
     member_address: &Address,
     master_share: &IbeMasterKey,
 ) -> Result<()> {
-    let mut grpc_client = sui_rpc_client.sui_grpc_client();
-    let member_info =
-        fetch_partial_key_server_for_member(&mut grpc_client, key_server_obj_id, member_address)
-            .await?;
+    let member_info = sui_rpc_client
+        .fetch_partial_key_server_for_member(key_server_obj_id, member_address)
+        .await?;
 
     let local_partial_pk = ibe::public_key_from_master_key(master_share);
     if local_partial_pk != member_info.partial_pk {
@@ -231,21 +214,21 @@ impl Server {
                 ),
             SuiGrpcClient::new(options.node_url()).expect("Failed to create SuiGrpcClient"),
             options.rpc_config.retry_config.clone(),
-            metrics,
+            metrics
+                .as_ref()
+                .map(|m| m.sui_rpc_request_duration_millis.clone()),
         );
         info!("Server started with network: {:?}", options.network);
 
         let committee_version = match &options.server_mode {
             ServerMode::Committee {
                 key_server_obj_id, ..
-            } => {
-                let mut grpc_client = sui_rpc_client.sui_grpc_client();
-                Some(
-                    fetch_committee_server_version(&mut grpc_client, key_server_obj_id)
-                        .await
-                        .expect("Failed to fetch committee server version"),
-                )
-            }
+            } => Some(
+                sui_rpc_client
+                    .fetch_committee_server_version(key_server_obj_id)
+                    .await
+                    .expect("Failed to fetch committee server version"),
+            ),
             _ => None,
         };
 
@@ -365,8 +348,7 @@ impl Server {
         );
 
         // Check if the address has aliases enabled - if so, reject verification
-        let mut grpc_client = self.sui_rpc_client.sui_grpc_client();
-        match has_address_aliases(&mut grpc_client, cert.user).await {
+        match has_address_aliases(&self.sui_rpc_client, cert.user).await {
             Ok(true) => {
                 debug!(
                     "Address has aliases enabled, rejecting signature verification (req_id: {:?})",
@@ -531,8 +513,7 @@ impl Server {
         // Handle package upgrades: Use the first as the namespace
         let first_pkg_id =
             call_with_duration(metrics.map(|m| &m.fetch_pkg_ids_duration), || async {
-                let mut grpc = self.sui_rpc_client.sui_grpc_client();
-                common::fetch_first_pkg_id(&mut grpc, &valid_ptb.pkg_id()).await
+                common::fetch_first_pkg_id(&self.sui_rpc_client, &valid_ptb.pkg_id()).await
             })
             .await?;
 
@@ -702,11 +683,10 @@ impl Server {
             // Define the fetch function for the periodic updater.
             let key_server_obj_id_clone = *key_server_obj_id;
             let fetch_fn = move |client: SuiRpcClient| async move {
-                let mut grpc = client.sui_grpc_client();
-                fetch_committee_server_version(&mut grpc, &key_server_obj_id_clone)
+                client
+                    .fetch_committee_server_version(&key_server_obj_id_clone)
                     .await
                     .map(|v| v as u64)
-                    .map_err(|e| RpcError::new(e.to_string()))
             };
 
             // Define the periodic updater.
@@ -803,23 +783,21 @@ impl Server {
 
             loop {
                 // Fetch current committee ID and package ID from key server object
-                let (committee_id, committee_pkg_id) = {
-                    let mut grpc_client = sui_rpc_client.sui_grpc_client();
-                    match fetch_committee_from_key_server(&mut grpc_client, &key_server_obj_id)
-                        .await
-                    {
-                        Ok((id, pkg_id)) => {
-                            debug!("Current committee_id: {}, package_id: {}", id, pkg_id);
-                            (id, pkg_id)
-                        }
-                        Err(e) => {
-                            warn!(
-                                "Failed to fetch committee ID and package ID from key server: {}",
-                                e
-                            );
-                            tokio::time::sleep(Duration::from_secs(30)).await;
-                            continue;
-                        }
+                let (committee_id, committee_pkg_id) = match sui_rpc_client
+                    .fetch_committee_from_key_server(&key_server_obj_id)
+                    .await
+                {
+                    Ok((id, pkg_id)) => {
+                        debug!("Current committee_id: {}, package_id: {}", id, pkg_id);
+                        (id, pkg_id)
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Failed to fetch committee ID and package ID from key server: {}",
+                            e
+                        );
+                        tokio::time::sleep(Duration::from_secs(30)).await;
+                        continue;
                     }
                 };
 
@@ -904,24 +882,14 @@ impl Server {
 
         // Define the fetch function for upgrade proposal existence
         let fetch_fn = move |client: SuiRpcClient| async move {
-            let mut grpc = client.sui_grpc_client();
+            let (committee_id, _) = client
+                .fetch_committee_from_key_server(&key_server_obj_id)
+                .await?;
 
-            // Fetch current committee ID from key server object owner
-            let (committee_id, _) =
-                match fetch_committee_from_key_server(&mut grpc, &key_server_obj_id).await {
-                    Ok(result) => result,
-                    Err(e) => {
-                        return Err(RpcError::new(format!(
-                            "Failed to fetch committee ID: {}",
-                            e
-                        )))
-                    }
-                };
-
-            fetch_upgrade_proposal(&mut grpc, &committee_id)
+            client
+                .fetch_upgrade_proposal(&committee_id)
                 .await
                 .map(|proposal_opt| if proposal_opt.is_some() { 1u64 } else { 0u64 })
-                .map_err(|e| RpcError::new(e.to_string()))
         };
 
         // Spawn periodic updater

--- a/crates/key-server/src/sui_rpc_client.rs
+++ b/crates/key-server/src/sui_rpc_client.rs
@@ -1,11 +1,23 @@
 // Copyright (c), Mysten Labs, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+//! Shared gRPC client wrapper used by both the key-server and aggregator binaries.
+//! All public methods retry via [`sui_rpc_with_retries`] and observe per-call
+//! metrics through the optional `sui_rpc_request_duration_millis` histogram.
 
-use crate::{key_server_options::RetryConfig, metrics::KeyServerMetrics};
+use prometheus::HistogramVec;
 use prost_types::FieldMask;
-use seal_committee::grpc_helper::extract_object;
+use seal_committee::grpc_helper::{
+    extract_object, fetch_committee_from_key_server as grpc_fetch_committee_from_key_server,
+    fetch_key_server_by_id as grpc_fetch_key_server_by_id, fetch_object as grpc_fetch_object,
+    fetch_upgrade_proposal as grpc_fetch_upgrade_proposal,
+};
+use seal_committee::move_types::{
+    KeyServerV2, PartialKeyServer, PartialKeyServerInfo, SealCommittee, ServerType, UpgradeProposal,
+};
+pub use seal_committee::{RpcError, RpcResult};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use sui_rpc::client::Client as SuiGrpcClient;
 use sui_rpc::proto::sui::rpc::v2::{
     Bcs, GetEpochRequest, GetObjectRequest, SimulateTransactionRequest,
@@ -13,9 +25,50 @@ use sui_rpc::proto::sui::rpc::v2::{
 };
 use sui_sdk::SuiClient;
 use sui_sdk_types::Address;
-use sui_types::base_types::ObjectID;
 use sui_types::object::Data;
 use sui_types::transaction::TransactionData;
+
+/// Configuration for the retry logic.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetryConfig {
+    /// The maximum number of retries.
+    pub max_retries: u32,
+
+    /// The minimum delay between retries.
+    pub min_delay: Duration,
+
+    /// The maximum delay between retries.
+    pub max_delay: Duration,
+}
+
+impl Default for RetryConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            min_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(10),
+        }
+    }
+}
+
+/// Configuration for the Sui RPC client.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RpcConfig {
+    /// Timeout for individual RPC requests.
+    pub timeout: Duration,
+
+    /// Retry configuration applied to retriable transport-level failures.
+    pub retry_config: RetryConfig,
+}
+
+impl Default for RpcConfig {
+    fn default() -> Self {
+        Self {
+            timeout: Duration::from_secs(60),
+            retry_config: RetryConfig::default(),
+        }
+    }
+}
 
 /// Trait for determining if an error is retriable
 pub trait RetriableError {
@@ -40,28 +93,6 @@ impl RetriableError for sui_sdk::error::Error {
     }
 }
 
-/// Result type for RPC operations
-pub type RpcResult<T> = Result<T, RpcError>;
-
-/// Error type for RPC operations.
-#[derive(Debug)]
-pub struct RpcError {
-    pub(crate) message: String,
-    /// `Some(code)` for gRPC transport errors; `None` for local post-processing failures (missing BCS, decode failure, wrong shape) — deterministic, never retried.
-    pub(crate) code: Option<tonic::Code>,
-}
-
-impl std::fmt::Display for RpcError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self.code {
-            Some(code) => write!(f, "gRPC {code}: {}", self.message),
-            None => write!(f, "{}", self.message),
-        }
-    }
-}
-
-impl std::error::Error for RpcError {}
-
 impl RetriableError for RpcError {
     fn is_retriable_error(&self) -> bool {
         // Retry only transient gRPC statuses; `code: None` (local decode failures) is deterministic.
@@ -77,30 +108,19 @@ impl RetriableError for RpcError {
     }
 }
 
-impl RpcError {
-    /// Wrap a gRPC status; produces `code: Some(...)`.
-    fn from_grpc(e: tonic::Status) -> Self {
-        Self {
-            message: e.message().to_string(),
-            code: Some(e.code()),
-        }
-    }
+/// Status label constants for `observe_attempt` callbacks.
+pub const RPC_STATUS_SUCCESS: &str = "success";
+pub const RPC_STATUS_RETRIABLE_ERROR: &str = "retriable_error";
+pub const RPC_STATUS_ERROR: &str = "error";
 
-    /// Wrap a local post-processing failure (missing BCS, decode failure, wrong shape); produces `code: None`.
-    pub(crate) fn new(message: impl Into<String>) -> Self {
-        Self {
-            message: message.into(),
-            code: None,
-        }
-    }
-}
-
-/// Executes an async function with automatic retries for retriable errors
-async fn sui_rpc_with_retries<T, E, F, Fut>(
+/// Executes an async function with automatic retries for retriable errors.
+/// `observe_attempt(status, duration_ms)` is called after each attempt where
+/// `status` is one of `RPC_STATUS_SUCCESS | RPC_STATUS_RETRIABLE_ERROR | RPC_STATUS_ERROR`.
+pub async fn sui_rpc_with_retries<T, E, F, Fut>(
     rpc_config: &RetryConfig,
     label: &str,
-    metrics: Option<Arc<KeyServerMetrics>>,
     mut func: F,
+    mut observe_attempt: impl FnMut(&'static str, f64),
 ) -> Result<T, E>
 where
     E: RetriableError + std::fmt::Debug,
@@ -116,12 +136,7 @@ where
 
         // Return immediately on success
         if result.is_ok() {
-            if let Some(metrics) = metrics.as_ref() {
-                metrics
-                    .sui_rpc_request_duration_millis
-                    .with_label_values(&[label, "success"])
-                    .observe(start_time.elapsed().as_millis() as f64);
-            }
+            observe_attempt(RPC_STATUS_SUCCESS, start_time.elapsed().as_millis() as f64);
             return result;
         }
 
@@ -137,12 +152,10 @@ where
                 attempts_remaining
             );
 
-            if let Some(metrics) = metrics.as_ref() {
-                metrics
-                    .sui_rpc_request_duration_millis
-                    .with_label_values(&[label, "retriable_error"])
-                    .observe(start_time.elapsed().as_millis() as f64);
-            }
+            observe_attempt(
+                RPC_STATUS_RETRIABLE_ERROR,
+                start_time.elapsed().as_millis() as f64,
+            );
 
             // Wait before retrying with exponential backoff
             tokio::time::sleep(current_delay).await;
@@ -160,12 +173,7 @@ where
             result.as_ref().err().expect("should be error")
         );
 
-        if let Some(metrics) = metrics.as_ref() {
-            metrics
-                .sui_rpc_request_duration_millis
-                .with_label_values(&[label, "error"])
-                .observe(start_time.elapsed().as_millis() as f64);
-        }
+        observe_attempt(RPC_STATUS_ERROR, start_time.elapsed().as_millis() as f64);
 
         // Either non-retriable error or no attempts remaining
         return result;
@@ -178,7 +186,7 @@ pub struct SuiRpcClient {
     sui_client: SuiClient,
     sui_grpc_client: SuiGrpcClient,
     rpc_retry_config: RetryConfig,
-    metrics: Option<Arc<KeyServerMetrics>>,
+    request_duration_millis: Option<HistogramVec>,
 }
 
 impl SuiRpcClient {
@@ -186,13 +194,13 @@ impl SuiRpcClient {
         sui_client: SuiClient,
         sui_grpc_client: SuiGrpcClient,
         rpc_retry_config: RetryConfig,
-        metrics: Option<Arc<KeyServerMetrics>>,
+        request_duration_millis: Option<HistogramVec>,
     ) -> Self {
         Self {
             sui_client,
             sui_grpc_client,
             rpc_retry_config,
-            metrics,
+            request_duration_millis,
         }
     }
 
@@ -206,9 +214,34 @@ impl SuiRpcClient {
         self.sui_grpc_client.clone()
     }
 
-    /// Returns a clone of the metrics object.
-    pub fn get_metrics(&self) -> Option<Arc<KeyServerMetrics>> {
-        self.metrics.clone()
+    /// Returns a clone of the request-duration histogram (if any).
+    pub fn request_duration_millis(&self) -> Option<HistogramVec> {
+        self.request_duration_millis.clone()
+    }
+
+    /// Call grpc through retry and metrics.
+    async fn run_grpc_with_retries<T, E, F, Fut>(
+        &self,
+        method: &'static str,
+        mut op: F,
+    ) -> Result<T, E>
+    where
+        E: RetriableError + std::fmt::Debug,
+        F: FnMut(SuiGrpcClient) -> Fut,
+        Fut: std::future::Future<Output = Result<T, E>>,
+    {
+        let hist = self.request_duration_millis.clone();
+        sui_rpc_with_retries(
+            &self.rpc_retry_config,
+            method,
+            || op(self.sui_grpc_client.clone()),
+            move |status, duration_ms| {
+                if let Some(h) = hist.as_ref() {
+                    h.with_label_values(&[method, status]).observe(duration_ms);
+                }
+            },
+        )
+        .await
     }
 
     /// Simulates a transaction block via gRPC.
@@ -216,77 +249,162 @@ impl SuiRpcClient {
         &self,
         tx_data: TransactionData,
     ) -> RpcResult<SimulateTransactionResponse> {
-        sui_rpc_with_retries(
-            &self.rpc_retry_config,
-            "simulate_transaction",
-            self.metrics.clone(),
-            || {
-                let mut grpc_client = self.sui_grpc_client.clone();
-                let tx_data = tx_data.clone();
-                async move {
-                    let tx_bcs = Bcs::from(
-                        bcs::to_bytes(&tx_data)
-                            .map_err(|e| RpcError::new(format!("BCS encode failed: {e}")))?,
-                    );
-                    let mut transaction = Transaction::default();
-                    transaction.bcs = Some(tx_bcs);
+        self.run_grpc_with_retries("simulate_transaction", |mut grpc_client| {
+            let tx_data = tx_data.clone();
+            async move {
+                let tx_bcs = Bcs::from(
+                    bcs::to_bytes(&tx_data)
+                        .map_err(|e| RpcError::new(&format!("BCS encode failed: {e}")))?,
+                );
+                let mut transaction = Transaction::default();
+                transaction.bcs = Some(tx_bcs);
 
-                    let request =
-                        SimulateTransactionRequest::new(transaction).with_read_mask(FieldMask {
-                            paths: vec![
-                                "transaction.effects.status".to_string(),
-                                "transaction.effects.gas_used".to_string(),
-                            ],
-                        });
+                let request =
+                    SimulateTransactionRequest::new(transaction).with_read_mask(FieldMask {
+                        paths: vec![
+                            "transaction.effects.status".to_string(),
+                            "transaction.effects.gas_used".to_string(),
+                        ],
+                    });
 
-                    let response = grpc_client
-                        .execution_client()
-                        .simulate_transaction(request)
-                        .await
-                        .map(|r| r.into_inner())
-                        .map_err(RpcError::from_grpc)?;
-
-                    Ok(response)
-                }
-            },
-        )
+                grpc_client
+                    .execution_client()
+                    .simulate_transaction(request)
+                    .await
+                    .map(|r| r.into_inner())
+                    .map_err(RpcError::from_grpc)
+            }
+        })
         .await
     }
 
     /// Fetches a Move object via gRPC and deserializes its contents as type T.
     pub async fn get_object<T: serde::de::DeserializeOwned>(
         &self,
-        object_id: ObjectID,
+        object_id: Address,
     ) -> RpcResult<T> {
-        sui_rpc_with_retries(
-            &self.rpc_retry_config,
-            "get_object",
-            self.metrics.clone(),
-            || {
-                let mut grpc_client = self.sui_grpc_client.clone();
-                async move {
-                    let address = Address::new(object_id.into_bytes());
+        self.run_grpc_with_retries("get_object", move |mut grpc| async move {
+            grpc_fetch_object::<T>(&mut grpc, &object_id).await
+        })
+        .await
+    }
 
-                    let mut request = GetObjectRequest::default();
-                    request.object_id = Some(address.to_string());
-                    request.read_mask = Some(FieldMask {
-                        paths: vec!["bcs".to_string()],
-                    });
+    /// Returns true if an object exists.
+    pub async fn object_exists(&self, object_id: Address) -> RpcResult<bool> {
+        self.run_grpc_with_retries("object_exists", move |mut grpc_client| async move {
+            let request = GetObjectRequest::default().with_object_id(object_id.to_string());
 
-                    let response = grpc_client
-                        .ledger_client()
-                        .get_object(request)
-                        .await
-                        .map(|r| r.into_inner())
-                        .map_err(RpcError::from_grpc)?;
+            match grpc_client.ledger_client().get_object(request).await {
+                Ok(_) => Ok(true),
+                Err(status) if status.code() == tonic::Code::NotFound => Ok(false),
+                Err(status) => Err(RpcError::from_grpc(status)),
+            }
+        })
+        .await
+    }
 
-                    let obj = extract_object(response).map_err(|e| RpcError::new(e.to_string()))?;
-                    let move_object = match &obj.data {
-                        Data::Move(m) => m,
-                        _ => return Err(RpcError::new("Object is not a Move struct")),
-                    };
-                    bcs::from_bytes(move_object.contents())
-                        .map_err(|e| RpcError::new(format!("Failed to deserialize contents: {e}")))
+    /// Fetch the on-chain `KeyServerV2` for `ks_obj_id`.
+    pub async fn fetch_key_server_by_id(&self, ks_obj_id: &Address) -> RpcResult<KeyServerV2> {
+        let ks_obj_id = *ks_obj_id;
+        self.run_grpc_with_retries("fetch_key_server_by_id", move |mut grpc| async move {
+            grpc_fetch_key_server_by_id(&mut grpc, &ks_obj_id).await
+        })
+        .await
+    }
+
+    /// Fetch the on-chain `KeyServerV2` and extract the committee `(threshold, members)`
+    /// in one call.
+    pub async fn fetch_committee_info(
+        &self,
+        ks_obj_id: &Address,
+    ) -> RpcResult<(u16, Vec<PartialKeyServer>)> {
+        let key_server_v2 = self.fetch_key_server_by_id(ks_obj_id).await?;
+        key_server_v2
+            .extract_committee_info()
+            .map_err(|e| RpcError::new(&e.to_string()))
+    }
+
+    /// Fetch the committee server version for the on-chain `KeyServerV2` at `ks_obj_id`.
+    pub async fn fetch_committee_server_version(&self, ks_obj_id: &Address) -> RpcResult<u32> {
+        match self.fetch_key_server_by_id(ks_obj_id).await?.server_type {
+            ServerType::Committee { version, .. } => Ok(version),
+            _ => Err(RpcError::new("KeyServer is not of type Committee")),
+        }
+    }
+
+    /// Fetch the partial key server info for `member_address` from the committee
+    /// rooted at `key_server_obj_id`.
+    pub async fn fetch_partial_key_server_for_member(
+        &self,
+        key_server_obj_id: &Address,
+        member_address: &Address,
+    ) -> RpcResult<PartialKeyServerInfo> {
+        let (committee_id, _) = self
+            .fetch_committee_from_key_server(key_server_obj_id)
+            .await?;
+        let ks = self.fetch_key_server_by_id(key_server_obj_id).await?;
+        let committee: SealCommittee = self.get_object(committee_id).await?;
+        let partials = ks
+            .to_partial_key_servers(&committee.members)
+            .map_err(|e| RpcError::new(&e.to_string()))?;
+        partials.get(member_address).cloned().ok_or_else(|| {
+            RpcError::new(&format!(
+                "PartialKeyServerInfo not found for member {member_address}"
+            ))
+        })
+    }
+
+    /// Fetch (committee_id, package_id) for the on-chain `KeyServer` at `ks_obj_id`.
+    pub async fn fetch_committee_from_key_server(
+        &self,
+        ks_obj_id: &Address,
+    ) -> RpcResult<(Address, Address)> {
+        let ks_obj_id = *ks_obj_id;
+        self.run_grpc_with_retries(
+            "fetch_committee_from_key_server",
+            move |mut grpc| async move {
+                let (committee_id, pkg_id) =
+                    grpc_fetch_committee_from_key_server(&mut grpc, &ks_obj_id).await?;
+                Ok((committee_id, Address::new(pkg_id.into_bytes())))
+            },
+        )
+        .await
+    }
+
+    /// Fetch the active upgrade proposal from the committee's UpgradeManager DOF.
+    pub async fn fetch_upgrade_proposal(
+        &self,
+        committee_id: &Address,
+    ) -> RpcResult<Option<UpgradeProposal>> {
+        let committee_id = *committee_id;
+        self.run_grpc_with_retries("fetch_upgrade_proposal", move |mut grpc| async move {
+            grpc_fetch_upgrade_proposal(&mut grpc, &committee_id).await
+        })
+        .await
+    }
+
+    /// Fetches a package object and returns its original package id.
+    pub async fn fetch_package_original_id(&self, package_id: Address) -> RpcResult<Address> {
+        self.run_grpc_with_retries(
+            "fetch_package_original_id",
+            move |mut grpc_client| async move {
+                let mut request = GetObjectRequest::default();
+                request.object_id = Some(package_id.to_string());
+                request.read_mask = Some(FieldMask {
+                    paths: vec!["bcs".to_string()],
+                });
+
+                let response = grpc_client
+                    .ledger_client()
+                    .get_object(request)
+                    .await
+                    .map(|r| r.into_inner())
+                    .map_err(RpcError::from_grpc)?;
+
+                let obj = extract_object(response).map_err(|_| RpcError::new("Invalid package"))?;
+                match &obj.data {
+                    Data::Package(p) => Ok(Address::new(p.original_package_id().into_bytes())),
+                    _ => Err(RpcError::new("Invalid package")),
                 }
             },
         )
@@ -295,35 +413,25 @@ impl SuiRpcClient {
 
     /// Returns the current reference gas price via gRPC.
     pub async fn get_reference_gas_price(&self) -> RpcResult<u64> {
-        sui_rpc_with_retries(
-            &self.rpc_retry_config,
-            "get_reference_gas_price",
-            self.metrics.clone(),
-            || {
-                let mut grpc_client = self.sui_grpc_client.clone();
-                async move {
-                    let mut client = grpc_client.ledger_client();
-                    let mut request = GetEpochRequest::default();
-                    request.read_mask = Some(FieldMask {
-                        paths: vec!["reference_gas_price".to_string()],
-                    });
-                    client
-                        .get_epoch(request)
-                        .await
-                        .map(|r| r.into_inner().epoch().reference_gas_price())
-                        .map_err(RpcError::from_grpc)
-                }
-            },
-        )
+        self.run_grpc_with_retries("get_reference_gas_price", |mut grpc_client| async move {
+            let mut client = grpc_client.ledger_client();
+            let mut request = GetEpochRequest::default();
+            request.read_mask = Some(FieldMask {
+                paths: vec!["reference_gas_price".to_string()],
+            });
+            client
+                .get_epoch(request)
+                .await
+                .map(|r| r.into_inner().epoch().reference_gas_price())
+                .map_err(RpcError::from_grpc)
+        })
         .await
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::key_server_options::RetryConfig;
-    use crate::sui_rpc_client::sui_rpc_with_retries;
-    use crate::sui_rpc_client::RetriableError;
+    use super::{sui_rpc_with_retries, RetriableError, RetryConfig};
     use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
     use std::time::Duration;
@@ -363,6 +471,8 @@ mod tests {
         }
     }
 
+    fn noop_observer(_status: &'static str, _duration_ms: f64) {}
+
     #[tokio::test]
     async fn test_sui_rpc_with_retries_success_first_attempt() {
         let retry_config = RetryConfig {
@@ -374,14 +484,19 @@ mod tests {
         let counter = Arc::new(AtomicU32::new(0));
         let counter_clone = counter.clone();
 
-        let result = sui_rpc_with_retries(&retry_config, "mock_function", None, || async {
-            mock_function_with_counter(
-                counter_clone.clone(),
-                0, // Don't fail any attempts
-                MockError { is_retriable: true },
-            )
-            .await
-        })
+        let result = sui_rpc_with_retries(
+            &retry_config,
+            "mock_function",
+            || async {
+                mock_function_with_counter(
+                    counter_clone.clone(),
+                    0, // Don't fail any attempts
+                    MockError { is_retriable: true },
+                )
+                .await
+            },
+            noop_observer,
+        )
         .await;
 
         assert!(result.is_ok());
@@ -400,14 +515,19 @@ mod tests {
         let counter = Arc::new(AtomicU32::new(0));
         let counter_clone = counter.clone();
 
-        let result = sui_rpc_with_retries(&retry_config, "mock_function", None, || async {
-            mock_function_with_counter(
-                counter_clone.clone(),
-                2, // Fail first 2 attempts, succeed on 3rd
-                MockError { is_retriable: true },
-            )
-            .await
-        })
+        let result = sui_rpc_with_retries(
+            &retry_config,
+            "mock_function",
+            || async {
+                mock_function_with_counter(
+                    counter_clone.clone(),
+                    2, // Fail first 2 attempts, succeed on 3rd
+                    MockError { is_retriable: true },
+                )
+                .await
+            },
+            noop_observer,
+        )
         .await;
 
         assert!(result.is_ok());
@@ -426,14 +546,19 @@ mod tests {
         let counter = Arc::new(AtomicU32::new(0));
         let counter_clone = counter.clone();
 
-        let result = sui_rpc_with_retries(&retry_config, "mock_function", None, || async {
-            mock_function_with_counter(
-                counter_clone.clone(),
-                10, // Fail more attempts than max_retries
-                MockError { is_retriable: true },
-            )
-            .await
-        })
+        let result = sui_rpc_with_retries(
+            &retry_config,
+            "mock_function",
+            || async {
+                mock_function_with_counter(
+                    counter_clone.clone(),
+                    10, // Fail more attempts than max_retries
+                    MockError { is_retriable: true },
+                )
+                .await
+            },
+            noop_observer,
+        )
         .await;
 
         assert!(result.is_err());
@@ -452,16 +577,21 @@ mod tests {
         let counter = Arc::new(AtomicU32::new(0));
         let counter_clone = counter.clone();
 
-        let result = sui_rpc_with_retries(&retry_config, "mock_function", None, || async {
-            mock_function_with_counter(
-                counter_clone.clone(),
-                10, // Fail more attempts than max_retries
-                MockError {
-                    is_retriable: false,
-                }, // Non-retriable error
-            )
-            .await
-        })
+        let result = sui_rpc_with_retries(
+            &retry_config,
+            "mock_function",
+            || async {
+                mock_function_with_counter(
+                    counter_clone.clone(),
+                    10, // Fail more attempts than max_retries
+                    MockError {
+                        is_retriable: false,
+                    }, // Non-retriable error
+                )
+                .await
+            },
+            noop_observer,
+        )
         .await;
 
         assert!(result.is_err());
@@ -480,14 +610,19 @@ mod tests {
         let counter = Arc::new(AtomicU32::new(0));
         let counter_clone = counter.clone();
 
-        let result = sui_rpc_with_retries(&retry_config, "mock_function", None, || async {
-            mock_function_with_counter(
-                counter_clone.clone(),
-                10, // Always fail
-                MockError { is_retriable: true },
-            )
-            .await
-        })
+        let result = sui_rpc_with_retries(
+            &retry_config,
+            "mock_function",
+            || async {
+                mock_function_with_counter(
+                    counter_clone.clone(),
+                    10, // Always fail
+                    MockError { is_retriable: true },
+                )
+                .await
+            },
+            noop_observer,
+        )
         .await;
 
         assert!(result.is_err());
@@ -507,14 +642,19 @@ mod tests {
 
         let start_time = std::time::Instant::now();
 
-        let result = sui_rpc_with_retries(&retry_config, "mock_function", None, || async {
-            mock_function_with_counter(
-                counter_clone.clone(),
-                5, // Fail first 5 attempts, succeed on 6th
-                MockError { is_retriable: true },
-            )
-            .await
-        })
+        let result = sui_rpc_with_retries(
+            &retry_config,
+            "mock_function",
+            || async {
+                mock_function_with_counter(
+                    counter_clone.clone(),
+                    5, // Fail first 5 attempts, succeed on 6th
+                    MockError { is_retriable: true },
+                )
+                .await
+            },
+            noop_observer,
+        )
         .await;
 
         let elapsed = start_time.elapsed();

--- a/crates/key-server/src/tests/mod.rs
+++ b/crates/key-server/src/tests/mod.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::externals::{add_package, add_upgraded_package};
-use crate::key_server_options::{KeyServerOptions, RetryConfig, RpcConfig, ServerMode};
+use crate::key_server_options::{KeyServerOptions, RpcConfig, ServerMode};
 use crate::master_keys::MasterKeys;
-use crate::sui_rpc_client::SuiRpcClient;
 use crate::tests::KeyServerType::Open;
 use crate::time::from_mins;
 use crate::types::Network;
@@ -14,6 +13,8 @@ use crypto::ibe::public_key_from_master_key;
 use fastcrypto::ed25519::Ed25519KeyPair;
 use fastcrypto::encoding::Encoding;
 use fastcrypto::serde_helpers::ToFromByteArray;
+use key_server::sui_rpc_client::RetryConfig;
+use key_server::sui_rpc_client::SuiRpcClient;
 use move_package_alt::PackageLoader;
 use rand::thread_rng;
 use seal_committee::grpc_helper::fetch_key_server_by_id;

--- a/crates/key-server/src/tests/test_utils.rs
+++ b/crates/key-server/src/tests/test_utils.rs
@@ -2,16 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    key_server_options::{
-        ClientConfig, CommitteeState, KeyServerOptions, RetryConfig, RpcConfig, ServerMode,
-    },
+    key_server_options::{ClientConfig, CommitteeState, KeyServerOptions, RpcConfig, ServerMode},
     master_keys::MasterKeys,
-    sui_rpc_client::SuiRpcClient,
     time::from_mins,
     types::Network,
     DefaultEncoding, Server,
 };
 use fastcrypto::encoding::Encoding;
+use key_server::sui_rpc_client::{RetryConfig, SuiRpcClient};
 use semver::VersionReq;
 use std::{
     collections::HashMap,

--- a/crates/seal-committee/Cargo.toml
+++ b/crates/seal-committee/Cargo.toml
@@ -12,6 +12,7 @@ fastcrypto.workspace = true
 fastcrypto-tbls.workspace = true
 prost-types.workspace = true
 serde.workspace = true
+tonic.workspace = true
 
 sui-rpc.workspace = true
 sui-sdk-types.workspace = true

--- a/crates/seal-committee/src/grpc_helper.rs
+++ b/crates/seal-committee/src/grpc_helper.rs
@@ -5,12 +5,12 @@
 
 use crate::{
     move_types::{
-        Field, KeyServerV2, PartialKeyServerInfo, SealCommittee, ServerType, UpgradeManager,
-        UpgradeProposal, Wrapper,
+        Field, KeyServerV2, SealCommittee, ServerType, UpgradeManager, UpgradeProposal, Wrapper,
     },
+    rpc_error::{RpcError, RpcResult},
     Network,
 };
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use std::str::FromStr;
 use sui_rpc::client::Client;
 use sui_rpc::proto::sui::rpc::v2::{GetObjectRequest, GetObjectResponse};
@@ -53,10 +53,10 @@ pub fn extract_object(response: GetObjectResponse) -> Result<Object> {
     Ok(bcs::from_bytes(&bcs_bytes)?)
 }
 
-async fn fetch_object<T: serde::de::DeserializeOwned>(
+pub async fn fetch_object<T: serde::de::DeserializeOwned>(
     grpc_client: &mut Client,
     object_id: &Address,
-) -> Result<T> {
+) -> RpcResult<T> {
     let mut request = GetObjectRequest::default();
     request.object_id = Some(object_id.to_string());
     request.read_mask = Some(prost_types::FieldMask {
@@ -67,21 +67,23 @@ async fn fetch_object<T: serde::de::DeserializeOwned>(
         .ledger_client()
         .get_object(request)
         .await
-        .map(|r| r.into_inner())?;
+        .map(|r| r.into_inner())
+        .map_err(RpcError::from_grpc)?;
 
-    let obj = extract_object(response)?;
+    let obj = extract_object(response).map_err(|e| RpcError::new(&e.to_string()))?;
     let move_object = match &obj.data {
         Data::Move(m) => m,
-        _ => bail!("Object is not a Move struct"),
+        _ => return Err(RpcError::new("Object is not a Move struct")),
     };
-    Ok(bcs::from_bytes(move_object.contents())?)
+    bcs::from_bytes(move_object.contents())
+        .map_err(|e| RpcError::new(&format!("Failed to deserialize contents: {e}")))
 }
 
 /// Fetch seal Committee object onchain.
 pub async fn fetch_committee_data(
     grpc_client: &mut Client,
     committee_id: &Address,
-) -> Result<SealCommittee> {
+) -> RpcResult<SealCommittee> {
     fetch_object(grpc_client, committee_id).await
 }
 
@@ -90,7 +92,7 @@ pub async fn fetch_committee_data(
 pub async fn fetch_key_server_by_id(
     grpc_client: &mut Client,
     ks_obj_id: &Address,
-) -> Result<KeyServerV2> {
+) -> RpcResult<KeyServerV2> {
     // Derive KeyServerV2 dynamic field ID on KeyServer object.
     // This is a regular dynamic_field, not dynamic_object_field.
     // Key type: u64, Key value: EXPECTED_KEY_SERVER_VERSION
@@ -104,28 +106,18 @@ pub async fn fetch_key_server_by_id(
     Ok(field.value)
 }
 
-pub async fn fetch_committee_server_version(
-    grpc_client: &mut Client,
-    ks_obj_id: &Address,
-) -> Result<u32> {
-    let key_server_v2 = fetch_key_server_by_id(grpc_client, ks_obj_id).await?;
-    match key_server_v2.server_type {
-        ServerType::Committee { version, .. } => Ok(version),
-        _ => Err(anyhow!("KeyServer is not of type Committee")),
-    }
-}
-
 /// Fetch the KeyServer object and KeyServerV2 data for a given committee.
 /// Returns the KeyServer object ID and the KeyServerV2 data.
+// TODO: use batch get objects from grpc
 pub async fn fetch_key_server_by_committee(
     grpc_client: &mut Client,
     committee_id: &Address,
-) -> Result<(Address, KeyServerV2)> {
+) -> RpcResult<(Address, KeyServerV2)> {
     // Derive dynamic object field wrapper id.
     let wrapper_key = Wrapper {
         name: *committee_id,
     };
-    let wrapper_key_bcs = bcs::to_bytes(&wrapper_key)?;
+    let wrapper_key_bcs = bcs::to_bytes(&wrapper_key).map_err(|e| RpcError::new(&e.to_string()))?;
 
     let wrapper_type_tag = TypeTag::Struct(Box::new(StructTag::new(
         Address::TWO,
@@ -151,52 +143,13 @@ pub async fn fetch_key_server_by_committee(
     Ok((ks_obj_id, key_server_v2))
 }
 
-/// Fetch partial key server information for a specific committee member from onchain KeyServer object.
-/// Returns the PartialKeyServerInfo for the specified member address.
-pub async fn get_partial_key_server_for_member(
-    grpc_client: &mut Client,
-    key_server_obj_id: &Address,
-    committee_id: &Address,
-    member_address: &Address,
-) -> Result<PartialKeyServerInfo> {
-    let ks = fetch_key_server_by_id(grpc_client, key_server_obj_id).await?;
-    let committee = fetch_committee_data(grpc_client, committee_id).await?;
-    let partial_key_servers = ks.to_partial_key_servers(&committee.members)?;
-
-    partial_key_servers
-        .get(member_address)
-        .cloned()
-        .ok_or_else(|| {
-            anyhow!(
-                "PartialKeyServerInfo not found for member {}",
-                member_address
-            )
-        })
-}
-
-/// Fetch partial key server information for a specific committee member from onchain KeyServer
-/// object. This first resolves the current committee from the KeyServer object.
-pub async fn fetch_partial_key_server_for_member(
-    grpc_client: &mut Client,
-    key_server_obj_id: &Address,
-    member_address: &Address,
-) -> Result<PartialKeyServerInfo> {
-    let (committee_id, _) = fetch_committee_from_key_server(grpc_client, key_server_obj_id).await?;
-    get_partial_key_server_for_member(
-        grpc_client,
-        key_server_obj_id,
-        &committee_id,
-        member_address,
-    )
-    .await
-}
-
 /// Fetch committee ID and package ID from a key server object ID.
 /// Returns (committee_id, package_id).
+// TODO: use batch get objects
 pub async fn fetch_committee_from_key_server(
     grpc_client: &mut Client,
     key_server_obj_id: &Address,
-) -> Result<(Address, ObjectID)> {
+) -> RpcResult<(Address, ObjectID)> {
     // Fetch key server object to get owner (field wrapper).
     let field_wrapper_id = {
         let mut ledger_client = grpc_client.ledger_client();
@@ -209,22 +162,23 @@ pub async fn fetch_committee_from_key_server(
         let ks_response = ledger_client
             .get_object(ks_request)
             .await
-            .map(|r| r.into_inner())?;
+            .map(|r| r.into_inner())
+            .map_err(RpcError::from_grpc)?;
 
         let ks_object = ks_response
             .object
-            .ok_or_else(|| anyhow!("Key server object not found"))?;
+            .ok_or_else(|| RpcError::new("Key server object not found"))?;
 
         // Parse owner to get field wrapper ID.
         let owner_data = ks_object
             .owner
-            .ok_or_else(|| anyhow!("Key server object has no owner"))?;
+            .ok_or_else(|| RpcError::new("Key server object has no owner"))?;
 
         let owner_address = owner_data
             .address
-            .ok_or_else(|| anyhow!("Owner has no address"))?;
+            .ok_or_else(|| RpcError::new("Owner has no address"))?;
 
-        Address::from_str(&owner_address)?
+        Address::from_str(&owner_address).map_err(|e| RpcError::new(&e.to_string()))?
     };
 
     // Fetch field wrapper to extract committee ID.
@@ -243,17 +197,19 @@ pub async fn fetch_committee_from_key_server(
     let committee_response = ledger_client
         .get_object(committee_request)
         .await
-        .map(|r| r.into_inner())?;
+        .map(|r| r.into_inner())
+        .map_err(RpcError::from_grpc)?;
 
     let committee_object = committee_response
         .object
-        .ok_or_else(|| anyhow!("Committee object not found"))?;
+        .ok_or_else(|| RpcError::new("Committee object not found"))?;
 
     let committee_type = committee_object
         .object_type
-        .ok_or_else(|| anyhow!("Committee has no type"))?;
+        .ok_or_else(|| RpcError::new("Committee has no type"))?;
 
-    let committee_struct_tag = StructTag::from_str(&committee_type)?;
+    let committee_struct_tag =
+        StructTag::from_str(&committee_type).map_err(|e| RpcError::new(&e.to_string()))?;
     let package_id = ObjectID::new(committee_struct_tag.address().into_inner());
 
     Ok((committee_id, package_id))
@@ -264,16 +220,17 @@ pub async fn fetch_committee_from_key_server(
 pub async fn fetch_upgrade_proposal(
     grpc_client: &mut Client,
     committee_id: &Address,
-) -> Result<Option<UpgradeProposal>> {
+) -> RpcResult<Option<UpgradeProposal>> {
     let upgrade_manager = fetch_upgrade_manager(grpc_client, committee_id).await?;
     Ok(upgrade_manager.upgrade_proposal)
 }
 
 /// Fetch the full UpgradeManager from the committee's UpgradeManager DOF.
+// TODO: use batch get objects
 pub async fn fetch_upgrade_manager(
     grpc_client: &mut Client,
     committee_id: &Address,
-) -> Result<UpgradeManager> {
+) -> RpcResult<UpgradeManager> {
     use std::str::FromStr;
 
     // First, we need to get the committee package address to construct the correct type tag.
@@ -287,20 +244,22 @@ pub async fn fetch_upgrade_manager(
     let committee_response = ledger_client
         .get_object(committee_request)
         .await
-        .map(|r| r.into_inner())?;
+        .map(|r| r.into_inner())
+        .map_err(RpcError::from_grpc)?;
 
     let object_type = committee_response
         .object
         .and_then(|obj| obj.object_type)
-        .ok_or_else(|| anyhow!("Committee object has no type"))?;
+        .ok_or_else(|| RpcError::new("Committee object has no type"))?;
 
-    let struct_tag = StructTag::from_str(&object_type)?;
+    let struct_tag =
+        StructTag::from_str(&object_type).map_err(|e| RpcError::new(&e.to_string()))?;
     let committee_pkg_addr = struct_tag.address();
 
     let wrapper_key = Wrapper {
         name: UpgradeManagerKey { dummy_field: false },
     };
-    let wrapper_key_bcs = bcs::to_bytes(&wrapper_key)?;
+    let wrapper_key_bcs = bcs::to_bytes(&wrapper_key).map_err(|e| RpcError::new(&e.to_string()))?;
 
     // The type tag for Wrapper<UpgradeManagerKey>.
     let wrapper_type_tag = TypeTag::Struct(Box::new(StructTag::new(
@@ -336,32 +295,24 @@ pub async fn fetch_upgrade_manager(
 pub async fn get_committee_rotation_info(
     grpc_client: &mut Client,
     committee_id: &Address,
-) -> Result<(u32, Option<Vec<u8>>)> {
+) -> RpcResult<(u32, Option<Vec<u8>>)> {
     let committee = fetch_committee_data(grpc_client, committee_id).await?;
 
     if let Some(old_committee_id) = committee.old_committee_id {
         // Rotation: fetch the old committee's KeyServer version then increment by 1.
-        match fetch_key_server_by_committee(grpc_client, &old_committee_id).await {
-            Ok((_, key_server_v2)) => {
-                let pk = key_server_v2.pk;
-                match key_server_v2.server_type {
-                    ServerType::Committee { version, .. } => {
-                        println!(
-                            "Old committee version: {}, new version will be: {}",
-                            version,
-                            version + 1
-                        );
-                        Ok((version + 1, Some(pk)))
-                    }
-                    _ => bail!("Old KeyServer is not of type Committee"),
-                }
-            }
-            Err(e) => {
-                bail!(
-                    "Failed to fetch old committee's KeyServer for rotation: {}",
-                    e
+        let (_, key_server_v2) =
+            fetch_key_server_by_committee(grpc_client, &old_committee_id).await?;
+        let pk = key_server_v2.pk;
+        match key_server_v2.server_type {
+            ServerType::Committee { version, .. } => {
+                println!(
+                    "Old committee version: {}, new version will be: {}",
+                    version,
+                    version + 1
                 );
+                Ok((version + 1, Some(pk)))
             }
+            _ => Err(RpcError::new("Old KeyServer is not of type Committee")),
         }
     } else {
         Ok((0, None))

--- a/crates/seal-committee/src/lib.rs
+++ b/crates/seal-committee/src/lib.rs
@@ -3,6 +3,7 @@
 
 pub mod grpc_helper;
 pub mod move_types;
+pub mod rpc_error;
 pub mod types;
 pub mod utils;
 
@@ -16,5 +17,6 @@ pub use move_types::{
     PartialKeyServerInfo, SealCommittee, ServerType, UidWrapper, UpgradeManager, UpgradeProposal,
     UpgradeVote, VecMap, Wrapper,
 };
+pub use rpc_error::{RpcError, RpcResult};
 pub use types::Network;
 pub use utils::build_new_to_old_map;

--- a/crates/seal-committee/src/rpc_error.rs
+++ b/crates/seal-committee/src/rpc_error.rs
@@ -1,0 +1,45 @@
+// Copyright (c), Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Result type for Sui gRPC operations.
+pub type RpcResult<T> = Result<T, RpcError>;
+
+/// Error type for Sui gRPC operations.
+///
+/// `code` is populated only for errors returned by tonic. Local post-processing
+/// failures (missing BCS, decode errors, unexpected object shape) are
+/// deterministic and keep `code` empty.
+#[derive(Debug)]
+pub struct RpcError {
+    pub message: String,
+    pub code: Option<tonic::Code>,
+}
+
+impl RpcError {
+    /// Build from a gRPC status; produces `code: Some(...)`.
+    pub fn from_grpc(status: tonic::Status) -> Self {
+        Self {
+            message: status.message().to_string(),
+            code: Some(status.code()),
+        }
+    }
+
+    /// Build a local post-processing failure; produces `code: None`.
+    pub fn new(message: &str) -> Self {
+        Self {
+            message: message.to_string(),
+            code: None,
+        }
+    }
+}
+
+impl std::fmt::Display for RpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.code {
+            Some(code) => write!(f, "gRPC {code}: {}", self.message),
+            None => write!(f, "{}", self.message),
+        }
+    }
+}
+
+impl std::error::Error for RpcError {}


### PR DESCRIPTION
## Description 

make SuiRpcClient a shared infra for key server and aggregator binaries. so all grpc calls all go through retry and metrics observe. (previously aggregator uses a raw grpc client without any retry logic, metrics was also captured adhoc per call sit)

this makes the future json rpc client deprecation a minimal change. since all calls goes through SuiRpcClient.grpc_client(), we just need to remove SuiRpcClient.sui_client() and its associated event polling call. 


## Test plan 

How did you test the new or updated feature?