### PR TITLE
[cli] add ds for signing, add logs, fix custom network path

### DIFF
--- a/crates/key-server/src/aggregator/server.rs
+++ b/crates/key-server/src/aggregator/server.rs
@@ -352,7 +352,7 @@ async fn handle_fetch_key(
     let expected_full_ids_owned = get_expected_full_ids(&state.sui_rpc_client, &request.ptb)
         .await
         .inspect_err(|e| {
-            warn!(
+            debug!(
                 "Aggregator failed to resolve expected full ids (req_id: {}, error_type: {}, error: {:?})",
                 req_id,
                 e.as_str(),
@@ -488,7 +488,7 @@ async fn handle_fetch_key(
         let response_count = responses.len();
         let error_count = errors.len();
         let err = handle_insufficient_responses(responses.len(), threshold as usize, errors);
-        warn!(
+        debug!(
             "Aggregator failed to collect threshold responses (req_id: {}, responses: {}, errors: {}, completed: {}, committee_size: {}, threshold: {}, error_type: {}, message: {})",
             req_id,
             response_count,

--- a/crates/key-server/src/aggregator/server.rs
+++ b/crates/key-server/src/aggregator/server.rs
@@ -352,6 +352,12 @@ async fn handle_fetch_key(
     let expected_full_ids_owned = get_expected_full_ids(&state.sui_rpc_client, &request.ptb)
         .await
         .inspect_err(|e| {
+            warn!(
+                "Aggregator failed to resolve expected full ids (req_id: {}, error_type: {}, error: {:?})",
+                req_id,
+                e.as_str(),
+                e
+            );
             state.aggregator_metrics.observe_error(e.as_str());
         })?;
     state
@@ -360,6 +366,11 @@ async fn handle_fetch_key(
         .observe(expected_full_ids_owned.len() as f64);
     if expected_full_ids_owned.is_empty() {
         let err = InternalError::InvalidPTB("Empty key ids".to_string());
+        debug!(
+            "Aggregator request resolved no expected full ids (req_id: {}, error_type: {})",
+            req_id,
+            err.as_str()
+        );
         state.aggregator_metrics.observe_error(err.as_str());
         return Err(err.into());
     }
@@ -422,8 +433,8 @@ async fn handle_fetch_key(
                     Err(e) => {
                         metrics.observe_upstream_error(&partial_key_server.name, &e.error);
                         debug!(
-                            "Failed to fetch from party_id={}, url={}: {:?}",
-                            partial_key_server.party_id, partial_key_server.url, e
+                            "Failed to fetch from party_id={}, url={}, req_id={}: {:?},",
+                            partial_key_server.party_id, partial_key_server.url, req_id, e
                         );
                         Err(e)
                     }
@@ -474,7 +485,20 @@ async fn handle_fetch_key(
 
     // If not enough responses, return majority error from key servers.
     if responses.len() < threshold as usize {
+        let response_count = responses.len();
+        let error_count = errors.len();
         let err = handle_insufficient_responses(responses.len(), threshold as usize, errors);
+        warn!(
+            "Aggregator failed to collect threshold responses (req_id: {}, responses: {}, errors: {}, completed: {}, committee_size: {}, threshold: {}, error_type: {}, message: {})",
+            req_id,
+            response_count,
+            error_count,
+            completed,
+            committee_size,
+            threshold,
+            err.error,
+            err.message
+        );
         state.aggregator_metrics.observe_error(&err.error);
         return Err(err);
     }

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -990,7 +990,7 @@ async fn handle_fetch_key_internal(
             match r {
                 Ok(_) => info!("Valid request: {request_info}"),
                 Err(InternalError::Failure(s)) => warn!("Check request failed with debug message '{s}': {request_info}"),
-                _ => {},
+                Err(e) => debug!("Check request failed with error {e:?}: {request_info}"),
             }
         })
 }

--- a/crates/seal-cli/src/main.rs
+++ b/crates/seal-cli/src/main.rs
@@ -30,24 +30,6 @@ use sui_types::TypeTag;
 
 const KEY_LENGTH: usize = 32;
 
-/// Get RPC URL for a network with optional custom URL override.
-fn get_rpc_url(
-    network: &Network,
-    custom_rpc_url: Option<String>,
-) -> Result<String, FastCryptoError> {
-    match custom_rpc_url {
-        Some(url) => Ok(url),
-        None => network
-            .default_rpc_url()
-            .map(|s| s.to_string())
-            .ok_or_else(|| {
-                FastCryptoError::GeneralError(
-                    "Custom network requires explicit RPC URL".to_string(),
-                )
-            }),
-    }
-}
-
 /// Key server object layout containing object id, name, url, and public key.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct KeyServerInfo {
@@ -64,7 +46,7 @@ pub async fn fetch_key_server_urls(
     key_server_ids: &[ObjectID],
     custom_rpc_url: Option<String>,
 ) -> Result<Vec<KeyServerInfo>, FastCryptoError> {
-    let sui_rpc = get_rpc_url(network, custom_rpc_url)?;
+    let sui_rpc = custom_rpc_url.unwrap_or_else(|| network.default_rpc_url().to_string());
     let sui_client = SuiClientBuilder::default()
         .build(sui_rpc)
         .await
@@ -351,11 +333,11 @@ enum Command {
         #[arg(short = 't', long)]
         threshold: u8,
 
-        /// Network (mainnet, testnet or custom)
+        /// Network (mainnet or testnet)
         #[arg(short = 'n', long, default_value = "testnet")]
         network: Network,
 
-        /// Custom RPC URL to use instead of the default network URL
+        /// RPC URL override.
         #[arg(long)]
         rpc_url: Option<String>,
     },
@@ -373,11 +355,11 @@ enum Command {
         #[arg(short = 't', long)]
         threshold: u8,
 
-        /// Network (mainnet, testnet or custom)
+        /// Network (mainnet or testnet)
         #[arg(short = 'n', long, default_value = "testnet")]
         network: Network,
 
-        /// Custom RPC URL to use instead of the default network URL
+        /// RPC URL override.
         #[arg(long)]
         rpc_url: Option<String>,
     },

--- a/crates/seal-committee-cli/dkg-rotation.example.yaml
+++ b/crates/seal-committee-cli/dkg-rotation.example.yaml
@@ -5,8 +5,8 @@
 # Initial Parameters - Created by coordinator before running init-rotation
 # ============================================================================
 init-params:
-  NETWORK: Testnet  # "Testnet", "Mainnet", or "Custom"
-  # NODE_URL: https://fullnode.testnet.sui.io:443  # Optional: custom RPC URL (required for "Custom" network)
+  NETWORK: Testnet  # "Testnet" or "Mainnet"
+  # NODE_URL: https://fullnode.testnet.sui.io:443  # Optional RPC URL override.
   THRESHOLD: 3  # New threshold for rotated committee
   MEMBERS:  # New committee members (can include continuing members)
     - 0x0ceffe3ba385abe7a11f535e3428ae2ff4508eb4b6d370b829318b0d901c1152

--- a/crates/seal-committee-cli/dkg.example.yaml
+++ b/crates/seal-committee-cli/dkg.example.yaml
@@ -5,8 +5,8 @@
 # Initial Parameters - Created by coordinator before running commands
 # ============================================================================
 init-params:
-  NETWORK: Testnet  # "Testnet", "Mainnet", or "Custom"
-  # NODE_URL: https://fullnode.testnet.sui.io:443  # Optional: custom RPC URL (required for "Custom" network)
+  NETWORK: Testnet  # "Testnet" or "Mainnet"
+  # NODE_URL: https://fullnode.testnet.sui.io:443  # Optional RPC URL override.
   THRESHOLD: 2
   MEMBERS:
     - 0x0ceffe3ba385abe7a11f535e3428ae2ff4508eb4b6d370b829318b0d901c1152

--- a/crates/seal-committee-cli/src/main.rs
+++ b/crates/seal-committee-cli/src/main.rs
@@ -840,7 +840,12 @@ async fn main() -> Result<()> {
             }
 
             // Load wallet.
-            let wallet = load_wallet(cli.wallet.as_deref(), cli.active_address)?;
+            let wallet = load_wallet_for_network(
+                cli.wallet.as_deref(),
+                cli.active_address,
+                &network,
+                node_url.as_deref(),
+            )?;
 
             if is_rotation {
                 println!("\n=== Proposing committee rotation onchain ===");
@@ -1053,16 +1058,12 @@ async fn main() -> Result<()> {
             rpc_url,
         } => {
             let wallet = if matches!(network, Network::Custom) {
-                let wallet = if let Some(rpc_url) = rpc_url.as_deref() {
-                    load_wallet_for_network(
-                        cli.wallet.as_deref(),
-                        cli.active_address,
-                        &network,
-                        Some(rpc_url),
-                    )?
-                } else {
-                    load_wallet(cli.wallet.as_deref(), cli.active_address)?
-                };
+                let wallet = load_wallet_for_network(
+                    cli.wallet.as_deref(),
+                    cli.active_address,
+                    &network,
+                    rpc_url.as_deref(),
+                )?;
                 let wallet_env = wallet.get_active_env()?;
                 println!("Network: custom");
                 println!(
@@ -1241,7 +1242,12 @@ async fn main() -> Result<()> {
             rpc_url,
         } => {
             // Load wallet.
-            let mut wallet = load_wallet(cli.wallet.as_deref(), cli.active_address)?;
+            let mut wallet = load_wallet_for_network(
+                cli.wallet.as_deref(),
+                cli.active_address,
+                &network,
+                rpc_url.as_deref(),
+            )?;
             let member_address = wallet.active_address()?;
 
             println!("Member address: {}", member_address);
@@ -1840,14 +1846,14 @@ fn load_wallet_for_network(
                 if let Some(alias) = matching_env {
                     alias
                 } else {
-                    // No alias found for the dkg.yaml URL, create a new one with sui cli.
+                    // No alias found for the provided URL, create a new one with sui cli.
                     bail!(
                         "Custom RPC URL {} not found in wallet config, add it first. e.g. 'sui client new-env --alias my-custom-devnet --rpc https://my-custom-rpc.example.com:443'",
                         url
                     );
                 }
             } else {
-                bail!("Custom network specified but no NODE_URL provided in config");
+                bail!("Custom network specified but no RPC URL provided");
             }
         }
     };
@@ -2331,8 +2337,7 @@ async fn create_build_config(
         Network::Custom => {
             let wallet = wallet.ok_or_else(|| {
                 anyhow!(
-                    "Custom network package builds require a wallet environment; pass --rpc-url \
-                    or switch the active wallet environment to the custom network"
+                    "Custom network package builds require a wallet environment; pass --rpc-url"
                 )
             })?;
             find_environment(package_path, None, wallet, for_publication)

--- a/crates/seal-committee-cli/src/main.rs
+++ b/crates/seal-committee-cli/src/main.rs
@@ -18,7 +18,7 @@ use fastcrypto_tbls::random_oracle::RandomOracle;
 use move_package_alt_compilation::build_config::BuildConfig as MoveBuildConfig;
 use rand::thread_rng;
 use seal_committee::{
-    build_new_to_old_map, create_grpc_client_with_url, fetch_committee_data,
+    build_new_to_old_map, create_grpc_client_from_config, fetch_committee_data,
     fetch_committee_from_key_server, fetch_key_server_by_committee, fetch_upgrade_manager,
     fetch_upgrade_proposal, get_committee_rotation_info, CommitteeState, KeyServerV2, Network,
     ServerType, UpgradeVote,
@@ -31,9 +31,8 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use sui_keys::keystore::{AccountKeystore, GenerateOptions};
 use sui_move_build::BuildConfig;
-use sui_package_alt::{find_environment, mainnet_environment, testnet_environment};
+use sui_package_alt::{mainnet_environment, testnet_environment};
 use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
-use sui_rpc::Client;
 use sui_rpc_api::client::ExecutedTransaction;
 use sui_sdk::wallet_context::WalletContext;
 use sui_sdk_types::Address;
@@ -66,7 +65,6 @@ fn package_ops_budget(gas_budget: Option<u64>, network: &Network) -> u64 {
     gas_budget.unwrap_or(match network {
         Network::Testnet => gas_defaults::PACKAGE_OPS_TESTNET,
         Network::Mainnet => gas_defaults::PACKAGE_OPS_MAINNET,
-        Network::Custom => gas_defaults::PACKAGE_OPS_TESTNET,
     })
 }
 
@@ -74,7 +72,6 @@ fn regular_gas_budget(gas_budget: Option<u64>, network: &Network) -> u64 {
     gas_budget.unwrap_or(match network {
         Network::Testnet => gas_defaults::REGULAR_TESTNET,
         Network::Mainnet => gas_defaults::REGULAR_MAINNET,
-        Network::Custom => gas_defaults::REGULAR_TESTNET,
     })
 }
 
@@ -177,10 +174,6 @@ enum Commands {
         /// Network to build for.
         #[arg(short, long)]
         network: Network,
-
-        /// Custom RPC URL to use for resolving the package environment. For custom networks, it must match an existing wallet environment RPC; add one with `sui client new-env --alias <name> --rpc <url>`.
-        #[arg(long)]
-        rpc_url: Option<String>,
     },
 
     /// Approve package upgrade (as committee member).
@@ -197,7 +190,7 @@ enum Commands {
         #[arg(short, long)]
         network: Network,
 
-        /// Custom RPC URL to use instead of the default network URL. For custom networks, it must match an existing wallet environment RPC; add one with `sui client new-env --alias <name> --rpc <url>`.
+        /// RPC URL override. If set, this URL must exist as a Sui wallet env, to add, use `sui client new-env --alias <name> --rpc <url>`.
         #[arg(long)]
         rpc_url: Option<String>,
     },
@@ -212,7 +205,7 @@ enum Commands {
         #[arg(short, long)]
         network: Network,
 
-        /// Custom RPC URL to use instead of the default network URL. For custom networks, it must match an existing wallet environment RPC; add one with `sui client new-env --alias <name> --rpc <url>`.
+        /// RPC URL override. If set, this URL must exist as a Sui wallet env, to add, use `sui client new-env --alias <name> --rpc <url>`.
         #[arg(long)]
         rpc_url: Option<String>,
     },
@@ -231,7 +224,7 @@ enum Commands {
         #[arg(short, long)]
         network: Network,
 
-        /// Custom RPC URL to use instead of the default network URL. For custom networks, it must match an existing wallet environment RPC; add one with `sui client new-env --alias <name> --rpc <url>`.
+        /// RPC URL override. If set, this URL must exist as a Sui wallet env, to add, use `sui client new-env --alias <name> --rpc <url>`.
         #[arg(long)]
         rpc_url: Option<String>,
     },
@@ -246,7 +239,7 @@ enum Commands {
         #[arg(short, long)]
         network: Network,
 
-        /// Custom RPC URL to use instead of the default network URL. For custom networks, it must match an existing wallet environment RPC; add one with `sui client new-env --alias <name> --rpc <url>`.
+        /// RPC URL override. If set, this URL must exist as a Sui wallet env, to add, use `sui client new-env --alias <name> --rpc <url>`.
         #[arg(long)]
         rpc_url: Option<String>,
     },
@@ -261,7 +254,7 @@ enum Commands {
         #[arg(short, long)]
         network: Network,
 
-        /// Custom RPC URL to use instead of the default network URL. For custom networks, it must match an existing wallet environment RPC; add one with `sui client new-env --alias <name> --rpc <url>`.
+        /// RPC URL override.
         #[arg(long)]
         rpc_url: Option<String>,
     },
@@ -286,9 +279,8 @@ async fn main() -> Result<()> {
             let config_content = load_config(&config)?;
 
             // Check if already initialized.
-            if get_config_field(&config_content, &["publish-and-init"], "COMMITTEE_PKG").is_some()
-                || get_config_field(&config_content, &["publish-and-init"], "COMMITTEE_ID")
-                    .is_some()
+            if get_config_field(&config_content, "publish-and-init", "COMMITTEE_PKG").is_some()
+                || get_config_field(&config_content, "publish-and-init", "COMMITTEE_ID").is_some()
             {
                 println!("Committee already initialized. Skipping publish and init. Remove these fields from config to reinitialize.");
                 return Ok(());
@@ -317,9 +309,7 @@ async fn main() -> Result<()> {
             println!("Threshold: {}", threshold);
 
             // Get committee package path.
-            let committee_path = std::env::current_dir()
-                .context("Failed to get current directory")?
-                .join("move/committee");
+            let committee_path = std::env::current_dir()?.join("move/committee");
             if !committee_path.exists() {
                 bail!(
                     "Committee package not found at: {}",
@@ -334,16 +324,11 @@ async fn main() -> Result<()> {
                     "Removing {} to enable fresh publish...",
                     published_toml.display()
                 );
-                fs::remove_file(&published_toml)
-                    .with_context(|| format!("Failed to remove {}", published_toml.display()))?;
+                fs::remove_file(&published_toml)?;
             }
 
             // Build and publish package.
-            let build_config =
-                create_build_config(&committee_path, &network, Some(&wallet), true).await?;
-            let compiled_package = build_config
-                .build(&committee_path)
-                .with_context(|| format!("Failed to build {}", committee_path.display()))?;
+            let compiled_package = create_build_config(&network).build(&committee_path)?;
             let compiled_modules_bytes = compiled_package.get_package_bytes(false);
 
             let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
@@ -395,20 +380,11 @@ async fn main() -> Result<()> {
             let mut init_builder = ProgrammableTransactionBuilder::new();
 
             // Get object arg for UpgradeCap.
-            let upgrade_cap_ref = wallet
-                .get_object_ref(upgrade_cap_id)
-                .await
-                .with_context(|| format!("Failed to fetch UpgradeCap {}", upgrade_cap_id))?;
-            let upgrade_cap_arg = init_builder
-                .obj(ObjectArg::ImmOrOwnedObject(upgrade_cap_ref))
-                .context("Failed to add UpgradeCap object argument")?;
+            let upgrade_cap_ref = wallet.get_object_ref(upgrade_cap_id).await?;
+            let upgrade_cap_arg = init_builder.obj(ObjectArg::ImmOrOwnedObject(upgrade_cap_ref))?;
 
-            let threshold_arg = init_builder
-                .pure(threshold)
-                .context("Failed to encode threshold")?;
-            let members_arg = init_builder
-                .pure(members)
-                .context("Failed to encode members")?;
+            let threshold_arg = init_builder.pure(threshold)?;
+            let members_arg = init_builder.pure(members)?;
 
             init_builder.programmable_move_call(
                 package_id,
@@ -420,13 +396,7 @@ async fn main() -> Result<()> {
 
             let init_gas_coin_ref = wallet
                 .gas_for_owner_budget(coordinator_address, gas_budget, Default::default())
-                .await
-                .with_context(|| {
-                    format!(
-                        "Failed to select gas coin for {} with budget {}",
-                        coordinator_address, gas_budget
-                    )
-                })?
+                .await?
                 .1
                 .compute_object_reference();
 
@@ -466,7 +436,7 @@ async fn main() -> Result<()> {
             let (config, _) = derive_paths(&state_dir);
             let config_content = load_config(&config)?;
 
-            if get_config_field(&config_content, &["init-rotation"], "COMMITTEE_ID").is_some() {
+            if get_config_field(&config_content, "init-rotation", "COMMITTEE_ID").is_some() {
                 println!("Committee rotation already initialized. Skipping init-rotation. Remove COMMITTEE_ID from config to re-initialize.");
                 return Ok(());
             }
@@ -573,8 +543,8 @@ async fn main() -> Result<()> {
             let config_content = load_config(&config)?;
 
             // Check if already generated keys.
-            if get_config_field(&config_content, &["genkey-and-register"], "DKG_ENC_PK").is_some()
-                || get_config_field(&config_content, &["genkey-and-register"], "DKG_SIGNING_PK")
+            if get_config_field(&config_content, "genkey-and-register", "DKG_ENC_PK").is_some()
+                || get_config_field(&config_content, "genkey-and-register", "DKG_SIGNING_PK")
                     .is_some()
             {
                 println!("Keys already generated. Skipping key generation and registration. Remove the genkey-and-register section from the config file to re-run this operation.");
@@ -641,9 +611,8 @@ async fn main() -> Result<()> {
             let signing_sk = signing_kp.private();
 
             // Serialize keys to BCS bytes.
-            let enc_pk_bytes = bcs::to_bytes(&enc_pk).context("Failed to serialize DKG_ENC_PK")?;
-            let signing_pk_bytes =
-                bcs::to_bytes(&signing_pk).context("Failed to serialize DKG_SIGNING_PK")?;
+            let enc_pk_bytes = bcs::to_bytes(&enc_pk)?;
+            let signing_pk_bytes = bcs::to_bytes(&signing_pk)?;
 
             let created_keys_file = KeysFile {
                 enc_sk,
@@ -653,12 +622,9 @@ async fn main() -> Result<()> {
             };
 
             // Write keys to file.
-            let json_content = serde_json::to_string_pretty(&created_keys_file)
-                .context("Failed to serialize dkg.key")?;
+            let json_content = serde_json::to_string_pretty(&created_keys_file)?;
             if let Some(parent) = keys_file.parent() {
-                fs::create_dir_all(parent).with_context(|| {
-                    format!("Failed to create keys directory {}", parent.display())
-                })?;
+                fs::create_dir_all(parent)?;
             }
             write_secret_file(&keys_file, &json_content)?;
 
@@ -747,14 +713,14 @@ async fn main() -> Result<()> {
 
             let committee_pkg = get_committee_pkg(&config_content)?;
             let committee_id = get_committee_id(&config_content)?;
-            let my_address = SuiAddress::from_bytes(get_my_address(&config_content)?.into_inner())?;
+            let my_address = SuiAddress::from_bytes(get_my_address(&config_content)?.inner())?;
             let network = get_network(&config_content)?;
             let node_url = get_node_url(&config_content);
             print_network_info(&network, node_url.as_deref());
 
             // Check if this is a rotation.
             let current_committee_id =
-                get_config_field(&config_content, &["init-rotation"], "CURRENT_COMMITTEE_ID")
+                get_config_field(&config_content, "init-rotation", "CURRENT_COMMITTEE_ID")
                     .and_then(|v| v.as_str())
                     .map(|id| {
                         Address::from_str(id).with_context(|| {
@@ -773,24 +739,11 @@ async fn main() -> Result<()> {
             let mut state = DkgState::load(&state_dir)?;
             let local_keys = KeysFile::load(&keys_file)?;
 
-            // Determine version before processing so stale config fails before expensive DKG work.
+            // Determine version and fetch old key server PK (for rotation).
             let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
             let (next_version, old_key_server_pk) =
                 get_committee_rotation_info(&mut grpc_client, &state.config.committee_id).await?;
-            let existing_output_fields =
-                existing_process_output_fields(&config_content, next_version);
-            if !existing_output_fields.is_empty() {
-                println!(
-                    "[WARNING] Skipping processing and onchain proposal because process-all-and-propose already contains {:?}. Remove these field(s) from the config file to reprocess messages and propose onchain.",
-                    existing_output_fields
-                );
-                return Ok(());
-            }
-            validate_process_output_version(
-                &config_content,
-                next_version,
-                old_key_server_pk.as_deref(),
-            )?;
+            validate_process_section(&config_content, next_version, old_key_server_pk.as_deref())?;
 
             // Load and process all messages.
             let messages = load_messages_from_dir(&full_messages_dir)?;
@@ -1055,26 +1008,9 @@ async fn main() -> Result<()> {
         Commands::PackageDigest {
             package_path,
             network,
-            rpc_url,
         } => {
-            let wallet = if matches!(network, Network::Custom) {
-                let wallet = load_wallet_for_network(
-                    cli.wallet.as_deref(),
-                    cli.active_address,
-                    &network,
-                    rpc_url.as_deref(),
-                )?;
-                let wallet_env = wallet.get_active_env()?;
-                println!("Network: custom");
-                println!(
-                    "Wallet environment: {} ({})",
-                    wallet_env.alias, wallet_env.rpc
-                );
-                Some(wallet)
-            } else {
-                None
-            };
-            compute_package_digest(&package_path, &network, wallet.as_ref()).await?;
+            println!("Network: {}", network);
+            compute_package_digest(&package_path, &network).await?;
         }
 
         Commands::ApproveUpgrade {
@@ -1143,17 +1079,15 @@ async fn main() -> Result<()> {
             print_network_info(&network, rpc_url.as_deref());
 
             // Build package and compute digest.
-            let digest = get_package_digest(&package_path, &network, Some(&wallet)).await?;
+            let digest = get_package_digest(&package_path, &network).await?;
             println!("\nPackage digest: {}", digest);
 
             // Build the package to get compiled modules and dependencies.
-            let build_config =
-                create_build_config(&package_path, &network, Some(&wallet), true).await?;
-            let compiled_package = build_config.build(&package_path)?;
+            let compiled_package = create_build_config(&network).build(&package_path)?;
             let compiled_modules_bytes = compiled_package.get_package_bytes(false);
 
             // Fetch key server to get committee ID.
-            let mut grpc_client = create_grpc_client_with_url(&network, rpc_url.as_deref())?;
+            let mut grpc_client = create_grpc_client_from_config(&network, rpc_url.as_deref())?;
             let (committee_id, _) =
                 fetch_committee_from_key_server(&mut grpc_client, &key_server_id).await?;
 
@@ -1254,7 +1188,7 @@ async fn main() -> Result<()> {
             print_network_info(&network, rpc_url.as_deref());
 
             // Fetch key server to get committee ID.
-            let mut grpc_client = create_grpc_client_with_url(&network, rpc_url.as_deref())?;
+            let mut grpc_client = create_grpc_client_from_config(&network, rpc_url.as_deref())?;
             let (committee_id, _) =
                 fetch_committee_from_key_server(&mut grpc_client, &key_server_id).await?;
 
@@ -1344,7 +1278,7 @@ async fn main() -> Result<()> {
             print_network_info(&network, rpc_url.as_deref());
             println!("Key Server ID: {}", key_server_id);
 
-            let mut grpc_client = create_grpc_client_with_url(&network, rpc_url.as_deref())?;
+            let mut grpc_client = create_grpc_client_from_config(&network, rpc_url.as_deref())?;
 
             // Fetch committee information.
             let (committee_id, _committee_pkg) =
@@ -1734,8 +1668,7 @@ async fn create_dkg_state_and_message(
         });
         let message_json = serde_json::to_string_pretty(&message_json)
             .context("Failed to serialize DKG message JSON")?;
-        fs::write(&message_file, message_json)
-            .with_context(|| format!("Failed to write DKG message {}", message_file.display()))?;
+        fs::write(&message_file, message_json)?;
 
         println!(
             "DKG message written to: {}. Share this file with the coordinator.",
@@ -1758,6 +1691,7 @@ async fn create_dkg_state_and_message(
             new_to_old_mapping,
             expected_old_pks,
             my_old_share,
+            my_old_pk: derived_old_pk,
         },
         my_message,
         received_messages: HashMap::new(),
@@ -1782,21 +1716,15 @@ async fn get_gas_params(
     address: SuiAddress,
     gas_budget: u64,
 ) -> Result<(u64, u64, sui_types::base_types::ObjectRef)> {
-    let gas_price = grpc_client
-        .get_reference_gas_price()
-        .await
-        .context("Failed to fetch reference gas price")?;
+    let gas_price = grpc_client.get_reference_gas_price().await?;
     let gas_coin = wallet
         .gas_for_owner_budget(address, gas_budget, Default::default())
-        .await
-        .with_context(|| {
-            format!("Failed to select gas coin for {address} with budget {gas_budget}")
-        })?
+        .await?
         .1;
     Ok((gas_price, gas_budget, gas_coin.compute_object_reference()))
 }
 
-/// Load wallet context from path and optionally set active environment.
+/// Load wallet context from path.
 fn load_wallet(
     wallet_path: Option<&Path>,
     active_address: Option<SuiAddress>,
@@ -1809,8 +1737,7 @@ fn load_wallet(
         default
     };
 
-    let mut wallet = WalletContext::new(&config_path)
-        .with_context(|| format!("Failed to load wallet context {}", config_path.display()))?;
+    let mut wallet = WalletContext::new(&config_path).context("Failed to load wallet context")?;
 
     // Override active address if specified.
     if let Some(addr) = active_address {
@@ -1829,33 +1756,25 @@ fn load_wallet_for_network(
 ) -> Result<WalletContext> {
     let wallet = load_wallet(wallet_path, active_address)?;
 
-    // Determine the environment alias to use
+    if let Some(url) = rpc_url {
+        let target_env = wallet
+            .config
+            .envs
+            .iter()
+            .find(|env| env.rpc == url)
+            .map(|env| env.alias.clone())
+            .ok_or_else(|| {
+                anyhow!(
+                    "RPC URL {} not found in wallet config, add it first. e.g. 'sui client new-env --alias my-testnet-rpc --rpc https://my-rpc.example.com:443'",
+                    url
+                )
+            })?;
+        return Ok(wallet.with_env_override(target_env));
+    }
+
     let target_env = match network {
         Network::Testnet => "testnet".to_string(),
         Network::Mainnet => "mainnet".to_string(),
-        Network::Custom => {
-            // For custom network, find or create an env with matching RPC URL
-            if let Some(url) = rpc_url {
-                let matching_env = wallet
-                    .config
-                    .envs
-                    .iter()
-                    .find(|env| env.rpc == url)
-                    .map(|env| env.alias.clone());
-
-                if let Some(alias) = matching_env {
-                    alias
-                } else {
-                    // No alias found for the provided URL, create a new one with sui cli.
-                    bail!(
-                        "Custom RPC URL {} not found in wallet config, add it first. e.g. 'sui client new-env --alias my-custom-devnet --rpc https://my-custom-rpc.example.com:443'",
-                        url
-                    );
-                }
-            } else {
-                bail!("Custom network specified but no RPC URL provided");
-            }
-        }
     };
 
     Ok(wallet.with_env_override(target_env))
@@ -1870,16 +1789,12 @@ fn derive_paths(state_dir: &Path) -> (PathBuf, PathBuf) {
 
 /// Helper function to write a file with restricted permissions (owner only) in Unix systems.
 fn write_secret_file(path: &Path, content: &str) -> Result<()> {
-    fs::write(path, content)
-        .with_context(|| format!("Failed to write secret file {}", path.display()))?;
+    fs::write(path, content)?;
     #[cfg(unix)]
     {
-        let mut perms = fs::metadata(path)
-            .with_context(|| format!("Failed to stat secret file {}", path.display()))?
-            .permissions();
+        let mut perms = fs::metadata(path)?.permissions();
         perms.set_mode(0o600);
-        fs::set_permissions(path, perms)
-            .with_context(|| format!("Failed to set permissions on {}", path.display()))?;
+        fs::set_permissions(path, perms)?;
     }
     Ok(())
 }
@@ -1930,31 +1845,23 @@ fn validate_continuing_member_old_share(
 
 /// Load YAML configuration file.
 fn load_config(path: &Path) -> Result<serde_yaml::Value> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read config file: {}", path.display()))?;
+    let content = fs::read_to_string(path)?;
     serde_yaml::from_str(&content)
         .with_context(|| format!("Failed to parse YAML config: {}", path.display()))
 }
 
-/// Get a field from config, checking nested sections first, then flat structure.
+/// Get a field from a named config section.
 fn get_config_field<'a>(
     config: &'a serde_yaml::Value,
-    sections: &[&str],
+    section: &str,
     field: &str,
 ) -> Option<&'a serde_yaml::Value> {
-    for section in sections {
-        if let Some(section_val) = config.get(section)
-            && let Some(field_val) = section_val.get(field)
-        {
-            return Some(field_val);
-        }
-    }
-    None
+    config.get(section)?.get(field)
 }
 
 /// Get network from config.
 fn get_network(config: &serde_yaml::Value) -> Result<Network> {
-    let network_str = get_config_field(config, &["init-params"], "NETWORK")
+    let network_str = get_config_field(config, "init-params", "NETWORK")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("NETWORK not found in config or invalid"))?;
 
@@ -1963,32 +1870,20 @@ fn get_network(config: &serde_yaml::Value) -> Result<Network> {
 
 /// Get optional NODE_URL from config.
 fn get_node_url(config: &serde_yaml::Value) -> Option<String> {
-    get_config_field(config, &["init-params"], "NODE_URL")
+    get_config_field(config, "init-params", "NODE_URL")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string())
 }
 
-/// Create gRPC client with rpc url or network default.
-fn create_grpc_client_from_config(
-    network: &Network,
-    config_node_url: Option<&str>,
-) -> Result<Client> {
-    let rpc_url = config_node_url.or_else(|| network.default_rpc_url());
-    create_grpc_client_with_url(network, rpc_url)
-}
-
 /// Print network with rpc url.
 fn print_network_info(network: &Network, rpc_url: Option<&str>) {
-    let rpc_url = rpc_url.or_else(|| network.default_rpc_url());
-    match rpc_url {
-        Some(url) => println!("Network: {} ({})", network, url),
-        None => println!("Network: {}", network),
-    }
+    let rpc_url = rpc_url.unwrap_or_else(|| network.default_rpc_url());
+    println!("Network: {} ({})", network, rpc_url);
 }
 
 /// Get members list from config.
 fn get_members(config: &serde_yaml::Value) -> Result<Vec<Address>> {
-    let members = get_config_field(config, &["init-params"], "MEMBERS")
+    let members = get_config_field(config, "init-params", "MEMBERS")
         .and_then(|v| v.as_sequence())
         .ok_or_else(|| anyhow!("MEMBERS list not found or invalid in config"))?;
 
@@ -2011,7 +1906,7 @@ fn get_members(config: &serde_yaml::Value) -> Result<Vec<Address>> {
 
 /// Get threshold from config.
 fn get_threshold(config: &serde_yaml::Value) -> Result<u16> {
-    let threshold = get_config_field(config, &["init-params"], "THRESHOLD")
+    let threshold = get_config_field(config, "init-params", "THRESHOLD")
         .and_then(|v| v.as_u64())
         .ok_or_else(|| anyhow!("THRESHOLD not found or invalid in config"))?;
 
@@ -2024,7 +1919,7 @@ fn get_threshold(config: &serde_yaml::Value) -> Result<u16> {
 
 /// Get key server object ID from config.
 fn get_key_server_obj_id(config: &serde_yaml::Value) -> Result<Address> {
-    let id_str = get_config_field(config, &["init-rotation-params"], "KEY_SERVER_OBJ_ID")
+    let id_str = get_config_field(config, "init-rotation-params", "KEY_SERVER_OBJ_ID")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("KEY_SERVER_OBJ_ID not found in config"))?;
     Address::from_str(id_str).with_context(|| format!("Invalid KEY_SERVER_OBJ_ID {id_str}"))
@@ -2032,44 +1927,34 @@ fn get_key_server_obj_id(config: &serde_yaml::Value) -> Result<Address> {
 
 /// Get COMMITTEE_PKG from config.
 fn get_committee_pkg(config: &serde_yaml::Value) -> Result<Address> {
-    let sections = committee_id_sections(config);
-    let pkg_str = get_config_field(config, &sections, "COMMITTEE_PKG")
+    let section = committee_id_section(config);
+    let pkg_str = get_config_field(config, section, "COMMITTEE_PKG")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("COMMITTEE_PKG not found in config"))?;
-    Address::from_str(pkg_str).with_context(|| {
-        format!(
-            "Invalid {}.COMMITTEE_PKG {pkg_str}",
-            sections.first().copied().unwrap_or("config")
-        )
-    })
+    Address::from_str(pkg_str).with_context(|| format!("Invalid {section}.COMMITTEE_PKG {pkg_str}"))
 }
 
 /// Get COMMITTEE_ID from config.
 fn get_committee_id(config: &serde_yaml::Value) -> Result<Address> {
-    let sections = committee_id_sections(config);
-    let id_str = get_config_field(config, &sections, "COMMITTEE_ID")
+    let section = committee_id_section(config);
+    let id_str = get_config_field(config, section, "COMMITTEE_ID")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("COMMITTEE_ID not found in config"))?;
-    Address::from_str(id_str).with_context(|| {
-        format!(
-            "Invalid {}.COMMITTEE_ID {id_str}",
-            sections.first().copied().unwrap_or("config")
-        )
-    })
+    Address::from_str(id_str).with_context(|| format!("Invalid {section}.COMMITTEE_ID {id_str}"))
 }
 
 /// Select the generated config section that owns COMMITTEE_PKG and COMMITTEE_ID.
-fn committee_id_sections(config: &serde_yaml::Value) -> [&'static str; 1] {
-    if get_config_field(config, &["init-rotation-params"], "KEY_SERVER_OBJ_ID").is_some() {
-        ["init-rotation"]
+fn committee_id_section(config: &serde_yaml::Value) -> &'static str {
+    if get_config_field(config, "init-rotation-params", "KEY_SERVER_OBJ_ID").is_some() {
+        "init-rotation"
     } else {
-        ["publish-and-init"]
+        "publish-and-init"
     }
 }
 
 /// Get MY_ADDRESS from config.
 fn get_my_address(config: &serde_yaml::Value) -> Result<Address> {
-    let addr_str = get_config_field(config, &["genkey-and-register"], "MY_ADDRESS")
+    let addr_str = get_config_field(config, "genkey-and-register", "MY_ADDRESS")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("MY_ADDRESS not found in config"))?;
     Address::from_str(addr_str).with_context(|| format!("Invalid MY_ADDRESS {addr_str}"))
@@ -2077,8 +1962,7 @@ fn get_my_address(config: &serde_yaml::Value) -> Result<Address> {
 
 /// Update fields within a specific section of the YAML config with hex-encoded byte values.
 fn update_config_bytes_val(path: &Path, section: &str, updates: Vec<(&str, &[u8])>) -> Result<()> {
-    let content =
-        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let content = fs::read_to_string(path)?;
     let mut config: serde_yaml::Value = serde_yaml::from_str(&content)
         .with_context(|| format!("Failed to parse YAML config {}", path.display()))?;
 
@@ -2095,14 +1979,13 @@ fn update_config_bytes_val(path: &Path, section: &str, updates: Vec<(&str, &[u8]
 
     let updated = serde_yaml::to_string(&config)
         .with_context(|| format!("Failed to serialize YAML config {}", path.display()))?;
-    fs::write(path, updated).with_context(|| format!("Failed to write {}", path.display()))?;
+    fs::write(path, updated)?;
     Ok(())
 }
 
 /// Update fields within a specific section of the YAML config with string values.
 fn update_config_string_val(path: &Path, section: &str, updates: Vec<(&str, &str)>) -> Result<()> {
-    let content =
-        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let content = fs::read_to_string(path)?;
     let mut config: serde_yaml::Value = serde_yaml::from_str(&content)
         .with_context(|| format!("Failed to parse YAML config {}", path.display()))?;
 
@@ -2120,7 +2003,7 @@ fn update_config_string_val(path: &Path, section: &str, updates: Vec<(&str, &str
 
     let updated = serde_yaml::to_string(&config)
         .with_context(|| format!("Failed to serialize YAML config {}", path.display()))?;
-    fs::write(path, updated).with_context(|| format!("Failed to write {}", path.display()))?;
+    fs::write(path, updated)?;
     Ok(())
 }
 
@@ -2136,7 +2019,7 @@ fn persist_process_outputs(
     let master_share_key = format!("MASTER_SHARE_V{}", next_version);
     let partial_pks_key = format!("PARTIAL_PKS_V{}", next_version);
     let config_content = load_config(config)?;
-    validate_process_output_version(&config_content, next_version, old_key_server_pk)?;
+    validate_process_section(&config_content, next_version, old_key_server_pk)?;
 
     bcs::from_bytes::<G2Element>(key_server_pk_bytes)
         .context("KEY_SERVER_PK must be a valid BCS G2Element")?;
@@ -2253,8 +2136,8 @@ fn validate_rotation_message_senders(
     Ok(())
 }
 
-/// Validate process output version fields before writing new DKG output into config.
-fn validate_process_output_version(
+/// Validate process-all-and-propose fields before writing new DKG output into config.
+fn validate_process_section(
     config: &serde_yaml::Value,
     next_version: u32,
     old_key_server_pk: Option<&[u8]>,
@@ -2269,7 +2152,7 @@ fn validate_process_output_version(
     }
 
     let existing_key_server_pk =
-        get_config_field(config, &["process-all-and-propose"], "KEY_SERVER_PK")
+        get_config_field(config, "process-all-and-propose", "KEY_SERVER_PK")
             .and_then(|value| value.as_str());
     if next_version == 0 {
         if existing_key_server_pk.is_some() {
@@ -2315,17 +2198,12 @@ fn existing_process_output_fields(config: &serde_yaml::Value, next_version: u32)
 
     fields
         .into_iter()
-        .filter(|field| get_config_field(config, &["process-all-and-propose"], field).is_some())
+        .filter(|field| get_config_field(config, "process-all-and-propose", field).is_some())
         .collect()
 }
 
 /// Create a BuildConfig for package compilation.
-async fn create_build_config(
-    package_path: &Path,
-    network: &Network,
-    wallet: Option<&WalletContext>,
-    for_publication: bool,
-) -> Result<BuildConfig> {
+fn create_build_config(network: &Network) -> BuildConfig {
     let move_build_config = MoveBuildConfig {
         root_as_zero: true,
         ..Default::default()
@@ -2334,24 +2212,14 @@ async fn create_build_config(
     let environment = match network {
         Network::Testnet => testnet_environment(),
         Network::Mainnet => mainnet_environment(),
-        Network::Custom => {
-            let wallet = wallet.ok_or_else(|| {
-                anyhow!(
-                    "Custom network package builds require a wallet environment; pass --rpc-url"
-                )
-            })?;
-            find_environment(package_path, None, wallet, for_publication)
-                .await
-                .context("Failed to resolve package environment for custom network")?
-        }
     };
 
-    Ok(BuildConfig {
+    BuildConfig {
         config: move_build_config,
         run_bytecode_verifier: true,
         print_diags_to_stderr: true,
         environment,
-    })
+    }
 }
 
 /// Load DKG messages from a directory.
@@ -2366,9 +2234,7 @@ fn load_messages_from_dir(messages_dir: &Path) -> Result<Vec<SignedMessage>> {
     })?;
 
     for entry in entries {
-        let path = entry
-            .with_context(|| format!("Failed to read entry in {}", messages_dir.display()))?
-            .path();
+        let path = entry?.path();
         if path.extension().and_then(|s| s.to_str()) != Some("json") {
             continue;
         }
@@ -2589,15 +2455,11 @@ fn create_dkg_random_oracle(committee_id: &Address) -> RandomOracle {
 }
 
 /// Compute and display the package digest.
-async fn compute_package_digest(
-    package_path: &Path,
-    network: &Network,
-    wallet: Option<&WalletContext>,
-) -> Result<()> {
+async fn compute_package_digest(package_path: &Path, network: &Network) -> Result<()> {
     println!("Building package at: {}", package_path.display());
     println!();
 
-    let digest = get_package_digest(package_path, network, wallet).await?;
+    let digest = get_package_digest(package_path, network).await?;
     println!(
         "Digest for package '{}': {}",
         package_path
@@ -2611,13 +2473,9 @@ async fn compute_package_digest(
 }
 
 /// Compute package digest as hex string.
-async fn get_package_digest(
-    package_path: &Path,
-    network: &Network,
-    wallet: Option<&WalletContext>,
-) -> Result<String> {
+async fn get_package_digest(package_path: &Path, network: &Network) -> Result<String> {
     let package_path = package_path.canonicalize()?;
-    let build_config = create_build_config(&package_path, network, wallet, true).await?;
+    let build_config = create_build_config(network);
     let compiled_package = build_config
         .build(&package_path)
         .context("Failed to build package")?;
@@ -2656,16 +2514,16 @@ async fn vote_for_upgrade(
     wallet: &mut WalletContext,
     gas_budget: u64,
     approve: bool,
-    custom_rpc_url: Option<&str>,
+    rpc_url: Option<&str>,
 ) -> Result<()> {
     let voter_address = wallet.active_address()?;
 
     println!("Voter address: {}", voter_address);
-    print_network_info(network, custom_rpc_url);
+    print_network_info(network, rpc_url);
 
     // Build package and compute digest (only for approve).
     let digest = if let Some(path) = package_path {
-        let d = get_package_digest(path, network, Some(wallet)).await?;
+        let d = get_package_digest(path, network).await?;
         println!("\nPackage digest: {}", d);
         Some(d)
     } else {
@@ -2673,7 +2531,7 @@ async fn vote_for_upgrade(
     };
 
     // Fetch key server to get committee ID.
-    let mut grpc_client = create_grpc_client_with_url(network, custom_rpc_url)?;
+    let mut grpc_client = create_grpc_client_from_config(network, rpc_url)?;
     let (committee_id, _) =
         fetch_committee_from_key_server(&mut grpc_client, key_server_id).await?;
 

--- a/crates/seal-committee-cli/src/main.rs
+++ b/crates/seal-committee-cli/src/main.rs
@@ -31,7 +31,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use sui_keys::keystore::{AccountKeystore, GenerateOptions};
 use sui_move_build::BuildConfig;
-use sui_package_alt::{mainnet_environment, testnet_environment};
+use sui_package_alt::{find_environment, mainnet_environment, testnet_environment};
 use sui_rpc::proto::sui::rpc::v2::GetObjectRequest;
 use sui_rpc::Client;
 use sui_rpc_api::client::ExecutedTransaction;
@@ -187,9 +187,13 @@ enum Commands {
         #[arg(short, long, default_value = "move/committee")]
         package_path: PathBuf,
 
-        /// Network to build for (Testnet or Mainnet).
+        /// Network to build for.
         #[arg(short, long)]
         network: Network,
+
+        /// Custom RPC URL to use for resolving the package environment. For custom networks, it must match an existing wallet environment RPC; add one with `sui client new-env --alias <name> --rpc <url>`.
+        #[arg(long)]
+        rpc_url: Option<String>,
     },
 
     /// Approve package upgrade (as committee member).
@@ -206,7 +210,7 @@ enum Commands {
         #[arg(short, long)]
         network: Network,
 
-        /// Custom RPC URL to use instead of the default network URL.
+        /// Custom RPC URL to use instead of the default network URL. For custom networks, it must match an existing wallet environment RPC; add one with `sui client new-env --alias <name> --rpc <url>`.
         #[arg(long)]
         rpc_url: Option<String>,
     },
@@ -221,7 +225,7 @@ enum Commands {
         #[arg(short, long)]
         network: Network,
 
-        /// Custom RPC URL to use instead of the default network URL.
+        /// Custom RPC URL to use instead of the default network URL. For custom networks, it must match an existing wallet environment RPC; add one with `sui client new-env --alias <name> --rpc <url>`.
         #[arg(long)]
         rpc_url: Option<String>,
     },
@@ -240,7 +244,7 @@ enum Commands {
         #[arg(short, long)]
         network: Network,
 
-        /// Custom RPC URL to use instead of the default network URL.
+        /// Custom RPC URL to use instead of the default network URL. For custom networks, it must match an existing wallet environment RPC; add one with `sui client new-env --alias <name> --rpc <url>`.
         #[arg(long)]
         rpc_url: Option<String>,
     },
@@ -255,7 +259,7 @@ enum Commands {
         #[arg(short, long)]
         network: Network,
 
-        /// Custom RPC URL to use instead of the default network URL.
+        /// Custom RPC URL to use instead of the default network URL. For custom networks, it must match an existing wallet environment RPC; add one with `sui client new-env --alias <name> --rpc <url>`.
         #[arg(long)]
         rpc_url: Option<String>,
     },
@@ -270,7 +274,7 @@ enum Commands {
         #[arg(short, long)]
         network: Network,
 
-        /// Custom RPC URL to use instead of the default network URL.
+        /// Custom RPC URL to use instead of the default network URL. For custom networks, it must match an existing wallet environment RPC; add one with `sui client new-env --alias <name> --rpc <url>`.
         #[arg(long)]
         rpc_url: Option<String>,
     },
@@ -344,7 +348,9 @@ async fn main() -> Result<()> {
             }
 
             // Build and publish package.
-            let compiled_package = create_build_config(&network).build(&committee_path)?;
+            let build_config =
+                create_build_config(&committee_path, &network, Some(&wallet), true).await?;
+            let compiled_package = build_config.build(&committee_path)?;
             let compiled_modules_bytes = compiled_package.get_package_bytes(false);
 
             let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
@@ -1063,8 +1069,30 @@ async fn main() -> Result<()> {
         Commands::PackageDigest {
             package_path,
             network,
+            rpc_url,
         } => {
-            compute_package_digest(&package_path, &network)?;
+            let wallet = if matches!(network, Network::Custom) {
+                let wallet = if let Some(rpc_url) = rpc_url.as_deref() {
+                    load_wallet_for_network(
+                        cli.wallet.as_deref(),
+                        cli.active_address,
+                        &network,
+                        Some(rpc_url),
+                    )?
+                } else {
+                    load_wallet(cli.wallet.as_deref(), cli.active_address)?
+                };
+                let wallet_env = wallet.get_active_env()?;
+                println!("Network: custom");
+                println!(
+                    "Wallet environment: {} ({})",
+                    wallet_env.alias, wallet_env.rpc
+                );
+                Some(wallet)
+            } else {
+                None
+            };
+            compute_package_digest(&package_path, &network, wallet.as_ref()).await?;
         }
 
         Commands::ApproveUpgrade {
@@ -1073,7 +1101,12 @@ async fn main() -> Result<()> {
             network,
             rpc_url,
         } => {
-            let mut wallet = load_wallet(cli.wallet.as_deref(), cli.active_address)?;
+            let mut wallet = load_wallet_for_network(
+                cli.wallet.as_deref(),
+                cli.active_address,
+                &network,
+                rpc_url.as_deref(),
+            )?;
             vote_for_upgrade(
                 Some(&package_path),
                 &key_server_id,
@@ -1091,7 +1124,12 @@ async fn main() -> Result<()> {
             network,
             rpc_url,
         } => {
-            let mut wallet = load_wallet(cli.wallet.as_deref(), cli.active_address)?;
+            let mut wallet = load_wallet_for_network(
+                cli.wallet.as_deref(),
+                cli.active_address,
+                &network,
+                rpc_url.as_deref(),
+            )?;
             vote_for_upgrade(
                 None,
                 &key_server_id,
@@ -1111,18 +1149,25 @@ async fn main() -> Result<()> {
             rpc_url,
         } => {
             // Load wallet.
-            let mut wallet = load_wallet(cli.wallet.as_deref(), cli.active_address)?;
+            let mut wallet = load_wallet_for_network(
+                cli.wallet.as_deref(),
+                cli.active_address,
+                &network,
+                rpc_url.as_deref(),
+            )?;
             let executor_address = wallet.active_address()?;
 
             println!("Executor address: {}", executor_address);
             print_network_info(&network, rpc_url.as_deref());
 
             // Build package and compute digest.
-            let digest = get_package_digest(&package_path, &network)?;
+            let digest = get_package_digest(&package_path, &network, Some(&wallet)).await?;
             println!("\nPackage digest: {}", digest);
 
             // Build the package to get compiled modules and dependencies.
-            let compiled_package = create_build_config(&network).build(&package_path)?;
+            let build_config =
+                create_build_config(&package_path, &network, Some(&wallet), true).await?;
+            let compiled_package = build_config.build(&package_path)?;
             let compiled_modules_bytes = compiled_package.get_package_bytes(false);
 
             // Fetch key server to get committee ID.
@@ -1643,7 +1688,12 @@ async fn create_dkg_state_and_message(
 
         let message = party.create_message(&mut thread_rng())?;
         let nizk_proof = party.nizk_pop_of_secret(&mut thread_rng());
-        let signed_message = sign_message(message.clone(), &local_keys.signing_sk, nizk_proof);
+        let signed_message = sign_message(
+            &committee_id,
+            message.clone(),
+            &local_keys.signing_sk,
+            nizk_proof,
+        );
 
         // Write message to file.
         let message_hex = bcs_hex_encode!(&signed_message);
@@ -1962,7 +2012,12 @@ fn update_config_string_val(path: &Path, section: &str, updates: Vec<(&str, &str
 }
 
 /// Create a BuildConfig for package compilation.
-fn create_build_config(network: &Network) -> BuildConfig {
+async fn create_build_config(
+    package_path: &Path,
+    network: &Network,
+    wallet: Option<&WalletContext>,
+    for_publication: bool,
+) -> Result<BuildConfig> {
     let move_build_config = MoveBuildConfig {
         root_as_zero: true,
         ..Default::default()
@@ -1971,15 +2026,25 @@ fn create_build_config(network: &Network) -> BuildConfig {
     let environment = match network {
         Network::Testnet => testnet_environment(),
         Network::Mainnet => mainnet_environment(),
-        Network::Custom => testnet_environment(),
+        Network::Custom => {
+            let wallet = wallet.ok_or_else(|| {
+                anyhow!(
+                    "Custom network package builds require a wallet environment; pass --rpc-url \
+                    or switch the active wallet environment to the custom network"
+                )
+            })?;
+            find_environment(package_path, None, wallet, for_publication)
+                .await
+                .context("Failed to resolve package environment for custom network")?
+        }
     };
 
-    BuildConfig {
+    Ok(BuildConfig {
         config: move_build_config,
         run_bytecode_verifier: true,
         print_diags_to_stderr: true,
         environment,
-    }
+    })
 }
 
 /// Load DKG messages from a directory.
@@ -2029,11 +2094,10 @@ fn load_messages_from_dir(messages_dir: &Path) -> Result<Vec<SignedMessage>> {
 }
 
 /// Process DKG messages and complete the protocol. Returns the DKG output and a consistency hash
-/// over all received messages `Blake2b256(BCS(msg_1) || ... || BCS(msg_n))` where messages are
-/// sorted by sender party ID.
+/// over one BCS-serialized vector of messages where messages are sorted by sender party ID.
 fn process_dkg_messages(
     state: &mut DkgState,
-    messages: Vec<SignedMessage>,
+    mut messages: Vec<SignedMessage>,
     local_keys: &KeysFile,
 ) -> Result<(
     fastcrypto_tbls::dkg_v1::Output<G2Element, G1Element>,
@@ -2041,14 +2105,20 @@ fn process_dkg_messages(
 )> {
     println!("Processing {} message(s)...", messages.len());
 
-    // Compute hash over messages sorted by sender party ID.
-    let messages_hash = {
-        let mut sorted = messages.iter().collect::<Vec<_>>();
-        sorted.sort_by_key(|m| m.message.sender);
-        let mut hasher = Blake2b256::default();
-        for msg in sorted {
-            hasher.update(&bcs::to_bytes(&msg)?);
+    let mut seen_senders = HashSet::new();
+    for signed_msg in &messages {
+        let sender = signed_msg.message.sender;
+        if !seen_senders.insert(sender) {
+            bail!("Duplicate DKG message from party {sender}");
         }
+    }
+
+    // Compute hash over of the vector of messages sorted by sender party ID.
+    messages.sort_by_key(|m| m.message.sender);
+    let messages_hash = {
+        let hash_input = bcs::to_bytes(&messages)?;
+        let mut hasher = Blake2b256::default();
+        hasher.update(&hash_input);
         hasher.finalize().digest.to_vec()
     };
 
@@ -2093,7 +2163,7 @@ fn process_dkg_messages(
             .signing_pks
             .get(&sender_party_id)
             .ok_or_else(|| anyhow!("Signing public key not found for party {}", sender_party_id))?;
-        verify_signature(&signed_msg, sender_signing_pk)?;
+        verify_signature(&state.config.committee_id, &signed_msg, sender_signing_pk)?;
 
         let processed = if state.config.old_threshold.is_some() {
             let new_to_old_mapping = state
@@ -2194,11 +2264,15 @@ fn create_dkg_random_oracle(committee_id: &Address) -> RandomOracle {
 }
 
 /// Compute and display the package digest.
-fn compute_package_digest(package_path: &Path, network: &Network) -> Result<()> {
+async fn compute_package_digest(
+    package_path: &Path,
+    network: &Network,
+    wallet: Option<&WalletContext>,
+) -> Result<()> {
     println!("Building package at: {}", package_path.display());
     println!();
 
-    let digest = get_package_digest(package_path, network)?;
+    let digest = get_package_digest(package_path, network, wallet).await?;
     println!(
         "Digest for package '{}': {}",
         package_path
@@ -2212,10 +2286,15 @@ fn compute_package_digest(package_path: &Path, network: &Network) -> Result<()> 
 }
 
 /// Compute package digest as hex string.
-fn get_package_digest(package_path: &Path, network: &Network) -> Result<String> {
-    let build_config = create_build_config(network);
+async fn get_package_digest(
+    package_path: &Path,
+    network: &Network,
+    wallet: Option<&WalletContext>,
+) -> Result<String> {
+    let package_path = package_path.canonicalize()?;
+    let build_config = create_build_config(&package_path, network, wallet, true).await?;
     let compiled_package = build_config
-        .build(&package_path.canonicalize()?)
+        .build(&package_path)
         .context("Failed to build package")?;
 
     let digest = compiled_package.get_package_digest(/* with_unpublished_deps */ false);
@@ -2261,7 +2340,7 @@ async fn vote_for_upgrade(
 
     // Build package and compute digest (only for approve).
     let digest = if let Some(path) = package_path {
-        let d = get_package_digest(path, network)?;
+        let d = get_package_digest(path, network, Some(wallet)).await?;
         println!("\nPackage digest: {}", d);
         Some(d)
     } else {

--- a/crates/seal-committee-cli/src/main.rs
+++ b/crates/seal-committee-cli/src/main.rs
@@ -51,19 +51,6 @@ use crate::types::{sign_message, verify_signature, SignedMessage};
 /// Domain separation tag for DKG random oracle
 const DST_DKG: &str = "SEAL_DKG_V0:";
 
-/// BCS-serialize a value and hex-encode the result.
-macro_rules! bcs_hex_encode {
-    ($val:expr) => {
-        Hex::encode(bcs::to_bytes($val)?)
-    };
-}
-
-/// Hex-decode a string and BCS-deserialize to the given type.
-macro_rules! bcs_hex_decode {
-    ($ty:ty, $s:expr) => {
-        bcs::from_bytes::<$ty>(&Hex::decode($s)?)
-    };
-}
 /// Default gas budgets in MIST.
 mod gas_defaults {
     /// Higher budget for package ops: publish, authorize-and-upgrade.
@@ -299,8 +286,9 @@ async fn main() -> Result<()> {
             let config_content = load_config(&config)?;
 
             // Check if already initialized.
-            if config_content.get("COMMITTEE_PKG").is_some()
-                || config_content.get("COMMITTEE_ID").is_some()
+            if get_config_field(&config_content, &["publish-and-init"], "COMMITTEE_PKG").is_some()
+                || get_config_field(&config_content, &["publish-and-init"], "COMMITTEE_ID")
+                    .is_some()
             {
                 println!("Committee already initialized. Skipping publish and init. Remove these fields from config to reinitialize.");
                 return Ok(());
@@ -329,7 +317,9 @@ async fn main() -> Result<()> {
             println!("Threshold: {}", threshold);
 
             // Get committee package path.
-            let committee_path = std::env::current_dir()?.join("move/committee");
+            let committee_path = std::env::current_dir()
+                .context("Failed to get current directory")?
+                .join("move/committee");
             if !committee_path.exists() {
                 bail!(
                     "Committee package not found at: {}",
@@ -344,13 +334,16 @@ async fn main() -> Result<()> {
                     "Removing {} to enable fresh publish...",
                     published_toml.display()
                 );
-                fs::remove_file(published_toml)?;
+                fs::remove_file(&published_toml)
+                    .with_context(|| format!("Failed to remove {}", published_toml.display()))?;
             }
 
             // Build and publish package.
             let build_config =
                 create_build_config(&committee_path, &network, Some(&wallet), true).await?;
-            let compiled_package = build_config.build(&committee_path)?;
+            let compiled_package = build_config
+                .build(&committee_path)
+                .with_context(|| format!("Failed to build {}", committee_path.display()))?;
             let compiled_modules_bytes = compiled_package.get_package_bytes(false);
 
             let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
@@ -402,11 +395,20 @@ async fn main() -> Result<()> {
             let mut init_builder = ProgrammableTransactionBuilder::new();
 
             // Get object arg for UpgradeCap.
-            let upgrade_cap_ref = wallet.get_object_ref(upgrade_cap_id).await?;
-            let upgrade_cap_arg = init_builder.obj(ObjectArg::ImmOrOwnedObject(upgrade_cap_ref))?;
+            let upgrade_cap_ref = wallet
+                .get_object_ref(upgrade_cap_id)
+                .await
+                .with_context(|| format!("Failed to fetch UpgradeCap {}", upgrade_cap_id))?;
+            let upgrade_cap_arg = init_builder
+                .obj(ObjectArg::ImmOrOwnedObject(upgrade_cap_ref))
+                .context("Failed to add UpgradeCap object argument")?;
 
-            let threshold_arg = init_builder.pure(threshold)?;
-            let members_arg = init_builder.pure(members)?;
+            let threshold_arg = init_builder
+                .pure(threshold)
+                .context("Failed to encode threshold")?;
+            let members_arg = init_builder
+                .pure(members)
+                .context("Failed to encode members")?;
 
             init_builder.programmable_move_call(
                 package_id,
@@ -418,7 +420,13 @@ async fn main() -> Result<()> {
 
             let init_gas_coin_ref = wallet
                 .gas_for_owner_budget(coordinator_address, gas_budget, Default::default())
-                .await?
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to select gas coin for {} with budget {}",
+                        coordinator_address, gas_budget
+                    )
+                })?
                 .1
                 .compute_object_reference();
 
@@ -484,9 +492,8 @@ async fn main() -> Result<()> {
             println!("\nFetching key server: {}...", key_server_obj_id);
 
             let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
-            let key_server_addr = Address::from_hex(&key_server_obj_id)?;
             let (current_committee_id, package_id) =
-                fetch_committee_from_key_server(&mut grpc_client, &key_server_addr).await?;
+                fetch_committee_from_key_server(&mut grpc_client, &key_server_obj_id).await?;
 
             println!("\nCurrent committee ID: {}", current_committee_id);
             println!("Committee package ID: {}", package_id);
@@ -506,9 +513,8 @@ async fn main() -> Result<()> {
 
             // Call init_rotation.
             let mut rotation_builder = ProgrammableTransactionBuilder::new();
-            let current_committee_obj_id = ObjectID::new(current_committee_id.into_inner());
             let current_committee_arg = rotation_builder.obj(
-                get_shared_committee_arg(&mut grpc_client, current_committee_obj_id, false).await?,
+                get_shared_committee_arg(&mut grpc_client, current_committee_id, false).await?,
             )?;
             let threshold_arg = rotation_builder.pure(threshold)?;
             let members_arg = rotation_builder.pure(members)?;
@@ -635,8 +641,9 @@ async fn main() -> Result<()> {
             let signing_sk = signing_kp.private();
 
             // Serialize keys to BCS bytes.
-            let enc_pk_bytes = bcs::to_bytes(&enc_pk)?;
-            let signing_pk_bytes = bcs::to_bytes(&signing_pk)?;
+            let enc_pk_bytes = bcs::to_bytes(&enc_pk).context("Failed to serialize DKG_ENC_PK")?;
+            let signing_pk_bytes =
+                bcs::to_bytes(&signing_pk).context("Failed to serialize DKG_SIGNING_PK")?;
 
             let created_keys_file = KeysFile {
                 enc_sk,
@@ -646,9 +653,12 @@ async fn main() -> Result<()> {
             };
 
             // Write keys to file.
-            let json_content = serde_json::to_string_pretty(&created_keys_file)?;
+            let json_content = serde_json::to_string_pretty(&created_keys_file)
+                .context("Failed to serialize dkg.key")?;
             if let Some(parent) = keys_file.parent() {
-                fs::create_dir_all(parent)?;
+                fs::create_dir_all(parent).with_context(|| {
+                    format!("Failed to create keys directory {}", parent.display())
+                })?;
             }
             write_secret_file(&keys_file, &json_content)?;
 
@@ -680,7 +690,7 @@ async fn main() -> Result<()> {
             let name_arg = register_builder.pure(server_name.as_str())?;
 
             register_builder.programmable_move_call(
-                committee_pkg,
+                committee_pkg.into(),
                 "seal_committee".parse()?,
                 "register".parse()?,
                 vec![],
@@ -737,7 +747,7 @@ async fn main() -> Result<()> {
 
             let committee_pkg = get_committee_pkg(&config_content)?;
             let committee_id = get_committee_id(&config_content)?;
-            let my_address = SuiAddress::from_bytes(get_my_address(&config_content)?.inner())?;
+            let my_address = SuiAddress::from_bytes(get_my_address(&config_content)?.into_inner())?;
             let network = get_network(&config_content)?;
             let node_url = get_node_url(&config_content);
             print_network_info(&network, node_url.as_deref());
@@ -746,7 +756,11 @@ async fn main() -> Result<()> {
             let current_committee_id =
                 get_config_field(&config_content, &["init-rotation"], "CURRENT_COMMITTEE_ID")
                     .and_then(|v| v.as_str())
-                    .map(ObjectID::from_hex_literal)
+                    .map(|id| {
+                        Address::from_str(id).with_context(|| {
+                            format!("Invalid init-rotation.CURRENT_COMMITTEE_ID {id}")
+                        })
+                    })
                     .transpose()?;
             let is_rotation = current_committee_id.is_some();
 
@@ -759,97 +773,65 @@ async fn main() -> Result<()> {
             let mut state = DkgState::load(&state_dir)?;
             let local_keys = KeysFile::load(&keys_file)?;
 
-            // Load and process all messages.
-            let messages = load_messages_from_dir(&full_messages_dir)?;
-            let (output, messages_hash) = process_dkg_messages(&mut state, messages, &local_keys)?;
-
-            // Determine version and fetch old key server PK (for rotation).
+            // Determine version before processing so stale config fails before expensive DKG work.
             let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
             let (next_version, old_key_server_pk) =
                 get_committee_rotation_info(&mut grpc_client, &state.config.committee_id).await?;
-
-            // Extract key server PK and master share.
-            let key_server_pk_bytes = bcs::to_bytes(&output.vss_pk.c0())?;
-            let master_share_bytes = if let Some(shares) = &output.shares {
-                shares
-                    .first()
-                    .map(|share| bcs::to_bytes(&share.value))
-                    .transpose()?
-                    .unwrap_or_default()
-            } else {
-                vec![]
-            };
-
-            // Check if already written to config.
-            let master_share_key = format!("MASTER_SHARE_V{}", next_version);
-            let partial_pks_key = format!("PARTIAL_PKS_V{}", next_version);
-
-            if get_config_field(
-                &config_content,
-                &["process-all-and-propose"],
-                &master_share_key,
-            )
-            .is_some()
-                || get_config_field(
-                    &config_content,
-                    &["process-all-and-propose"],
-                    &partial_pks_key,
-                )
-                .is_some()
-            {
-                println!("[WARNING] Skipping processing and onchain proposal. To reprocess messages and propose onchain, remove the process-all-and-propose section from the config file.");
+            let existing_output_fields =
+                existing_process_output_fields(&config_content, next_version);
+            if !existing_output_fields.is_empty() {
+                println!(
+                    "[WARNING] Skipping processing and onchain proposal because process-all-and-propose already contains {:?}. Remove these field(s) from the config file to reprocess messages and propose onchain.",
+                    existing_output_fields
+                );
                 return Ok(());
             }
+            validate_process_output_version(
+                &config_content,
+                next_version,
+                old_key_server_pk.as_deref(),
+            )?;
+
+            // Load and process all messages.
+            let messages = load_messages_from_dir(&full_messages_dir)?;
+            let (output, messages_hash) = process_dkg_messages(&mut state, messages, &local_keys)
+                .context("Failed to process DKG messages")?;
+
+            // Extract key server PK and master share.
+            let key_server_pk_bytes =
+                bcs::to_bytes(&output.vss_pk.c0()).context("Failed to serialize KEY_SERVER_PK")?;
+            let master_share_bytes = output
+                .shares
+                .as_ref()
+                .and_then(|shares| shares.first())
+                .map(|share| {
+                    bcs::to_bytes(&share.value).with_context(|| {
+                        format!("Failed to serialize MASTER_SHARE_V{next_version}")
+                    })
+                })
+                .transpose()?
+                .ok_or_else(|| anyhow!("DKG output did not contain a master share"))?;
 
             // Serialize partial_pks to yaml list.
             let mut partial_pks = Vec::new();
             for party_id in 0..state.config.nodes.num_nodes() {
                 let share_index = NonZeroU16::new(party_id as u16 + 1).expect("must be valid");
                 let partial_pk = output.vss_pk.eval(share_index);
-                partial_pks.push(to_hex(&partial_pk.value)?);
+                partial_pks.push(to_hex(&partial_pk.value).with_context(|| {
+                    format!("Failed to serialize PARTIAL_PKS_V{next_version}[{party_id}]")
+                })?);
             }
-            let partial_pks_yaml = serde_yaml::to_string(&partial_pks)?;
+            let partial_pks_yaml = serde_yaml::to_string(&partial_pks)
+                .with_context(|| format!("Failed to serialize PARTIAL_PKS_V{next_version}"))?;
 
-            if next_version == 0 {
-                // For v0, add KEY_SERVER_PK, PARTIAL_PKS_V0, MASTER_SHARE_V0.
-                update_config_bytes_val(
-                    &config,
-                    "process-all-and-propose",
-                    vec![("KEY_SERVER_PK", &key_server_pk_bytes)],
-                )?;
-                update_config_string_val(
-                    &config,
-                    "process-all-and-propose",
-                    vec![(partial_pks_key.as_str(), partial_pks_yaml.trim())],
-                )?;
-                update_config_bytes_val(
-                    &config,
-                    "process-all-and-propose",
-                    vec![(master_share_key.as_str(), &master_share_bytes)],
-                )?;
-            } else {
-                // For rotation, verify KEY_SERVER_PK matches the onchain old committee's key server PK.
-                if let Some(onchain_pk) = old_key_server_pk {
-                    if onchain_pk != key_server_pk_bytes {
-                        bail!(
-                            "KEY_SERVER_PK mismatch!\n  Expected (onchain): {}\n  Got (from rotation DKG): {}",
-                            Hex::encode_with_format(&onchain_pk),
-                            Hex::encode_with_format(&key_server_pk_bytes),
-                        );
-                    }
-                    println!("✓ KEY_SERVER_PK matches onchain old committee.");
-                }
-                update_config_string_val(
-                    &config,
-                    "process-all-and-propose",
-                    vec![(partial_pks_key.as_str(), partial_pks_yaml.trim())],
-                )?;
-                update_config_bytes_val(
-                    &config,
-                    "process-all-and-propose",
-                    vec![(master_share_key.as_str(), &master_share_bytes)],
-                )?;
-            }
+            persist_process_outputs(
+                &config,
+                next_version,
+                &key_server_pk_bytes,
+                old_key_server_pk.as_deref(),
+                partial_pks_yaml.trim(),
+                &master_share_bytes,
+            )?;
 
             if next_version == 0 {
                 println!("\n✓ Updated {} process-all-and-propose section with KEY_SERVER_PK, PARTIAL_PKS_V{}, MASTER_SHARE_V{}", config.display(), next_version, next_version);
@@ -882,14 +864,13 @@ async fn main() -> Result<()> {
             let messages_hash_arg = propose_builder.pure(messages_hash)?;
 
             if is_rotation {
-                let current_committee_obj_id = current_committee_id.unwrap();
                 let current_committee_arg = propose_builder.obj(
-                    get_shared_committee_arg(&mut grpc_client, current_committee_obj_id, true)
+                    get_shared_committee_arg(&mut grpc_client, current_committee_id.unwrap(), true)
                         .await?,
                 )?;
 
                 propose_builder.programmable_move_call(
-                    committee_pkg,
+                    committee_pkg.into(),
                     "seal_committee".parse()?,
                     "propose_for_rotation".parse()?,
                     vec![],
@@ -905,7 +886,7 @@ async fn main() -> Result<()> {
                 let key_server_pk_arg = propose_builder.pure(key_server_pk_bytes)?;
 
                 propose_builder.programmable_move_call(
-                    committee_pkg,
+                    committee_pkg.into(),
                     "seal_committee".parse()?,
                     "propose".parse()?,
                     vec![],
@@ -950,7 +931,7 @@ async fn main() -> Result<()> {
             let (config, _) = derive_paths(&state_dir);
             let config_content = load_config(&config)?;
 
-            let committee_id = Address::from(get_committee_id(&config_content)?.into_bytes());
+            let committee_id = get_committee_id(&config_content)?;
             let network = get_network(&config_content)?;
             let node_url = get_node_url(&config_content);
             print_network_info(&network, node_url.as_deref());
@@ -1183,8 +1164,6 @@ async fn main() -> Result<()> {
             println!("Current package: {}", committee_pkg);
             println!("Package version: {}", upgrade_manager.cap.version);
 
-            let committee_obj_id = ObjectID::new(committee_id.into_inner());
-
             // Get dependencies for upgrade.
             let dependencies: Vec<ObjectID> = compiled_package
                 .dependency_ids
@@ -1197,7 +1176,7 @@ async fn main() -> Result<()> {
 
             // Call authorize_upgrade.
             let committee_arg_auth = upgrade_builder
-                .obj(get_shared_committee_arg(&mut grpc_client, committee_obj_id, true).await?)?;
+                .obj(get_shared_committee_arg(&mut grpc_client, committee_id, true).await?)?;
 
             let upgrade_ticket = upgrade_builder.programmable_move_call(
                 committee_pkg,
@@ -1217,7 +1196,7 @@ async fn main() -> Result<()> {
 
             // Commit upgrade.
             let committee_arg_commit = upgrade_builder
-                .obj(get_shared_committee_arg(&mut grpc_client, committee_obj_id, true).await?)?;
+                .obj(get_shared_committee_arg(&mut grpc_client, committee_id, true).await?)?;
 
             upgrade_builder.programmable_move_call(
                 committee_pkg,
@@ -1282,9 +1261,8 @@ async fn main() -> Result<()> {
 
             // Build reset transaction.
             let mut reset_builder = ProgrammableTransactionBuilder::new();
-            let committee_obj_id = ObjectID::new(committee_id.into_inner());
             let committee_arg = reset_builder
-                .obj(get_shared_committee_arg(&mut grpc_client, committee_obj_id, true).await?)?;
+                .obj(get_shared_committee_arg(&mut grpc_client, committee_id, true).await?)?;
 
             reset_builder.programmable_move_call(
                 committee_pkg,
@@ -1443,13 +1421,16 @@ async fn execute_tx_and_log_status(
     tx_data: TransactionData,
 ) -> Result<ExecutedTransaction> {
     let transaction = wallet.sign_transaction(&tx_data).await;
-    let response = wallet.execute_transaction_may_fail(transaction).await?;
+    let response = wallet
+        .execute_transaction_may_fail(transaction)
+        .await
+        .context("Failed to execute transaction")?;
 
     let digest = response.transaction.digest();
     let status = response.effects.status();
 
     if !status.is_ok() {
-        bail!("Transaction FAILED with status: {:?}", status);
+        bail!("Transaction FAILED: digest {}, status {:?}", digest, status);
     }
 
     println!("Transaction SUCCESS!");
@@ -1487,7 +1468,7 @@ fn extract_created_committee_id(response: &ExecutedTransaction) -> Result<Object
 /// Get shared object argument for a committee object using gRPC.
 async fn get_shared_committee_arg(
     grpc_client: &mut sui_rpc::client::Client,
-    committee_id: ObjectID,
+    committee_id: Address,
     mutable: bool,
 ) -> Result<ObjectArg> {
     let mut ledger_client = grpc_client.ledger_client();
@@ -1501,23 +1482,24 @@ async fn get_shared_committee_arg(
     let response = ledger_client
         .get_object(request)
         .await
-        .map(|r| r.into_inner())?;
+        .with_context(|| format!("Failed to fetch committee object {}", committee_id))?
+        .into_inner();
 
     let object = response
         .object
-        .ok_or_else(|| anyhow!("Committee object not found"))?;
+        .ok_or_else(|| anyhow!("Committee object {} not found", committee_id))?;
 
     let owner = object
         .owner
-        .ok_or_else(|| anyhow!("Committee object has no owner"))?;
+        .ok_or_else(|| anyhow!("Committee object {} has no owner", committee_id))?;
 
     // Get initial_shared_version for shared object committee.
     let initial_shared_version = owner
         .version
-        .ok_or_else(|| anyhow!("Shared object has no version"))?;
+        .ok_or_else(|| anyhow!("Shared committee object {} has no version", committee_id))?;
 
     Ok(ObjectArg::SharedObject {
-        id: committee_id,
+        id: committee_id.into(),
         initial_shared_version: initial_shared_version.into(),
         mutability: if mutable {
             SharedObjectMutability::Mutable
@@ -1537,7 +1519,7 @@ async fn create_dkg_state_and_message(
     // Load config to get parameters.
     let config_content = load_config(config)?;
     let my_address = get_my_address(&config_content)?;
-    let committee_id = Address::from(get_committee_id(&config_content)?.into_bytes());
+    let committee_id = get_committee_id(&config_content)?;
     let network = get_network(&config_content)?;
     let node_url = get_node_url(&config_content);
     print_network_info(&network, node_url.as_deref());
@@ -1546,7 +1528,7 @@ async fn create_dkg_state_and_message(
     let local_keys = KeysFile::load(keys_file)?;
 
     // Compute old public key from old share if provided. Provided for continuing members in key rotation.
-    let (my_old_share, my_old_pk) = if let Some(key_share) = old_share {
+    let (my_old_share, derived_old_pk) = if let Some(key_share) = old_share {
         let key_pk = G2Element::generator() * key_share;
         println!("Continuing member for key rotation, old share parsed.");
         (Some(key_share), Some(key_pk))
@@ -1556,7 +1538,9 @@ async fn create_dkg_state_and_message(
 
     // Fetch current committee from onchain.
     let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
-    let committee = fetch_committee_data(&mut grpc_client, &committee_id).await?;
+    let committee = fetch_committee_data(&mut grpc_client, &committee_id)
+        .await
+        .with_context(|| format!("Failed to fetch committee {}", committee_id))?;
 
     // Validate committee state contains my address.
     if !committee.contains(&my_address) {
@@ -1574,7 +1558,9 @@ async fn create_dkg_state_and_message(
     );
 
     // Fetch members info.
-    let members_info = committee.get_members_info()?;
+    let members_info = committee
+        .get_members_info()
+        .with_context(|| format!("Failed to parse member info for committee {}", committee_id))?;
 
     let my_member_info = members_info
         .get(&my_address)
@@ -1612,14 +1598,34 @@ async fn create_dkg_state_and_message(
         Some(old_committee_id) => {
             println!("Old committee ID: {old_committee_id}, performing key rotation.");
 
-            let old_committee = fetch_committee_data(&mut grpc_client, &old_committee_id).await?;
+            let old_committee = fetch_committee_data(&mut grpc_client, &old_committee_id)
+                .await
+                .with_context(|| format!("Failed to fetch old committee {}", old_committee_id))?;
             let old_threshold = Some(old_committee.threshold);
             let new_to_old_mapping = build_new_to_old_map(&committee, &old_committee);
+            validate_rotation_quorum(
+                &old_committee_id,
+                old_committee.threshold,
+                new_to_old_mapping.len(),
+            )?;
 
             // Fetch partial key server info from the old committee's key server object.
-            let (_, ks) =
-                fetch_key_server_by_committee(&mut grpc_client, &old_committee_id).await?;
-            let old_partial_key_infos = ks.to_partial_key_servers(&old_committee.members)?;
+            let (_, ks) = fetch_key_server_by_committee(&mut grpc_client, &old_committee_id)
+                .await
+                .with_context(|| {
+                    format!(
+                        "Failed to fetch key server for old committee {}",
+                        old_committee_id
+                    )
+                })?;
+            let old_partial_key_infos = ks
+                .to_partial_key_servers(&old_committee.members)
+                .with_context(|| {
+                    format!(
+                        "Failed to parse old partial key server info for committee {}",
+                        old_committee_id
+                    )
+                })?;
 
             // Build mapping from old party ID to partial public key.
             let expected_old_pks: HashMap<u16, G2Element> = old_partial_key_infos
@@ -1637,6 +1643,17 @@ async fn create_dkg_state_and_message(
                             old_committee_id
                         ));
                     }
+                    let derived_old_pk = derived_old_pk.as_ref().ok_or_else(|| {
+                        anyhow!("Internal error: --old-share was parsed but no old public key was derived")
+                    })?;
+                    validate_continuing_member_old_share(
+                        &my_address,
+                        &old_committee_id,
+                        my_party_id,
+                        &new_to_old_mapping,
+                        &expected_old_pks,
+                        derived_old_pk,
+                    )?;
                     println!("Continuing member for key rotation.");
                 }
                 None => {
@@ -1678,15 +1695,20 @@ async fn create_dkg_state_and_message(
         let random_oracle = create_dkg_random_oracle(&committee_id);
         let party = Party::<G2Element, G1Element>::new_advanced(
             local_keys.enc_sk.clone(),
-            Nodes::new(nodes.clone())?.clone(),
+            Nodes::new(nodes.clone())
+                .context("Failed to build DKG nodes")?
+                .clone(),
             committee.threshold,
             random_oracle,
             my_old_share,
             old_threshold,
             &mut thread_rng(),
-        )?;
+        )
+        .context("Failed to initialize DKG party")?;
 
-        let message = party.create_message(&mut thread_rng())?;
+        let message = party
+            .create_message(&mut thread_rng())
+            .context("Failed to create DKG message")?;
         let nizk_proof = party.nizk_pop_of_secret(&mut thread_rng());
         let signed_message = sign_message(
             &committee_id,
@@ -1696,13 +1718,18 @@ async fn create_dkg_state_and_message(
         );
 
         // Write message to file.
-        let message_hex = bcs_hex_encode!(&signed_message);
+        let message_bytes =
+            bcs::to_bytes(&signed_message).context("Failed to serialize signed DKG message")?;
+        let message_hex = Hex::encode(message_bytes);
         let message_file = state_dir.join(format!("message_{my_party_id}.json"));
 
         let message_json = serde_json::json!({
             "message": message_hex
         });
-        fs::write(&message_file, serde_json::to_string_pretty(&message_json)?)?;
+        let message_json = serde_json::to_string_pretty(&message_json)
+            .context("Failed to serialize DKG message JSON")?;
+        fs::write(&message_file, message_json)
+            .with_context(|| format!("Failed to write DKG message {}", message_file.display()))?;
 
         println!(
             "DKG message written to: {}. Share this file with the coordinator.",
@@ -1717,7 +1744,7 @@ async fn create_dkg_state_and_message(
     let state = DkgState {
         config: InitializedConfig {
             my_party_id,
-            nodes: Nodes::new(nodes)?,
+            nodes: Nodes::new(nodes).context("Failed to build DKG state nodes")?,
             committee_id,
             threshold: committee.threshold,
             signing_pks,
@@ -1725,7 +1752,6 @@ async fn create_dkg_state_and_message(
             new_to_old_mapping,
             expected_old_pks,
             my_old_share,
-            my_old_pk,
         },
         my_message,
         received_messages: HashMap::new(),
@@ -1734,7 +1760,9 @@ async fn create_dkg_state_and_message(
         output: None,
     };
 
-    state.save(state_dir)?;
+    state
+        .save(state_dir)
+        .with_context(|| format!("Failed to save DKG state in {}", state_dir.display()))?;
     println!(
         "State saved to {state_dir:?}. Wait for coordinator to announce Phase C (Finalization)."
     );
@@ -1748,10 +1776,16 @@ async fn get_gas_params(
     address: SuiAddress,
     gas_budget: u64,
 ) -> Result<(u64, u64, sui_types::base_types::ObjectRef)> {
-    let gas_price = grpc_client.get_reference_gas_price().await?;
+    let gas_price = grpc_client
+        .get_reference_gas_price()
+        .await
+        .context("Failed to fetch reference gas price")?;
     let gas_coin = wallet
         .gas_for_owner_budget(address, gas_budget, Default::default())
-        .await?
+        .await
+        .with_context(|| {
+            format!("Failed to select gas coin for {address} with budget {gas_budget}")
+        })?
         .1;
     Ok((gas_price, gas_budget, gas_coin.compute_object_reference()))
 }
@@ -1769,7 +1803,8 @@ fn load_wallet(
         default
     };
 
-    let mut wallet = WalletContext::new(&config_path).context("Failed to load wallet context")?;
+    let mut wallet = WalletContext::new(&config_path)
+        .with_context(|| format!("Failed to load wallet context {}", config_path.display()))?;
 
     // Override active address if specified.
     if let Some(addr) = active_address {
@@ -1829,12 +1864,16 @@ fn derive_paths(state_dir: &Path) -> (PathBuf, PathBuf) {
 
 /// Helper function to write a file with restricted permissions (owner only) in Unix systems.
 fn write_secret_file(path: &Path, content: &str) -> Result<()> {
-    fs::write(path, content)?;
+    fs::write(path, content)
+        .with_context(|| format!("Failed to write secret file {}", path.display()))?;
     #[cfg(unix)]
     {
-        let mut perms = fs::metadata(path)?.permissions();
+        let mut perms = fs::metadata(path)
+            .with_context(|| format!("Failed to stat secret file {}", path.display()))?
+            .permissions();
         perms.set_mode(0o600);
-        fs::set_permissions(path, perms)?;
+        fs::set_permissions(path, perms)
+            .with_context(|| format!("Failed to set permissions on {}", path.display()))?;
     }
     Ok(())
 }
@@ -1842,6 +1881,45 @@ fn write_secret_file(path: &Path, content: &str) -> Result<()> {
 /// Helper function to BCS-serialize and format any serializable value as hex string with 0x prefix.
 fn to_hex<T: Serialize>(value: &T) -> Result<String> {
     Ok(Hex::encode_with_format(&bcs::to_bytes(value)?))
+}
+
+/// Validate a continuing rotation member's old share against the old onchain partial public key.
+fn validate_continuing_member_old_share(
+    my_address: &Address,
+    old_committee_id: &Address,
+    new_party_id: u16,
+    new_to_old_mapping: &HashMap<u16, u16>,
+    expected_old_pks: &HashMap<u16, G2Element>,
+    derived_old_pk: &G2Element,
+) -> Result<()> {
+    let old_party_id = new_to_old_mapping.get(&new_party_id).ok_or_else(|| {
+        anyhow!(
+            "Continuing member {} with new party ID {} is missing an old party mapping for committee {}",
+            my_address,
+            new_party_id,
+            old_committee_id,
+        )
+    })?;
+    let expected_old_pk = expected_old_pks.get(old_party_id).ok_or_else(|| {
+        anyhow!(
+            "Old partial public key not found for old party {} in committee {}",
+            old_party_id,
+            old_committee_id,
+        )
+    })?;
+
+    if expected_old_pk != derived_old_pk {
+        bail!(
+            "Invalid --old-share for address {}: derived old partial public key does not match onchain old committee {} party {}.\n  Expected (onchain): {}\n  Got (from --old-share): {}",
+            my_address,
+            old_committee_id,
+            old_party_id,
+            to_hex(expected_old_pk)?,
+            to_hex(derived_old_pk)?,
+        );
+    }
+
+    Ok(())
 }
 
 /// Load YAML configuration file.
@@ -1874,7 +1952,7 @@ fn get_network(config: &serde_yaml::Value) -> Result<Network> {
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("NETWORK not found in config or invalid"))?;
 
-    Network::from_str(network_str).map_err(|e| anyhow!(e))
+    Network::from_str(network_str).map_err(|e| anyhow!("Invalid NETWORK {network_str}: {e}"))
 }
 
 /// Get optional NODE_URL from config.
@@ -1903,7 +1981,7 @@ fn print_network_info(network: &Network, rpc_url: Option<&str>) {
 }
 
 /// Get members list from config.
-fn get_members(config: &serde_yaml::Value) -> Result<Vec<SuiAddress>> {
+fn get_members(config: &serde_yaml::Value) -> Result<Vec<Address>> {
     let members = get_config_field(config, &["init-params"], "MEMBERS")
         .and_then(|v| v.as_sequence())
         .ok_or_else(|| anyhow!("MEMBERS list not found or invalid in config"))?;
@@ -1914,11 +1992,13 @@ fn get_members(config: &serde_yaml::Value) -> Result<Vec<SuiAddress>> {
 
     members
         .iter()
-        .map(|member| {
+        .enumerate()
+        .map(|(index, member)| {
             let addr_str = member
                 .as_str()
-                .ok_or_else(|| anyhow!("Member address must be a string"))?;
-            SuiAddress::from_str(addr_str).context("Invalid member address")
+                .ok_or_else(|| anyhow!("MEMBERS[{index}] must be a string"))?;
+            Address::from_str(addr_str)
+                .with_context(|| format!("Invalid MEMBERS[{index}] address {addr_str}"))
         })
         .collect()
 }
@@ -1937,35 +2017,48 @@ fn get_threshold(config: &serde_yaml::Value) -> Result<u16> {
 }
 
 /// Get key server object ID from config.
-fn get_key_server_obj_id(config: &serde_yaml::Value) -> Result<String> {
-    get_config_field(config, &["init-rotation-params"], "KEY_SERVER_OBJ_ID")
+fn get_key_server_obj_id(config: &serde_yaml::Value) -> Result<Address> {
+    let id_str = get_config_field(config, &["init-rotation-params"], "KEY_SERVER_OBJ_ID")
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string())
-        .ok_or_else(|| anyhow!("KEY_SERVER_OBJ_ID not found in config"))
+        .ok_or_else(|| anyhow!("KEY_SERVER_OBJ_ID not found in config"))?;
+    Address::from_str(id_str).with_context(|| format!("Invalid KEY_SERVER_OBJ_ID {id_str}"))
 }
 
 /// Get COMMITTEE_PKG from config.
-fn get_committee_pkg(config: &serde_yaml::Value) -> Result<ObjectID> {
-    let pkg_str = get_config_field(
-        config,
-        &["publish-and-init", "init-rotation"],
-        "COMMITTEE_PKG",
-    )
-    .and_then(|v| v.as_str())
-    .ok_or_else(|| anyhow!("COMMITTEE_PKG not found in config"))?;
-    Ok(ObjectID::from_hex_literal(pkg_str)?)
+fn get_committee_pkg(config: &serde_yaml::Value) -> Result<Address> {
+    let sections = committee_id_sections(config);
+    let pkg_str = get_config_field(config, &sections, "COMMITTEE_PKG")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("COMMITTEE_PKG not found in config"))?;
+    Address::from_str(pkg_str).with_context(|| {
+        format!(
+            "Invalid {}.COMMITTEE_PKG {pkg_str}",
+            sections.first().copied().unwrap_or("config")
+        )
+    })
 }
 
 /// Get COMMITTEE_ID from config.
-fn get_committee_id(config: &serde_yaml::Value) -> Result<ObjectID> {
-    let id_str = get_config_field(
-        config,
-        &["publish-and-init", "init-rotation"],
-        "COMMITTEE_ID",
-    )
-    .and_then(|v| v.as_str())
-    .ok_or_else(|| anyhow!("COMMITTEE_ID not found in config"))?;
-    Ok(ObjectID::from_hex_literal(id_str)?)
+fn get_committee_id(config: &serde_yaml::Value) -> Result<Address> {
+    let sections = committee_id_sections(config);
+    let id_str = get_config_field(config, &sections, "COMMITTEE_ID")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("COMMITTEE_ID not found in config"))?;
+    Address::from_str(id_str).with_context(|| {
+        format!(
+            "Invalid {}.COMMITTEE_ID {id_str}",
+            sections.first().copied().unwrap_or("config")
+        )
+    })
+}
+
+/// Select the generated config section that owns COMMITTEE_PKG and COMMITTEE_ID.
+fn committee_id_sections(config: &serde_yaml::Value) -> [&'static str; 1] {
+    if get_config_field(config, &["init-rotation-params"], "KEY_SERVER_OBJ_ID").is_some() {
+        ["init-rotation"]
+    } else {
+        ["publish-and-init"]
+    }
 }
 
 /// Get MY_ADDRESS from config.
@@ -1973,26 +2066,39 @@ fn get_my_address(config: &serde_yaml::Value) -> Result<Address> {
     let addr_str = get_config_field(config, &["genkey-and-register"], "MY_ADDRESS")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("MY_ADDRESS not found in config"))?;
-    Ok(Address::from_str(addr_str)?)
+    Address::from_str(addr_str).with_context(|| format!("Invalid MY_ADDRESS {addr_str}"))
 }
 
 /// Update fields within a specific section of the YAML config with hex-encoded byte values.
 fn update_config_bytes_val(path: &Path, section: &str, updates: Vec<(&str, &[u8])>) -> Result<()> {
-    let string_updates: Vec<(&str, String)> = updates
-        .into_iter()
-        .map(|(key, bytes)| (key, Hex::encode_with_format(bytes)))
-        .collect();
-    let string_refs: Vec<(&str, &str)> = string_updates
-        .iter()
-        .map(|(k, v)| (*k, v.as_str()))
-        .collect();
-    update_config_string_val(path, section, string_refs)
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let mut config: serde_yaml::Value = serde_yaml::from_str(&content)
+        .with_context(|| format!("Failed to parse YAML config {}", path.display()))?;
+
+    // Ensure the section exists.
+    if config.get(section).is_none() {
+        config[section] = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+    }
+
+    // Hex byte fields must stay strings. Parsing them as YAML can turn 0x-prefixed values into
+    // numbers, which breaks later config reads that expect strings.
+    for (key, bytes) in updates {
+        config[section][key] = serde_yaml::Value::String(Hex::encode_with_format(bytes));
+    }
+
+    let updated = serde_yaml::to_string(&config)
+        .with_context(|| format!("Failed to serialize YAML config {}", path.display()))?;
+    fs::write(path, updated).with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
 }
 
 /// Update fields within a specific section of the YAML config with string values.
 fn update_config_string_val(path: &Path, section: &str, updates: Vec<(&str, &str)>) -> Result<()> {
-    let content = fs::read_to_string(path)?;
-    let mut config: serde_yaml::Value = serde_yaml::from_str(&content)?;
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let mut config: serde_yaml::Value = serde_yaml::from_str(&content)
+        .with_context(|| format!("Failed to parse YAML config {}", path.display()))?;
 
     // Ensure the section exists.
     if config.get(section).is_none() {
@@ -2006,9 +2112,205 @@ fn update_config_string_val(path: &Path, section: &str, updates: Vec<(&str, &str
         config[section][key] = yaml_value;
     }
 
-    let updated = serde_yaml::to_string(&config)?;
-    fs::write(path, updated)?;
+    let updated = serde_yaml::to_string(&config)
+        .with_context(|| format!("Failed to serialize YAML config {}", path.display()))?;
+    fs::write(path, updated).with_context(|| format!("Failed to write {}", path.display()))?;
     Ok(())
+}
+
+/// Validate and persist process-all-and-propose outputs for fresh DKG or rotation.
+fn persist_process_outputs(
+    config: &Path,
+    next_version: u32,
+    key_server_pk_bytes: &[u8],
+    old_key_server_pk: Option<&[u8]>,
+    partial_pks_yaml: &str,
+    master_share_bytes: &[u8],
+) -> Result<()> {
+    let master_share_key = format!("MASTER_SHARE_V{}", next_version);
+    let partial_pks_key = format!("PARTIAL_PKS_V{}", next_version);
+    let config_content = load_config(config)?;
+    validate_process_output_version(&config_content, next_version, old_key_server_pk)?;
+
+    bcs::from_bytes::<G2Element>(key_server_pk_bytes)
+        .context("KEY_SERVER_PK must be a valid BCS G2Element")?;
+    bcs::from_bytes::<G2Scalar>(master_share_bytes)
+        .with_context(|| format!("{master_share_key} must be a valid BCS scalar"))?;
+
+    let partial_pks: Vec<String> = serde_yaml::from_str(partial_pks_yaml)
+        .with_context(|| format!("{partial_pks_key} must be a YAML list of hex G2Elements"))?;
+    if partial_pks.is_empty() {
+        bail!("{partial_pks_key} must not be empty");
+    }
+    for (index, partial_pk) in partial_pks.iter().enumerate() {
+        let partial_pk_bytes = Hex::decode(partial_pk)
+            .with_context(|| format!("{partial_pks_key}[{index}] must be hex"))?;
+        bcs::from_bytes::<G2Element>(&partial_pk_bytes)
+            .with_context(|| format!("{partial_pks_key}[{index}] must be a valid BCS G2Element"))?;
+    }
+
+    if next_version == 0 {
+        update_config_bytes_val(
+            config,
+            "process-all-and-propose",
+            vec![("KEY_SERVER_PK", key_server_pk_bytes)],
+        )?;
+    } else if let Some(onchain_pk) = old_key_server_pk {
+        if onchain_pk != key_server_pk_bytes {
+            bail!(
+                "KEY_SERVER_PK mismatch!\n  Expected (onchain): {}\n  Got (from rotation DKG): {}",
+                Hex::encode_with_format(onchain_pk),
+                Hex::encode_with_format(key_server_pk_bytes),
+            );
+        }
+        println!("✓ KEY_SERVER_PK matches onchain old committee.");
+    }
+
+    update_config_string_val(
+        config,
+        "process-all-and-propose",
+        vec![(partial_pks_key.as_str(), partial_pks_yaml.trim())],
+    )?;
+    update_config_bytes_val(
+        config,
+        "process-all-and-propose",
+        vec![(master_share_key.as_str(), master_share_bytes)],
+    )?;
+
+    Ok(())
+}
+
+/// Validate that a rotation has enough continuing members to satisfy the old threshold.
+fn validate_rotation_quorum(
+    old_committee_id: &Address,
+    old_threshold: u16,
+    continuing_count: usize,
+) -> Result<()> {
+    if continuing_count < old_threshold as usize {
+        bail!(
+            "Rotation cannot meet old committee threshold: old committee {} requires {} continuing member message(s), but only {} new committee member(s) continue from the old committee.",
+            old_committee_id,
+            old_threshold,
+            continuing_count,
+        );
+    }
+
+    Ok(())
+}
+
+/// Validate rotation message senders against the new-party IDs that continue from the old committee.
+fn validate_rotation_message_senders(
+    old_threshold: u16,
+    new_to_old_mapping: &HashMap<u16, u16>,
+    message_senders: &HashSet<u16>,
+) -> Result<()> {
+    if message_senders.len() != old_threshold as usize {
+        bail!(
+            "Key rotation requires exactly {} messages from continuing members, got {}",
+            old_threshold,
+            message_senders.len()
+        );
+    }
+
+    let mut continuing_party_ids: Vec<_> = new_to_old_mapping.keys().copied().collect();
+    continuing_party_ids.sort_unstable();
+    let mut invalid_senders: Vec<_> = message_senders
+        .iter()
+        .copied()
+        .filter(|sender| !new_to_old_mapping.contains_key(sender))
+        .collect();
+    invalid_senders.sort_unstable();
+    if !invalid_senders.is_empty() {
+        bail!(
+            "Key rotation messages must come from continuing members. Invalid new party ID(s): {:?}. Continuing new party ID(s): {:?}",
+            invalid_senders,
+            continuing_party_ids,
+        );
+    }
+
+    if new_to_old_mapping.len() == old_threshold as usize {
+        let mut missing_senders: Vec<_> = continuing_party_ids
+            .iter()
+            .copied()
+            .filter(|sender| !message_senders.contains(sender))
+            .collect();
+        missing_senders.sort_unstable();
+        if !missing_senders.is_empty() {
+            bail!(
+                "Key rotation requires messages from continuing new party ID(s) {:?}. Missing new party ID(s): {:?}",
+                continuing_party_ids,
+                missing_senders,
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Validate process output version fields before writing new DKG output into config.
+fn validate_process_output_version(
+    config: &serde_yaml::Value,
+    next_version: u32,
+    old_key_server_pk: Option<&[u8]>,
+) -> Result<()> {
+    let existing_output_fields = existing_process_output_fields(config, next_version);
+    if !existing_output_fields.is_empty() {
+        bail!(
+            "process-all-and-propose already contains output field(s) for version {}: {:?}. Remove them before reprocessing.",
+            next_version,
+            existing_output_fields,
+        );
+    }
+
+    let existing_key_server_pk =
+        get_config_field(config, &["process-all-and-propose"], "KEY_SERVER_PK")
+            .and_then(|value| value.as_str());
+    if next_version == 0 {
+        if existing_key_server_pk.is_some() {
+            bail!(
+                "process-all-and-propose.KEY_SERVER_PK already exists for fresh DKG. Remove the process-all-and-propose section before reprocessing."
+            );
+        }
+        return Ok(());
+    }
+
+    let onchain_pk = old_key_server_pk.ok_or_else(|| {
+        anyhow!(
+            "Rotation output for version {} requires the old onchain KEY_SERVER_PK",
+            next_version
+        )
+    })?;
+    if let Some(config_pk) = existing_key_server_pk {
+        let config_pk_bytes =
+            Hex::decode(config_pk).context("process-all-and-propose.KEY_SERVER_PK must be hex")?;
+        bcs::from_bytes::<G2Element>(&config_pk_bytes)
+            .context("process-all-and-propose.KEY_SERVER_PK must be a valid BCS G2Element")?;
+        if config_pk_bytes != onchain_pk {
+            bail!(
+                "process-all-and-propose.KEY_SERVER_PK mismatch!\n  Expected (onchain): {}\n  Got (config): {}",
+                Hex::encode_with_format(onchain_pk),
+                Hex::encode_with_format(&config_pk_bytes),
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Return process output field names that would be overwritten for this DKG version.
+fn existing_process_output_fields(config: &serde_yaml::Value, next_version: u32) -> Vec<String> {
+    let mut fields = vec![
+        format!("MASTER_SHARE_V{}", next_version),
+        format!("PARTIAL_PKS_V{}", next_version),
+    ];
+    if next_version == 0 {
+        fields.push("KEY_SERVER_PK".to_string());
+    }
+
+    fields
+        .into_iter()
+        .filter(|field| get_config_field(config, &["process-all-and-propose"], field).is_some())
+        .collect()
 }
 
 /// Create a BuildConfig for package compilation.
@@ -2059,7 +2361,9 @@ fn load_messages_from_dir(messages_dir: &Path) -> Result<Vec<SignedMessage>> {
     })?;
 
     for entry in entries {
-        let path = entry?.path();
+        let path = entry
+            .with_context(|| format!("Failed to read entry in {}", messages_dir.display()))?
+            .path();
         if path.extension().and_then(|s| s.to_str()) != Some("json") {
             continue;
         }
@@ -2074,14 +2378,16 @@ fn load_messages_from_dir(messages_dir: &Path) -> Result<Vec<SignedMessage>> {
             .as_str()
             .ok_or_else(|| anyhow!("Missing 'message' field in {}", path.display()))?;
 
-        let signed_message: SignedMessage =
-            bcs_hex_decode!(SignedMessage, message_hex).map_err(|e| {
-                anyhow!(
-                    "Failed to deserialize message from {}: {}",
-                    path.display(),
-                    e
-                )
-            })?;
+        let message_bytes = Hex::decode(message_hex)
+            .map_err(|e| anyhow!("Failed to decode message from {}: {}", path.display(), e))?;
+
+        let signed_message: SignedMessage = bcs::from_bytes(&message_bytes).map_err(|e| {
+            anyhow!(
+                "Failed to deserialize message from {}: {}",
+                path.display(),
+                e
+            )
+        })?;
 
         messages.push(signed_message);
     }
@@ -2116,7 +2422,8 @@ fn process_dkg_messages(
     // Compute hash over of the vector of messages sorted by sender party ID.
     messages.sort_by_key(|m| m.message.sender);
     let messages_hash = {
-        let hash_input = bcs::to_bytes(&messages)?;
+        let hash_input =
+            bcs::to_bytes(&messages).context("Failed to serialize DKG messages for hashing")?;
         let mut hasher = Blake2b256::default();
         hasher.update(&hash_input);
         hasher.finalize().digest.to_vec()
@@ -2124,13 +2431,12 @@ fn process_dkg_messages(
 
     // Validate message count.
     if let Some(old_threshold) = state.config.old_threshold {
-        if messages.len() != old_threshold as usize {
-            bail!(
-                "Key rotation requires exactly {} messages from continuing members, got {}",
-                old_threshold,
-                messages.len()
-            );
-        }
+        let new_to_old_mapping = state
+            .config
+            .new_to_old_mapping
+            .as_ref()
+            .ok_or_else(|| anyhow!("Missing new-to-old mapping for key rotation"))?;
+        validate_rotation_message_senders(old_threshold, new_to_old_mapping, &seen_senders)?;
     } else {
         let num_parties = state.config.nodes.num_nodes();
         if messages.len() != num_parties {
@@ -2151,7 +2457,8 @@ fn process_dkg_messages(
         state.config.my_old_share,
         state.config.old_threshold,
         &mut thread_rng(),
-    )?;
+    )
+    .context("Failed to initialize DKG party for message processing")?;
 
     // Process each message.
     for signed_msg in messages {
@@ -2198,16 +2505,22 @@ fn process_dkg_messages(
                     anyhow!("Key rotation verification failed for party {sender_party_id}: {e}")
                 })?
         } else {
-            party.process_message_with_checks(
-                signed_msg.message.clone(),
-                &None,
-                &Some(signed_msg.nizk_proof.clone()),
-                &mut thread_rng(),
-            )?
+            party
+                .process_message_with_checks(
+                    signed_msg.message.clone(),
+                    &None,
+                    &Some(signed_msg.nizk_proof.clone()),
+                    &mut thread_rng(),
+                )
+                .with_context(|| {
+                    format!("Fresh DKG verification failed for party {sender_party_id}")
+                })?
         };
 
         if let Some(complaint) = &processed.complaint {
-            let complaint_hex = bcs_hex_encode!(complaint);
+            let complaint_bytes =
+                bcs::to_bytes(complaint).context("Failed to serialize DKG complaint")?;
+            let complaint_hex = Hex::encode(complaint_bytes);
             bail!(
                 "Do NOT propose onchain. Complaint against party {}.\n\
                 Abort the protocol and share the following proof with the coordinator:\n  {}",
@@ -2220,7 +2533,9 @@ fn process_dkg_messages(
     }
 
     // Merge and complete.
-    let (confirmation, used_msgs) = party.merge(&state.processed_messages)?;
+    let (confirmation, used_msgs) = party
+        .merge(&state.processed_messages)
+        .context("Failed to merge processed DKG messages")?;
 
     if !confirmation.complaints.is_empty() {
         bail!(
@@ -2244,9 +2559,13 @@ fn process_dkg_messages(
             .collect();
 
         println!("Completing key rotation with mapping: {sender_to_old_map:?}");
-        party.complete_optimistic_key_rotation(&used_msgs, &sender_to_old_map)?
+        party
+            .complete_optimistic_key_rotation(&used_msgs, &sender_to_old_map)
+            .context("Failed to complete optimistic key rotation")?
     } else {
-        party.complete_optimistic(&used_msgs)?
+        party
+            .complete_optimistic(&used_msgs)
+            .context("Failed to complete fresh optimistic DKG")?
     };
 
     state.output = Some(output.clone());
@@ -2255,7 +2574,8 @@ fn process_dkg_messages(
 
 /// Parse a hex-encoded BCS-serialized G2Scalar from a CLI argument.
 fn parse_old_share(s: &str) -> anyhow::Result<G2Scalar> {
-    Ok(bcs_hex_decode!(G2Scalar, s)?)
+    let bytes = Hex::decode(s).context("--old-share must be hex")?;
+    bcs::from_bytes(&bytes).context("--old-share must be a BCS-serialized G2Scalar")
 }
 
 /// Create a RandomOracle with the DKG domain separator and committee ID.
@@ -2361,9 +2681,8 @@ async fn vote_for_upgrade(
 
     // Build vote transaction.
     let mut vote_builder = ProgrammableTransactionBuilder::new();
-    let committee_obj_id = ObjectID::new(committee_id.into_inner());
-    let committee_arg = vote_builder
-        .obj(get_shared_committee_arg(&mut grpc_client, committee_obj_id, true).await?)?;
+    let committee_arg =
+        vote_builder.obj(get_shared_committee_arg(&mut grpc_client, committee_id, true).await?)?;
 
     let function_name = if approve {
         "approve_digest_for_upgrade"
@@ -2405,3 +2724,6 @@ async fn vote_for_upgrade(
     println!("\n✓ Successfully voted to {}!", function_name);
     Ok(())
 }
+
+#[cfg(test)]
+mod tests;

--- a/crates/seal-committee-cli/src/main.rs
+++ b/crates/seal-committee-cli/src/main.rs
@@ -18,7 +18,7 @@ use fastcrypto_tbls::random_oracle::RandomOracle;
 use move_package_alt_compilation::build_config::BuildConfig as MoveBuildConfig;
 use rand::thread_rng;
 use seal_committee::{
-    build_new_to_old_map, create_grpc_client_from_config, fetch_committee_data,
+    build_new_to_old_map, create_grpc_client_with_url, fetch_committee_data,
     fetch_committee_from_key_server, fetch_key_server_by_committee, fetch_upgrade_manager,
     fetch_upgrade_proposal, get_committee_rotation_info, CommitteeState, KeyServerV2, Network,
     ServerType, UpgradeVote,
@@ -49,6 +49,21 @@ use crate::types::{sign_message, verify_signature, SignedMessage};
 
 /// Domain separation tag for DKG random oracle
 const DST_DKG: &str = "SEAL_DKG_V0:";
+
+macro_rules! bcs_hex_encode {
+    ($val:expr) => {
+        Hex::encode(bcs::to_bytes($val)?)
+    };
+}
+
+macro_rules! bcs_hex_decode {
+    ($ty:ty, $value:expr) => {{
+        (|| -> Result<$ty> {
+            let bytes = Hex::decode($value)?;
+            Ok(bcs::from_bytes::<$ty>(&bytes)?)
+        })()
+    }};
+}
 
 /// Default gas budgets in MIST.
 mod gas_defaults {
@@ -324,14 +339,14 @@ async fn main() -> Result<()> {
                     "Removing {} to enable fresh publish...",
                     published_toml.display()
                 );
-                fs::remove_file(&published_toml)?;
+                fs::remove_file(published_toml)?;
             }
 
             // Build and publish package.
             let compiled_package = create_build_config(&network).build(&committee_path)?;
             let compiled_modules_bytes = compiled_package.get_package_bytes(false);
 
-            let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
+            let mut grpc_client = create_grpc_client_with_url(&network, node_url.as_deref())?;
             let (gas_price, gas_budget, gas_coin_ref) = get_gas_params(
                 &mut grpc_client,
                 &wallet,
@@ -461,7 +476,7 @@ async fn main() -> Result<()> {
             // Fetch committee ID and package ID from key server.
             println!("\nFetching key server: {}...", key_server_obj_id);
 
-            let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
+            let mut grpc_client = create_grpc_client_with_url(&network, node_url.as_deref())?;
             let (current_committee_id, package_id) =
                 fetch_committee_from_key_server(&mut grpc_client, &key_server_obj_id).await?;
 
@@ -644,7 +659,7 @@ async fn main() -> Result<()> {
 
             println!("\n=== Registering onchain ===");
             print_network_info(&network, node_url.as_deref());
-            let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
+            let mut grpc_client = create_grpc_client_with_url(&network, node_url.as_deref())?;
 
             // Register onchain.
             let mut register_builder = ProgrammableTransactionBuilder::new();
@@ -718,18 +733,6 @@ async fn main() -> Result<()> {
             let node_url = get_node_url(&config_content);
             print_network_info(&network, node_url.as_deref());
 
-            // Check if this is a rotation.
-            let current_committee_id =
-                get_config_field(&config_content, "init-rotation", "CURRENT_COMMITTEE_ID")
-                    .and_then(|v| v.as_str())
-                    .map(|id| {
-                        Address::from_str(id).with_context(|| {
-                            format!("Invalid init-rotation.CURRENT_COMMITTEE_ID {id}")
-                        })
-                    })
-                    .transpose()?;
-            let is_rotation = current_committee_id.is_some();
-
             // Process DKG messages.
             println!("\n=== Processing DKG messages ===");
             println!("  Messages directory: {:?}", full_messages_dir);
@@ -737,31 +740,47 @@ async fn main() -> Result<()> {
             println!("  Keys file: {:?}\n", keys_file);
 
             let mut state = DkgState::load(&state_dir)?;
+            if committee_id != state.config.committee_id {
+                bail!(
+                    "dkg.yaml COMMITTEE_ID {} does not match state.json committee ID {}",
+                    committee_id,
+                    state.config.committee_id,
+                );
+            }
             let local_keys = KeysFile::load(&keys_file)?;
 
             // Determine version and fetch old key server PK (for rotation).
-            let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
-            let (next_version, old_key_server_pk) =
+            let mut grpc_client = create_grpc_client_with_url(&network, node_url.as_deref())?;
+            let (next_version, old_key_server_pk, current_committee_id) =
                 get_committee_rotation_info(&mut grpc_client, &state.config.committee_id).await?;
             validate_process_section(&config_content, next_version, old_key_server_pk.as_deref())?;
 
+            let mut wallet = load_wallet_for_network(
+                cli.wallet.as_deref(),
+                cli.active_address,
+                &network,
+                node_url.as_deref(),
+            )?;
+            let active_address = wallet.active_address()?;
+            if my_address != active_address {
+                bail!(
+                    "Active wallet address {} does not match genkey-and-register.MY_ADDRESS {}",
+                    active_address,
+                    my_address,
+                );
+            }
+
             // Load and process all messages.
             let messages = load_messages_from_dir(&full_messages_dir)?;
-            let (output, messages_hash) = process_dkg_messages(&mut state, messages, &local_keys)
-                .context("Failed to process DKG messages")?;
+            let (output, messages_hash) = process_dkg_messages(&mut state, messages, &local_keys)?;
 
             // Extract key server PK and master share.
-            let key_server_pk_bytes =
-                bcs::to_bytes(&output.vss_pk.c0()).context("Failed to serialize KEY_SERVER_PK")?;
+            let key_server_pk_bytes = bcs::to_bytes(&output.vss_pk.c0())?;
             let master_share_bytes = output
                 .shares
                 .as_ref()
                 .and_then(|shares| shares.first())
-                .map(|share| {
-                    bcs::to_bytes(&share.value).with_context(|| {
-                        format!("Failed to serialize MASTER_SHARE_V{next_version}")
-                    })
-                })
+                .map(|share| bcs::to_bytes(&share.value))
                 .transpose()?
                 .ok_or_else(|| anyhow!("DKG output did not contain a master share"))?;
 
@@ -770,12 +789,9 @@ async fn main() -> Result<()> {
             for party_id in 0..state.config.nodes.num_nodes() {
                 let share_index = NonZeroU16::new(party_id as u16 + 1).expect("must be valid");
                 let partial_pk = output.vss_pk.eval(share_index);
-                partial_pks.push(to_hex(&partial_pk.value).with_context(|| {
-                    format!("Failed to serialize PARTIAL_PKS_V{next_version}[{party_id}]")
-                })?);
+                partial_pks.push(to_hex(&partial_pk.value)?);
             }
-            let partial_pks_yaml = serde_yaml::to_string(&partial_pks)
-                .with_context(|| format!("Failed to serialize PARTIAL_PKS_V{next_version}"))?;
+            let partial_pks_yaml = serde_yaml::to_string(&partial_pks)?;
 
             persist_process_outputs(
                 &config,
@@ -785,6 +801,7 @@ async fn main() -> Result<()> {
                 partial_pks_yaml.trim(),
                 &master_share_bytes,
             )?;
+            validate_process_outputs_added(&load_config(&config)?, next_version)?;
 
             if next_version == 0 {
                 println!("\n✓ Updated {} process-all-and-propose section with KEY_SERVER_PK, PARTIAL_PKS_V{}, MASTER_SHARE_V{}", config.display(), next_version, next_version);
@@ -792,18 +809,10 @@ async fn main() -> Result<()> {
                 println!("\n✓ Updated {} process-all-and-propose section with PARTIAL_PKS_V{}, MASTER_SHARE_V{}", config.display(), next_version, next_version);
             }
 
-            // Load wallet.
-            let wallet = load_wallet_for_network(
-                cli.wallet.as_deref(),
-                cli.active_address,
-                &network,
-                node_url.as_deref(),
-            )?;
-
-            if is_rotation {
+            if let Some(current_committee_id) = current_committee_id {
                 println!("\n=== Proposing committee rotation onchain ===");
                 println!("  New Committee ID: {}", committee_id);
-                println!("  Current Committee ID: {}", current_committee_id.unwrap());
+                println!("  Current Committee ID: {}", current_committee_id);
             } else {
                 println!("\n=== Proposing committee onchain ===");
             }
@@ -821,10 +830,9 @@ async fn main() -> Result<()> {
 
             let messages_hash_arg = propose_builder.pure(messages_hash)?;
 
-            if is_rotation {
+            if let Some(current_committee_id) = current_committee_id {
                 let current_committee_arg = propose_builder.obj(
-                    get_shared_committee_arg(&mut grpc_client, current_committee_id.unwrap(), true)
-                        .await?,
+                    get_shared_committee_arg(&mut grpc_client, current_committee_id, true).await?,
                 )?;
 
                 propose_builder.programmable_move_call(
@@ -895,7 +903,7 @@ async fn main() -> Result<()> {
             print_network_info(&network, node_url.as_deref());
 
             // Fetch committee from onchain.
-            let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
+            let mut grpc_client = create_grpc_client_with_url(&network, node_url.as_deref())?;
             let committee = fetch_committee_data(&mut grpc_client, &committee_id).await?;
 
             println!("Committee ID: {committee_id}");
@@ -1010,7 +1018,7 @@ async fn main() -> Result<()> {
             network,
         } => {
             println!("Network: {}", network);
-            compute_package_digest(&package_path, &network).await?;
+            compute_package_digest(&package_path, &network)?;
         }
 
         Commands::ApproveUpgrade {
@@ -1079,7 +1087,7 @@ async fn main() -> Result<()> {
             print_network_info(&network, rpc_url.as_deref());
 
             // Build package and compute digest.
-            let digest = get_package_digest(&package_path, &network).await?;
+            let digest = get_package_digest(&package_path, &network)?;
             println!("\nPackage digest: {}", digest);
 
             // Build the package to get compiled modules and dependencies.
@@ -1087,7 +1095,7 @@ async fn main() -> Result<()> {
             let compiled_modules_bytes = compiled_package.get_package_bytes(false);
 
             // Fetch key server to get committee ID.
-            let mut grpc_client = create_grpc_client_from_config(&network, rpc_url.as_deref())?;
+            let mut grpc_client = create_grpc_client_with_url(&network, rpc_url.as_deref())?;
             let (committee_id, _) =
                 fetch_committee_from_key_server(&mut grpc_client, &key_server_id).await?;
 
@@ -1188,7 +1196,7 @@ async fn main() -> Result<()> {
             print_network_info(&network, rpc_url.as_deref());
 
             // Fetch key server to get committee ID.
-            let mut grpc_client = create_grpc_client_from_config(&network, rpc_url.as_deref())?;
+            let mut grpc_client = create_grpc_client_with_url(&network, rpc_url.as_deref())?;
             let (committee_id, _) =
                 fetch_committee_from_key_server(&mut grpc_client, &key_server_id).await?;
 
@@ -1278,7 +1286,7 @@ async fn main() -> Result<()> {
             print_network_info(&network, rpc_url.as_deref());
             println!("Key Server ID: {}", key_server_id);
 
-            let mut grpc_client = create_grpc_client_from_config(&network, rpc_url.as_deref())?;
+            let mut grpc_client = create_grpc_client_with_url(&network, rpc_url.as_deref())?;
 
             // Fetch committee information.
             let (committee_id, _committee_pkg) =
@@ -1361,10 +1369,7 @@ async fn execute_tx_and_log_status(
     tx_data: TransactionData,
 ) -> Result<ExecutedTransaction> {
     let transaction = wallet.sign_transaction(&tx_data).await;
-    let response = wallet
-        .execute_transaction_may_fail(transaction)
-        .await
-        .context("Failed to execute transaction")?;
+    let response = wallet.execute_transaction_may_fail(transaction).await?;
 
     let digest = response.transaction.digest();
     let status = response.effects.status();
@@ -1419,11 +1424,7 @@ async fn get_shared_committee_arg(
         paths: vec!["owner".to_string()],
     });
 
-    let response = ledger_client
-        .get_object(request)
-        .await
-        .with_context(|| format!("Failed to fetch committee object {}", committee_id))?
-        .into_inner();
+    let response = ledger_client.get_object(request).await?.into_inner();
 
     let object = response
         .object
@@ -1468,7 +1469,7 @@ async fn create_dkg_state_and_message(
     let local_keys = KeysFile::load(keys_file)?;
 
     // Compute old public key from old share if provided. Provided for continuing members in key rotation.
-    let (my_old_share, derived_old_pk) = if let Some(key_share) = old_share {
+    let (my_old_share, my_old_pk) = if let Some(key_share) = old_share {
         let key_pk = G2Element::generator() * key_share;
         println!("Continuing member for key rotation, old share parsed.");
         (Some(key_share), Some(key_pk))
@@ -1477,10 +1478,8 @@ async fn create_dkg_state_and_message(
     };
 
     // Fetch current committee from onchain.
-    let mut grpc_client = create_grpc_client_from_config(&network, node_url.as_deref())?;
-    let committee = fetch_committee_data(&mut grpc_client, &committee_id)
-        .await
-        .with_context(|| format!("Failed to fetch committee {}", committee_id))?;
+    let mut grpc_client = create_grpc_client_with_url(&network, node_url.as_deref())?;
+    let committee = fetch_committee_data(&mut grpc_client, &committee_id).await?;
 
     // Validate committee state contains my address.
     if !committee.contains(&my_address) {
@@ -1498,9 +1497,7 @@ async fn create_dkg_state_and_message(
     );
 
     // Fetch members info.
-    let members_info = committee
-        .get_members_info()
-        .with_context(|| format!("Failed to parse member info for committee {}", committee_id))?;
+    let members_info = committee.get_members_info()?;
 
     let my_member_info = members_info
         .get(&my_address)
@@ -1538,34 +1535,22 @@ async fn create_dkg_state_and_message(
         Some(old_committee_id) => {
             println!("Old committee ID: {old_committee_id}, performing key rotation.");
 
-            let old_committee = fetch_committee_data(&mut grpc_client, &old_committee_id)
-                .await
-                .with_context(|| format!("Failed to fetch old committee {}", old_committee_id))?;
+            let old_committee = fetch_committee_data(&mut grpc_client, &old_committee_id).await?;
             let old_threshold = Some(old_committee.threshold);
             let new_to_old_mapping = build_new_to_old_map(&committee, &old_committee);
-            validate_rotation_quorum(
-                &old_committee_id,
-                old_committee.threshold,
-                new_to_old_mapping.len(),
-            )?;
+            if new_to_old_mapping.len() < old_committee.threshold as usize {
+                bail!(
+                    "Rotation cannot meet old committee threshold: old committee {} requires {} continuing member message(s), but only {} new committee member(s) continue from the old committee.",
+                    old_committee_id,
+                    old_committee.threshold,
+                    new_to_old_mapping.len(),
+                );
+            }
 
             // Fetch partial key server info from the old committee's key server object.
-            let (_, ks) = fetch_key_server_by_committee(&mut grpc_client, &old_committee_id)
-                .await
-                .with_context(|| {
-                    format!(
-                        "Failed to fetch key server for old committee {}",
-                        old_committee_id
-                    )
-                })?;
-            let old_partial_key_infos = ks
-                .to_partial_key_servers(&old_committee.members)
-                .with_context(|| {
-                    format!(
-                        "Failed to parse old partial key server info for committee {}",
-                        old_committee_id
-                    )
-                })?;
+            let (_, ks) =
+                fetch_key_server_by_committee(&mut grpc_client, &old_committee_id).await?;
+            let old_partial_key_infos = ks.to_partial_key_servers(&old_committee.members)?;
 
             // Build mapping from old party ID to partial public key.
             let expected_old_pks: HashMap<u16, G2Element> = old_partial_key_infos
@@ -1583,17 +1568,21 @@ async fn create_dkg_state_and_message(
                             old_committee_id
                         ));
                     }
-                    let derived_old_pk = derived_old_pk.as_ref().ok_or_else(|| {
-                        anyhow!("Internal error: --old-share was parsed but no old public key was derived")
-                    })?;
-                    validate_continuing_member_old_share(
-                        &my_address,
-                        &old_committee_id,
-                        my_party_id,
-                        &new_to_old_mapping,
-                        &expected_old_pks,
-                        derived_old_pk,
-                    )?;
+                    let my_old_pk = my_old_pk
+                        .as_ref()
+                        .expect("--old-share should derive an old public key");
+                    let old_party_id = new_to_old_mapping[&my_party_id];
+                    let expected_old_pk = &expected_old_pks[&old_party_id];
+                    if expected_old_pk != my_old_pk {
+                        bail!(
+                            "Invalid --old-share for address {}: derived old partial public key does not match onchain old committee {} party {}.\n  Expected (onchain): {}\n  Got (from --old-share): {}",
+                            my_address,
+                            old_committee_id,
+                            old_party_id,
+                            to_hex(expected_old_pk)?,
+                            to_hex(my_old_pk)?,
+                        );
+                    }
                     println!("Continuing member for key rotation.");
                 }
                 None => {
@@ -1635,20 +1624,15 @@ async fn create_dkg_state_and_message(
         let random_oracle = create_dkg_random_oracle(&committee_id);
         let party = Party::<G2Element, G1Element>::new_advanced(
             local_keys.enc_sk.clone(),
-            Nodes::new(nodes.clone())
-                .context("Failed to build DKG nodes")?
-                .clone(),
+            Nodes::new(nodes.clone())?.clone(),
             committee.threshold,
             random_oracle,
             my_old_share,
             old_threshold,
             &mut thread_rng(),
-        )
-        .context("Failed to initialize DKG party")?;
+        )?;
 
-        let message = party
-            .create_message(&mut thread_rng())
-            .context("Failed to create DKG message")?;
+        let message = party.create_message(&mut thread_rng())?;
         let nizk_proof = party.nizk_pop_of_secret(&mut thread_rng());
         let signed_message = sign_message(
             &committee_id,
@@ -1658,17 +1642,13 @@ async fn create_dkg_state_and_message(
         );
 
         // Write message to file.
-        let message_bytes =
-            bcs::to_bytes(&signed_message).context("Failed to serialize signed DKG message")?;
-        let message_hex = Hex::encode(message_bytes);
+        let message_hex = bcs_hex_encode!(&signed_message);
         let message_file = state_dir.join(format!("message_{my_party_id}.json"));
 
         let message_json = serde_json::json!({
             "message": message_hex
         });
-        let message_json = serde_json::to_string_pretty(&message_json)
-            .context("Failed to serialize DKG message JSON")?;
-        fs::write(&message_file, message_json)?;
+        fs::write(&message_file, serde_json::to_string_pretty(&message_json)?)?;
 
         println!(
             "DKG message written to: {}. Share this file with the coordinator.",
@@ -1683,7 +1663,7 @@ async fn create_dkg_state_and_message(
     let state = DkgState {
         config: InitializedConfig {
             my_party_id,
-            nodes: Nodes::new(nodes).context("Failed to build DKG state nodes")?,
+            nodes: Nodes::new(nodes)?,
             committee_id,
             threshold: committee.threshold,
             signing_pks,
@@ -1691,7 +1671,7 @@ async fn create_dkg_state_and_message(
             new_to_old_mapping,
             expected_old_pks,
             my_old_share,
-            my_old_pk: derived_old_pk,
+            my_old_pk,
         },
         my_message,
         received_messages: HashMap::new(),
@@ -1700,9 +1680,7 @@ async fn create_dkg_state_and_message(
         output: None,
     };
 
-    state
-        .save(state_dir)
-        .with_context(|| format!("Failed to save DKG state in {}", state_dir.display()))?;
+    state.save(state_dir)?;
     println!(
         "State saved to {state_dir:?}. Wait for coordinator to announce Phase C (Finalization)."
     );
@@ -1724,7 +1702,7 @@ async fn get_gas_params(
     Ok((gas_price, gas_budget, gas_coin.compute_object_reference()))
 }
 
-/// Load wallet context from path.
+/// Load wallet context from path and optionally set active environment.
 fn load_wallet(
     wallet_path: Option<&Path>,
     active_address: Option<SuiAddress>,
@@ -1804,48 +1782,10 @@ fn to_hex<T: Serialize>(value: &T) -> Result<String> {
     Ok(Hex::encode_with_format(&bcs::to_bytes(value)?))
 }
 
-/// Validate a continuing rotation member's old share against the old onchain partial public key.
-fn validate_continuing_member_old_share(
-    my_address: &Address,
-    old_committee_id: &Address,
-    new_party_id: u16,
-    new_to_old_mapping: &HashMap<u16, u16>,
-    expected_old_pks: &HashMap<u16, G2Element>,
-    derived_old_pk: &G2Element,
-) -> Result<()> {
-    let old_party_id = new_to_old_mapping.get(&new_party_id).ok_or_else(|| {
-        anyhow!(
-            "Continuing member {} with new party ID {} is missing an old party mapping for committee {}",
-            my_address,
-            new_party_id,
-            old_committee_id,
-        )
-    })?;
-    let expected_old_pk = expected_old_pks.get(old_party_id).ok_or_else(|| {
-        anyhow!(
-            "Old partial public key not found for old party {} in committee {}",
-            old_party_id,
-            old_committee_id,
-        )
-    })?;
-
-    if expected_old_pk != derived_old_pk {
-        bail!(
-            "Invalid --old-share for address {}: derived old partial public key does not match onchain old committee {} party {}.\n  Expected (onchain): {}\n  Got (from --old-share): {}",
-            my_address,
-            old_committee_id,
-            old_party_id,
-            to_hex(expected_old_pk)?,
-            to_hex(derived_old_pk)?,
-        );
-    }
-
-    Ok(())
-}
-
 /// Load YAML configuration file.
 fn load_config(path: &Path) -> Result<serde_yaml::Value> {
-    let content = fs::read_to_string(path)?;
+    let content = fs::read_to_string(path)
+        .with_context(|| format!("Failed to read config file: {}", path.display()))?;
     serde_yaml::from_str(&content)
         .with_context(|| format!("Failed to parse YAML config: {}", path.display()))
 }
@@ -1898,8 +1838,7 @@ fn get_members(config: &serde_yaml::Value) -> Result<Vec<Address>> {
             let addr_str = member
                 .as_str()
                 .ok_or_else(|| anyhow!("MEMBERS[{index}] must be a string"))?;
-            Address::from_str(addr_str)
-                .with_context(|| format!("Invalid MEMBERS[{index}] address {addr_str}"))
+            Ok(Address::from_str(addr_str)?)
         })
         .collect()
 }
@@ -1922,7 +1861,7 @@ fn get_key_server_obj_id(config: &serde_yaml::Value) -> Result<Address> {
     let id_str = get_config_field(config, "init-rotation-params", "KEY_SERVER_OBJ_ID")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("KEY_SERVER_OBJ_ID not found in config"))?;
-    Address::from_str(id_str).with_context(|| format!("Invalid KEY_SERVER_OBJ_ID {id_str}"))
+    Ok(Address::from_str(id_str)?)
 }
 
 /// Get COMMITTEE_PKG from config.
@@ -1931,7 +1870,7 @@ fn get_committee_pkg(config: &serde_yaml::Value) -> Result<Address> {
     let pkg_str = get_config_field(config, section, "COMMITTEE_PKG")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("COMMITTEE_PKG not found in config"))?;
-    Address::from_str(pkg_str).with_context(|| format!("Invalid {section}.COMMITTEE_PKG {pkg_str}"))
+    Ok(Address::from_str(pkg_str)?)
 }
 
 /// Get COMMITTEE_ID from config.
@@ -1940,7 +1879,7 @@ fn get_committee_id(config: &serde_yaml::Value) -> Result<Address> {
     let id_str = get_config_field(config, section, "COMMITTEE_ID")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("COMMITTEE_ID not found in config"))?;
-    Address::from_str(id_str).with_context(|| format!("Invalid {section}.COMMITTEE_ID {id_str}"))
+    Ok(Address::from_str(id_str)?)
 }
 
 /// Select the generated config section that owns COMMITTEE_PKG and COMMITTEE_ID.
@@ -1957,28 +1896,25 @@ fn get_my_address(config: &serde_yaml::Value) -> Result<Address> {
     let addr_str = get_config_field(config, "genkey-and-register", "MY_ADDRESS")
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("MY_ADDRESS not found in config"))?;
-    Address::from_str(addr_str).with_context(|| format!("Invalid MY_ADDRESS {addr_str}"))
+    Ok(Address::from_str(addr_str)?)
 }
 
 /// Update fields within a specific section of the YAML config with hex-encoded byte values.
 fn update_config_bytes_val(path: &Path, section: &str, updates: Vec<(&str, &[u8])>) -> Result<()> {
     let content = fs::read_to_string(path)?;
-    let mut config: serde_yaml::Value = serde_yaml::from_str(&content)
-        .with_context(|| format!("Failed to parse YAML config {}", path.display()))?;
+    let mut config: serde_yaml::Value = serde_yaml::from_str(&content)?;
 
     // Ensure the section exists.
     if config.get(section).is_none() {
         config[section] = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
     }
 
-    // Hex byte fields must stay strings. Parsing them as YAML can turn 0x-prefixed values into
-    // numbers, which breaks later config reads that expect strings.
+    // Write as hex strings.
     for (key, bytes) in updates {
         config[section][key] = serde_yaml::Value::String(Hex::encode_with_format(bytes));
     }
 
-    let updated = serde_yaml::to_string(&config)
-        .with_context(|| format!("Failed to serialize YAML config {}", path.display()))?;
+    let updated = serde_yaml::to_string(&config)?;
     fs::write(path, updated)?;
     Ok(())
 }
@@ -1986,8 +1922,7 @@ fn update_config_bytes_val(path: &Path, section: &str, updates: Vec<(&str, &[u8]
 /// Update fields within a specific section of the YAML config with string values.
 fn update_config_string_val(path: &Path, section: &str, updates: Vec<(&str, &str)>) -> Result<()> {
     let content = fs::read_to_string(path)?;
-    let mut config: serde_yaml::Value = serde_yaml::from_str(&content)
-        .with_context(|| format!("Failed to parse YAML config {}", path.display()))?;
+    let mut config: serde_yaml::Value = serde_yaml::from_str(&content)?;
 
     // Ensure the section exists.
     if config.get(section).is_none() {
@@ -2001,8 +1936,7 @@ fn update_config_string_val(path: &Path, section: &str, updates: Vec<(&str, &str
         config[section][key] = yaml_value;
     }
 
-    let updated = serde_yaml::to_string(&config)
-        .with_context(|| format!("Failed to serialize YAML config {}", path.display()))?;
+    let updated = serde_yaml::to_string(&config)?;
     fs::write(path, updated)?;
     Ok(())
 }
@@ -2018,25 +1952,6 @@ fn persist_process_outputs(
 ) -> Result<()> {
     let master_share_key = format!("MASTER_SHARE_V{}", next_version);
     let partial_pks_key = format!("PARTIAL_PKS_V{}", next_version);
-    let config_content = load_config(config)?;
-    validate_process_section(&config_content, next_version, old_key_server_pk)?;
-
-    bcs::from_bytes::<G2Element>(key_server_pk_bytes)
-        .context("KEY_SERVER_PK must be a valid BCS G2Element")?;
-    bcs::from_bytes::<G2Scalar>(master_share_bytes)
-        .with_context(|| format!("{master_share_key} must be a valid BCS scalar"))?;
-
-    let partial_pks: Vec<String> = serde_yaml::from_str(partial_pks_yaml)
-        .with_context(|| format!("{partial_pks_key} must be a YAML list of hex G2Elements"))?;
-    if partial_pks.is_empty() {
-        bail!("{partial_pks_key} must not be empty");
-    }
-    for (index, partial_pk) in partial_pks.iter().enumerate() {
-        let partial_pk_bytes = Hex::decode(partial_pk)
-            .with_context(|| format!("{partial_pks_key}[{index}] must be hex"))?;
-        bcs::from_bytes::<G2Element>(&partial_pk_bytes)
-            .with_context(|| format!("{partial_pks_key}[{index}] must be a valid BCS G2Element"))?;
-    }
 
     if next_version == 0 {
         update_config_bytes_val(
@@ -2044,7 +1959,9 @@ fn persist_process_outputs(
             "process-all-and-propose",
             vec![("KEY_SERVER_PK", key_server_pk_bytes)],
         )?;
-    } else if let Some(onchain_pk) = old_key_server_pk {
+    } else {
+        let onchain_pk =
+            old_key_server_pk.expect("rotation output should have old onchain KEY_SERVER_PK");
         if onchain_pk != key_server_pk_bytes {
             bail!(
                 "KEY_SERVER_PK mismatch!\n  Expected (onchain): {}\n  Got (from rotation DKG): {}",
@@ -2069,24 +1986,6 @@ fn persist_process_outputs(
     Ok(())
 }
 
-/// Validate that a rotation has enough continuing members to satisfy the old threshold.
-fn validate_rotation_quorum(
-    old_committee_id: &Address,
-    old_threshold: u16,
-    continuing_count: usize,
-) -> Result<()> {
-    if continuing_count < old_threshold as usize {
-        bail!(
-            "Rotation cannot meet old committee threshold: old committee {} requires {} continuing member message(s), but only {} new committee member(s) continue from the old committee.",
-            old_committee_id,
-            old_threshold,
-            continuing_count,
-        );
-    }
-
-    Ok(())
-}
-
 /// Validate rotation message senders against the new-party IDs that continue from the old committee.
 fn validate_rotation_message_senders(
     old_threshold: u16,
@@ -2101,8 +2000,6 @@ fn validate_rotation_message_senders(
         );
     }
 
-    let mut continuing_party_ids: Vec<_> = new_to_old_mapping.keys().copied().collect();
-    continuing_party_ids.sort_unstable();
     let mut invalid_senders: Vec<_> = message_senders
         .iter()
         .copied()
@@ -2111,26 +2008,9 @@ fn validate_rotation_message_senders(
     invalid_senders.sort_unstable();
     if !invalid_senders.is_empty() {
         bail!(
-            "Key rotation messages must come from continuing members. Invalid new party ID(s): {:?}. Continuing new party ID(s): {:?}",
+            "Key rotation messages must come from continuing members. Invalid new party ID(s): {:?}",
             invalid_senders,
-            continuing_party_ids,
         );
-    }
-
-    if new_to_old_mapping.len() == old_threshold as usize {
-        let mut missing_senders: Vec<_> = continuing_party_ids
-            .iter()
-            .copied()
-            .filter(|sender| !message_senders.contains(sender))
-            .collect();
-        missing_senders.sort_unstable();
-        if !missing_senders.is_empty() {
-            bail!(
-                "Key rotation requires messages from continuing new party ID(s) {:?}. Missing new party ID(s): {:?}",
-                continuing_party_ids,
-                missing_senders,
-            );
-        }
     }
 
     Ok(())
@@ -2154,12 +2034,9 @@ fn validate_process_section(
     let existing_key_server_pk =
         get_config_field(config, "process-all-and-propose", "KEY_SERVER_PK")
             .and_then(|value| value.as_str());
+
+    // Skip validation for fresh dkg.
     if next_version == 0 {
-        if existing_key_server_pk.is_some() {
-            bail!(
-                "process-all-and-propose.KEY_SERVER_PK already exists for fresh DKG. Remove the process-all-and-propose section before reprocessing."
-            );
-        }
         return Ok(());
     }
 
@@ -2170,10 +2047,8 @@ fn validate_process_section(
         )
     })?;
     if let Some(config_pk) = existing_key_server_pk {
-        let config_pk_bytes =
-            Hex::decode(config_pk).context("process-all-and-propose.KEY_SERVER_PK must be hex")?;
-        bcs::from_bytes::<G2Element>(&config_pk_bytes)
-            .context("process-all-and-propose.KEY_SERVER_PK must be a valid BCS G2Element")?;
+        let config_pk_bytes = Hex::decode(config_pk)
+            .map_err(|e| anyhow!("process-all-and-propose.KEY_SERVER_PK must be hex: {e}"))?;
         if config_pk_bytes != onchain_pk {
             bail!(
                 "process-all-and-propose.KEY_SERVER_PK mismatch!\n  Expected (onchain): {}\n  Got (config): {}",
@@ -2186,8 +2061,7 @@ fn validate_process_section(
     Ok(())
 }
 
-/// Return process output field names that would be overwritten for this DKG version.
-fn existing_process_output_fields(config: &serde_yaml::Value, next_version: u32) -> Vec<String> {
+fn expected_process_output_fields(next_version: u32) -> Vec<String> {
     let mut fields = vec![
         format!("MASTER_SHARE_V{}", next_version),
         format!("PARTIAL_PKS_V{}", next_version),
@@ -2195,11 +2069,31 @@ fn existing_process_output_fields(config: &serde_yaml::Value, next_version: u32)
     if next_version == 0 {
         fields.push("KEY_SERVER_PK".to_string());
     }
-
     fields
+}
+
+/// Return process output field names that would be overwritten for this DKG version.
+fn existing_process_output_fields(config: &serde_yaml::Value, next_version: u32) -> Vec<String> {
+    expected_process_output_fields(next_version)
         .into_iter()
         .filter(|field| get_config_field(config, "process-all-and-propose", field).is_some())
         .collect()
+}
+
+/// Validate expected process output fields were added for this DKG version.
+fn validate_process_outputs_added(config: &serde_yaml::Value, next_version: u32) -> Result<()> {
+    let missing_fields: Vec<_> = expected_process_output_fields(next_version)
+        .into_iter()
+        .filter(|field| get_config_field(config, "process-all-and-propose", field).is_none())
+        .collect();
+    if !missing_fields.is_empty() {
+        bail!(
+            "process-all-and-propose did not write expected field(s) for version {}: {:?}",
+            next_version,
+            missing_fields,
+        );
+    }
+    Ok(())
 }
 
 /// Create a BuildConfig for package compilation.
@@ -2249,16 +2143,14 @@ fn load_messages_from_dir(messages_dir: &Path) -> Result<Vec<SignedMessage>> {
             .as_str()
             .ok_or_else(|| anyhow!("Missing 'message' field in {}", path.display()))?;
 
-        let message_bytes = Hex::decode(message_hex)
-            .map_err(|e| anyhow!("Failed to decode message from {}: {}", path.display(), e))?;
-
-        let signed_message: SignedMessage = bcs::from_bytes(&message_bytes).map_err(|e| {
-            anyhow!(
-                "Failed to deserialize message from {}: {}",
-                path.display(),
-                e
-            )
-        })?;
+        let signed_message: SignedMessage =
+            bcs_hex_decode!(SignedMessage, message_hex).map_err(|e| {
+                anyhow!(
+                    "Failed to deserialize message from {}: {}",
+                    path.display(),
+                    e
+                )
+            })?;
 
         messages.push(signed_message);
     }
@@ -2293,8 +2185,7 @@ fn process_dkg_messages(
     // Compute hash over of the vector of messages sorted by sender party ID.
     messages.sort_by_key(|m| m.message.sender);
     let messages_hash = {
-        let hash_input =
-            bcs::to_bytes(&messages).context("Failed to serialize DKG messages for hashing")?;
+        let hash_input = bcs::to_bytes(&messages)?;
         let mut hasher = Blake2b256::default();
         hasher.update(&hash_input);
         hasher.finalize().digest.to_vec()
@@ -2328,8 +2219,7 @@ fn process_dkg_messages(
         state.config.my_old_share,
         state.config.old_threshold,
         &mut thread_rng(),
-    )
-    .context("Failed to initialize DKG party for message processing")?;
+    )?;
 
     // Process each message.
     for signed_msg in messages {
@@ -2376,22 +2266,16 @@ fn process_dkg_messages(
                     anyhow!("Key rotation verification failed for party {sender_party_id}: {e}")
                 })?
         } else {
-            party
-                .process_message_with_checks(
-                    signed_msg.message.clone(),
-                    &None,
-                    &Some(signed_msg.nizk_proof.clone()),
-                    &mut thread_rng(),
-                )
-                .with_context(|| {
-                    format!("Fresh DKG verification failed for party {sender_party_id}")
-                })?
+            party.process_message_with_checks(
+                signed_msg.message.clone(),
+                &None,
+                &Some(signed_msg.nizk_proof.clone()),
+                &mut thread_rng(),
+            )?
         };
 
         if let Some(complaint) = &processed.complaint {
-            let complaint_bytes =
-                bcs::to_bytes(complaint).context("Failed to serialize DKG complaint")?;
-            let complaint_hex = Hex::encode(complaint_bytes);
+            let complaint_hex = bcs_hex_encode!(complaint);
             bail!(
                 "Do NOT propose onchain. Complaint against party {}.\n\
                 Abort the protocol and share the following proof with the coordinator:\n  {}",
@@ -2404,9 +2288,7 @@ fn process_dkg_messages(
     }
 
     // Merge and complete.
-    let (confirmation, used_msgs) = party
-        .merge(&state.processed_messages)
-        .context("Failed to merge processed DKG messages")?;
+    let (confirmation, used_msgs) = party.merge(&state.processed_messages)?;
 
     if !confirmation.complaints.is_empty() {
         bail!(
@@ -2430,13 +2312,9 @@ fn process_dkg_messages(
             .collect();
 
         println!("Completing key rotation with mapping: {sender_to_old_map:?}");
-        party
-            .complete_optimistic_key_rotation(&used_msgs, &sender_to_old_map)
-            .context("Failed to complete optimistic key rotation")?
+        party.complete_optimistic_key_rotation(&used_msgs, &sender_to_old_map)?
     } else {
-        party
-            .complete_optimistic(&used_msgs)
-            .context("Failed to complete fresh optimistic DKG")?
+        party.complete_optimistic(&used_msgs)?
     };
 
     state.output = Some(output.clone());
@@ -2445,8 +2323,7 @@ fn process_dkg_messages(
 
 /// Parse a hex-encoded BCS-serialized G2Scalar from a CLI argument.
 fn parse_old_share(s: &str) -> anyhow::Result<G2Scalar> {
-    let bytes = Hex::decode(s).context("--old-share must be hex")?;
-    bcs::from_bytes(&bytes).context("--old-share must be a BCS-serialized G2Scalar")
+    Ok(bcs_hex_decode!(G2Scalar, s)?)
 }
 
 /// Create a RandomOracle with the DKG domain separator and committee ID.
@@ -2455,11 +2332,11 @@ fn create_dkg_random_oracle(committee_id: &Address) -> RandomOracle {
 }
 
 /// Compute and display the package digest.
-async fn compute_package_digest(package_path: &Path, network: &Network) -> Result<()> {
+fn compute_package_digest(package_path: &Path, network: &Network) -> Result<()> {
     println!("Building package at: {}", package_path.display());
     println!();
 
-    let digest = get_package_digest(package_path, network).await?;
+    let digest = get_package_digest(package_path, network)?;
     println!(
         "Digest for package '{}': {}",
         package_path
@@ -2473,11 +2350,10 @@ async fn compute_package_digest(package_path: &Path, network: &Network) -> Resul
 }
 
 /// Compute package digest as hex string.
-async fn get_package_digest(package_path: &Path, network: &Network) -> Result<String> {
-    let package_path = package_path.canonicalize()?;
+fn get_package_digest(package_path: &Path, network: &Network) -> Result<String> {
     let build_config = create_build_config(network);
     let compiled_package = build_config
-        .build(&package_path)
+        .build(&package_path.canonicalize()?)
         .context("Failed to build package")?;
 
     let digest = compiled_package.get_package_digest(/* with_unpublished_deps */ false);
@@ -2523,7 +2399,7 @@ async fn vote_for_upgrade(
 
     // Build package and compute digest (only for approve).
     let digest = if let Some(path) = package_path {
-        let d = get_package_digest(path, network).await?;
+        let d = get_package_digest(path, network)?;
         println!("\nPackage digest: {}", d);
         Some(d)
     } else {
@@ -2531,7 +2407,7 @@ async fn vote_for_upgrade(
     };
 
     // Fetch key server to get committee ID.
-    let mut grpc_client = create_grpc_client_from_config(network, rpc_url)?;
+    let mut grpc_client = create_grpc_client_with_url(network, rpc_url)?;
     let (committee_id, _) =
         fetch_committee_from_key_server(&mut grpc_client, key_server_id).await?;
 

--- a/crates/seal-committee-cli/src/tests.rs
+++ b/crates/seal-committee-cli/src/tests.rs
@@ -49,9 +49,9 @@ fn process_field<'a>(config: &'a serde_yaml::Value, key: &str) -> &'a serde_yaml
         .unwrap_or_else(|| panic!("missing process-all-and-propose.{key}"))
 }
 
-/// Read one string field from any ordered list of config sections.
-fn config_str_field<'a>(config: &'a serde_yaml::Value, sections: &[&str], key: &str) -> &'a str {
-    get_config_field(config, sections, key)
+/// Read one string field from a config section.
+fn config_str_field<'a>(config: &'a serde_yaml::Value, section: &str, key: &str) -> &'a str {
+    get_config_field(config, section, key)
         .and_then(|value| value.as_str())
         .unwrap_or_else(|| panic!("missing string field {key}"))
 }
@@ -59,10 +59,10 @@ fn config_str_field<'a>(config: &'a serde_yaml::Value, sections: &[&str], key: &
 /// Decode a config hex field and parse it into the expected BCS type.
 fn config_bcs_hex_field<T: DeserializeOwned>(
     config: &serde_yaml::Value,
-    sections: &[&str],
+    section: &str,
     key: &str,
 ) -> T {
-    let bytes = Hex::decode(config_str_field(config, sections, key))
+    let bytes = Hex::decode(config_str_field(config, section, key))
         .unwrap_or_else(|_| panic!("{key} should be hex"));
     bcs::from_bytes(&bytes).unwrap_or_else(|_| panic!("{key} should be valid BCS"))
 }
@@ -225,27 +225,27 @@ fn test_config_step_updates_add_fields_without_overwriting_existing_sections() {
         ]
     );
     assert_eq!(
-        config_str_field(&config, &["publish-and-init"], "COMMITTEE_ID"),
+        config_str_field(&config, "publish-and-init", "COMMITTEE_ID"),
         COMMITTEE_ID
     );
     assert_eq!(
-        config_str_field(&config, &["publish-and-init"], "COMMITTEE_PKG"),
+        config_str_field(&config, "publish-and-init", "COMMITTEE_PKG"),
         COMMITTEE_PKG
     );
     assert_eq!(get_my_address(&config).unwrap().to_string(), MEMBER_0);
     assert_eq!(
-        config_str_field(&config, &["genkey-and-register"], "MY_SERVER_URL"),
+        config_str_field(&config, "genkey-and-register", "MY_SERVER_URL"),
         "http://localhost:4000"
     );
     assert_eq!(
-        config_str_field(&config, &["genkey-and-register"], "MY_SERVER_NAME"),
+        config_str_field(&config, "genkey-and-register", "MY_SERVER_NAME"),
         "server-mainnet-0"
     );
 
     let registered_enc_pk: PublicKey<G1Element> =
-        config_bcs_hex_field(&config, &["genkey-and-register"], "DKG_ENC_PK");
+        config_bcs_hex_field(&config, "genkey-and-register", "DKG_ENC_PK");
     let registered_signing_pk: BLS12381PublicKey =
-        config_bcs_hex_field(&config, &["genkey-and-register"], "DKG_SIGNING_PK");
+        config_bcs_hex_field(&config, "genkey-and-register", "DKG_SIGNING_PK");
     assert_eq!(bcs::to_bytes(&registered_enc_pk).unwrap(), enc_pk_bytes);
     assert_eq!(
         bcs::to_bytes(&registered_signing_pk).unwrap(),
@@ -286,9 +286,9 @@ genkey-and-register:
     );
     let keys = KeysFile::load(&keys_path).expect("dkg.key should load");
     let registered_enc_pk: PublicKey<G1Element> =
-        config_bcs_hex_field(&config, &["genkey-and-register"], "DKG_ENC_PK");
+        config_bcs_hex_field(&config, "genkey-and-register", "DKG_ENC_PK");
     let registered_signing_pk: BLS12381PublicKey =
-        config_bcs_hex_field(&config, &["genkey-and-register"], "DKG_SIGNING_PK");
+        config_bcs_hex_field(&config, "genkey-and-register", "DKG_SIGNING_PK");
     assert_eq!(
         bcs::to_bytes(&keys.enc_pk).unwrap(),
         bcs::to_bytes(&registered_enc_pk).unwrap()
@@ -316,16 +316,15 @@ fn test_persist_process_outputs_for_fresh_dkg_writes_v0_fields() {
 
     let config = load_config(&config_path).unwrap();
     assert_eq!(
-        config_str_field(&config, &["process-all-and-propose"], "KEY_SERVER_PK"),
+        config_str_field(&config, "process-all-and-propose", "KEY_SERVER_PK"),
         Hex::encode_with_format(&key_server_pk)
     );
     assert_eq!(
-        config_str_field(&config, &["process-all-and-propose"], "MASTER_SHARE_V0"),
+        config_str_field(&config, "process-all-and-propose", "MASTER_SHARE_V0"),
         Hex::encode_with_format(&master_share)
     );
-    let _: G2Element = config_bcs_hex_field(&config, &["process-all-and-propose"], "KEY_SERVER_PK");
-    let _: G2Scalar =
-        config_bcs_hex_field(&config, &["process-all-and-propose"], "MASTER_SHARE_V0");
+    let _: G2Element = config_bcs_hex_field(&config, "process-all-and-propose", "KEY_SERVER_PK");
+    let _: G2Scalar = config_bcs_hex_field(&config, "process-all-and-propose", "MASTER_SHARE_V0");
 
     let partial_pks = process_field(&config, "PARTIAL_PKS_V0")
         .as_sequence()
@@ -365,19 +364,18 @@ process-all-and-propose:
 
     let config = load_config(&config_path).unwrap();
     assert_eq!(
-        config_str_field(&config, &["process-all-and-propose"], "KEY_SERVER_PK"),
+        config_str_field(&config, "process-all-and-propose", "KEY_SERVER_PK"),
         existing_key_server_pk
     );
     assert_eq!(
-        config_str_field(&config, &["process-all-and-propose"], "MASTER_SHARE_V0"),
+        config_str_field(&config, "process-all-and-propose", "MASTER_SHARE_V0"),
         "0x8888"
     );
     assert_eq!(
-        config_str_field(&config, &["process-all-and-propose"], "MASTER_SHARE_V1"),
+        config_str_field(&config, "process-all-and-propose", "MASTER_SHARE_V1"),
         Hex::encode_with_format(&master_share)
     );
-    let _: G2Scalar =
-        config_bcs_hex_field(&config, &["process-all-and-propose"], "MASTER_SHARE_V1");
+    let _: G2Scalar = config_bcs_hex_field(&config, "process-all-and-propose", "MASTER_SHARE_V1");
 
     let partial_pks = process_field(&config, "PARTIAL_PKS_V1")
         .as_sequence()

--- a/crates/seal-committee-cli/src/tests.rs
+++ b/crates/seal-committee-cli/src/tests.rs
@@ -1,3 +1,6 @@
+// Copyright (c), Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use fastcrypto::bls12381::min_sig::BLS12381PublicKey;
 use serde::de::DeserializeOwned;
@@ -73,7 +76,7 @@ fn valid_process_output_material() -> (Vec<u8>, Vec<u8>, String) {
         G2Element::generator() * G2Scalar::from(40u128),
     ]
     .iter()
-    .map(|pk| Hex::encode_with_format(&bcs::to_bytes(pk).unwrap()))
+    .map(|pk| Hex::encode_with_format(bcs::to_bytes(pk).unwrap()))
     .collect();
     (
         key_server_pk,
@@ -264,8 +267,8 @@ fn test_dkg_key_file_matches_registered_public_keys() {
         signing_sk,
         signing_pk,
     };
-    let dkg_enc_pk = Hex::encode_with_format(&bcs::to_bytes(&keys.enc_pk).unwrap());
-    let dkg_signing_pk = Hex::encode_with_format(&bcs::to_bytes(&keys.signing_pk).unwrap());
+    let dkg_enc_pk = Hex::encode_with_format(bcs::to_bytes(&keys.enc_pk).unwrap());
+    let dkg_signing_pk = Hex::encode_with_format(bcs::to_bytes(&keys.signing_pk).unwrap());
 
     let config: serde_yaml::Value = serde_yaml::from_str(&format!(
         "\
@@ -433,7 +436,7 @@ fn test_validate_continuing_member_old_share_matches_onchain_pk() {
     let mut new_to_old_mapping = HashMap::new();
     new_to_old_mapping.insert(1, 0);
     let mut expected_old_pks = HashMap::new();
-    expected_old_pks.insert(0, expected_old_pk.clone());
+    expected_old_pks.insert(0, expected_old_pk);
 
     validate_continuing_member_old_share(
         &my_address,

--- a/crates/seal-committee-cli/src/tests.rs
+++ b/crates/seal-committee-cli/src/tests.rs
@@ -85,29 +85,6 @@ fn valid_process_output_material() -> (Vec<u8>, Vec<u8>, String) {
     )
 }
 
-/// Persist process outputs into a temp config and return the resulting error text.
-fn persist_process_outputs_error(
-    test_name: &str,
-    config_content: &str,
-    next_version: u32,
-    key_server_pk: &[u8],
-    old_key_server_pk: Option<&[u8]>,
-    partial_pks_yaml: &str,
-    master_share: &[u8],
-) -> String {
-    let config_path = write_temp_config(test_name, config_content);
-    persist_process_outputs(
-        &config_path,
-        next_version,
-        key_server_pk,
-        old_key_server_pk,
-        partial_pks_yaml.trim(),
-        master_share,
-    )
-    .unwrap_err()
-    .to_string()
-}
-
 #[test]
 fn test_committee_ids_follow_fresh_and_rotation_config_shapes() {
     let initial_fresh_config: serde_yaml::Value =
@@ -315,6 +292,7 @@ fn test_persist_process_outputs_for_fresh_dkg_writes_v0_fields() {
     .unwrap();
 
     let config = load_config(&config_path).unwrap();
+    validate_process_outputs_added(&config, 0).unwrap();
     assert_eq!(
         config_str_field(&config, "process-all-and-propose", "KEY_SERVER_PK"),
         Hex::encode_with_format(&key_server_pk)
@@ -363,6 +341,7 @@ process-all-and-propose:
     .unwrap();
 
     let config = load_config(&config_path).unwrap();
+    validate_process_outputs_added(&config, 1).unwrap();
     assert_eq!(
         config_str_field(&config, "process-all-and-propose", "KEY_SERVER_PK"),
         existing_key_server_pk
@@ -389,19 +368,6 @@ process-all-and-propose:
 }
 
 #[test]
-fn test_validate_rotation_quorum_rejects_too_few_continuing_members() {
-    let old_committee_id = Address::from_str(COMMITTEE_ID).unwrap();
-
-    validate_rotation_quorum(&old_committee_id, 2, 2).unwrap();
-
-    let err = validate_rotation_quorum(&old_committee_id, 3, 2)
-        .unwrap_err()
-        .to_string();
-    assert!(err.contains("requires 3 continuing member message"));
-    assert!(err.contains("only 2 new committee member"));
-}
-
-#[test]
 fn test_validate_rotation_message_senders_rejects_new_members() {
     let mut new_to_old_mapping = HashMap::new();
     new_to_old_mapping.insert(0, 1);
@@ -425,123 +391,54 @@ fn test_validate_rotation_message_senders_rejects_new_members() {
 }
 
 #[test]
-fn test_validate_continuing_member_old_share_matches_onchain_pk() {
-    let my_address = Address::from_str(MEMBER_0).unwrap();
-    let old_committee_id = Address::from_str(COMMITTEE_ID).unwrap();
-    let old_share = G2Scalar::from(50u128);
-    let expected_old_pk = G2Element::generator() * old_share;
-
-    let mut new_to_old_mapping = HashMap::new();
-    new_to_old_mapping.insert(1, 0);
-    let mut expected_old_pks = HashMap::new();
-    expected_old_pks.insert(0, expected_old_pk);
-
-    validate_continuing_member_old_share(
-        &my_address,
-        &old_committee_id,
-        1,
-        &new_to_old_mapping,
-        &expected_old_pks,
-        &expected_old_pk,
-    )
-    .unwrap();
-
-    let wrong_old_pk = G2Element::generator() * G2Scalar::from(51u128);
-    let err = validate_continuing_member_old_share(
-        &my_address,
-        &old_committee_id,
-        1,
-        &new_to_old_mapping,
-        &expected_old_pks,
-        &wrong_old_pk,
-    )
-    .unwrap_err()
-    .to_string();
-    assert!(err.contains("Invalid --old-share"));
-    assert!(err.contains("party 0"));
-}
-
-#[test]
-fn test_persist_process_outputs_rejects_version_mismatch() {
-    let (key_server_pk, master_share, partial_pks_yaml) = valid_process_output_material();
-    let err = persist_process_outputs_error(
-        "existing-version-output",
+fn test_validate_process_section_rejects_existing_or_mismatched_outputs() {
+    let (key_server_pk, _, _) = valid_process_output_material();
+    let config: serde_yaml::Value = serde_yaml::from_str(
         "\
 process-all-and-propose:
   MASTER_SHARE_V1: '0x1234'
 ",
-        1,
-        &key_server_pk,
-        Some(&key_server_pk),
-        &partial_pks_yaml,
-        &master_share,
-    );
+    )
+    .unwrap();
+    let err = validate_process_section(&config, 1, Some(&key_server_pk))
+        .unwrap_err()
+        .to_string();
     assert!(err.contains("already contains output field"));
 
-    let err = persist_process_outputs_error(
-        "missing-old-key-server-pk",
-        "init-params: {}\n",
-        1,
-        &key_server_pk,
-        None,
-        &partial_pks_yaml,
-        &master_share,
-    );
+    let config: serde_yaml::Value = serde_yaml::from_str("init-params: {}\n").unwrap();
+    let err = validate_process_section(&config, 1, None)
+        .unwrap_err()
+        .to_string();
     assert!(err.contains("requires the old onchain KEY_SERVER_PK"));
 
     let mismatched_key_server_pk =
         bcs::to_bytes(&(G2Element::generator() * G2Scalar::from(99u128))).unwrap();
     let mismatched_key_server_pk_hex = Hex::encode_with_format(&mismatched_key_server_pk);
-    let err = persist_process_outputs_error(
-        "mismatched-key-server-pk",
-        &format!(
-            "\
+    let config: serde_yaml::Value = serde_yaml::from_str(&format!(
+        "\
 process-all-and-propose:
   KEY_SERVER_PK: '{mismatched_key_server_pk_hex}'
 "
-        ),
-        1,
-        &key_server_pk,
-        Some(&key_server_pk),
-        &partial_pks_yaml,
-        &master_share,
-    );
+    ))
+    .unwrap();
+    let err = validate_process_section(&config, 1, Some(&key_server_pk))
+        .unwrap_err()
+        .to_string();
     assert!(err.contains("process-all-and-propose.KEY_SERVER_PK mismatch"));
 }
 
 #[test]
-fn test_persist_process_outputs_rejects_invalid_key_material() {
-    let (key_server_pk, master_share, partial_pks_yaml) = valid_process_output_material();
-    let err = persist_process_outputs_error(
-        "invalid-key-server-pk",
-        "init-params: {}\n",
-        0,
-        &[0, 0],
-        None,
-        &partial_pks_yaml,
-        &master_share,
-    );
-    assert!(err.contains("KEY_SERVER_PK must be a valid BCS G2Element"));
-
-    let err = persist_process_outputs_error(
-        "invalid-master-share",
-        "init-params: {}\n",
-        1,
-        &key_server_pk,
-        Some(&key_server_pk),
-        &partial_pks_yaml,
-        &[0],
-    );
-    assert!(err.contains("MASTER_SHARE_V1 must be a valid BCS scalar"));
-
-    let err = persist_process_outputs_error(
-        "invalid-partial-pk",
-        "init-params: {}\n",
-        1,
-        &key_server_pk,
-        Some(&key_server_pk),
-        "- 0xaa\n",
-        &master_share,
-    );
-    assert!(err.contains("PARTIAL_PKS_V1[0] must be a valid BCS G2Element"));
+fn test_validate_process_outputs_added_rejects_missing_fields() {
+    let config: serde_yaml::Value = serde_yaml::from_str(
+        "\
+process-all-and-propose:
+  KEY_SERVER_PK: '0x1234'
+",
+    )
+    .unwrap();
+    let err = validate_process_outputs_added(&config, 0)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("MASTER_SHARE_V0"));
+    assert!(err.contains("PARTIAL_PKS_V0"));
 }

--- a/crates/seal-committee-cli/src/tests.rs
+++ b/crates/seal-committee-cli/src/tests.rs
@@ -1,0 +1,546 @@
+use super::*;
+use fastcrypto::bls12381::min_sig::BLS12381PublicKey;
+use serde::de::DeserializeOwned;
+
+const MEMBER_0: &str = "0x00ba1ae103cf43b2017796914b20cfbed32fc78b43d506583cd2383af18ef739";
+const MEMBER_1: &str = "0x393bddd124a05a95859579d635d46ef20e5be802362d5bbd86999e2c845bf153";
+const MEMBER_2: &str = "0xb39cb0c9c979921bf1d63c3c6df20765b9c7c21b1ae9445ab42931f6e1b45c66";
+const COMMITTEE_PKG: &str = "0xd0aa3b6dd0cc41b99f7d18f58cb9fe5f353aca8f5198e930f8cab3082dc40e82";
+const COMMITTEE_ID: &str = "0x454c9cf3cb14caec4ccc6b90170f7af4c508af87c4d047085353d4b4d79fee85";
+
+/// Write a file in a unique temp directory and return its path.
+fn write_temp_file(test_name: &str, file_name: &str, content: &str) -> PathBuf {
+    let suffix = format!("{:032x}", rand::random::<u128>());
+    let dir = std::env::temp_dir().join(format!("seal-committee-cli-{test_name}-{suffix}"));
+    fs::create_dir_all(&dir).expect("failed to create temp dir");
+    let path = dir.join(file_name);
+    fs::write(&path, content).expect("failed to write temp file");
+    path
+}
+
+/// Write a dkg.yaml fixture in a unique temp directory.
+fn write_temp_config(test_name: &str, content: &str) -> PathBuf {
+    write_temp_file(test_name, "dkg.yaml", content)
+}
+
+/// Build the initial fresh-DKG config fixture.
+fn initial_init_params_yaml() -> String {
+    format!(
+        "\
+init-params:
+  NETWORK: Testnet
+  THRESHOLD: 2
+  MEMBERS:
+  - {MEMBER_0}
+  - {MEMBER_1}
+  - {MEMBER_2}
+"
+    )
+}
+
+/// Read one field from process-all-and-propose.
+fn process_field<'a>(config: &'a serde_yaml::Value, key: &str) -> &'a serde_yaml::Value {
+    config
+        .get("process-all-and-propose")
+        .and_then(|section| section.get(key))
+        .unwrap_or_else(|| panic!("missing process-all-and-propose.{key}"))
+}
+
+/// Read one string field from any ordered list of config sections.
+fn config_str_field<'a>(config: &'a serde_yaml::Value, sections: &[&str], key: &str) -> &'a str {
+    get_config_field(config, sections, key)
+        .and_then(|value| value.as_str())
+        .unwrap_or_else(|| panic!("missing string field {key}"))
+}
+
+/// Decode a config hex field and parse it into the expected BCS type.
+fn config_bcs_hex_field<T: DeserializeOwned>(
+    config: &serde_yaml::Value,
+    sections: &[&str],
+    key: &str,
+) -> T {
+    let bytes = Hex::decode(config_str_field(config, sections, key))
+        .unwrap_or_else(|_| panic!("{key} should be hex"));
+    bcs::from_bytes(&bytes).unwrap_or_else(|_| panic!("{key} should be valid BCS"))
+}
+
+/// Return valid process output fixtures in the order expected by persist_process_outputs.
+fn valid_process_output_material() -> (Vec<u8>, Vec<u8>, String) {
+    let key_server_pk = bcs::to_bytes(&(G2Element::generator() * G2Scalar::from(10u128))).unwrap();
+    let master_share = bcs::to_bytes(&G2Scalar::from(20u128)).unwrap();
+    let partial_pks: Vec<String> = [
+        G2Element::generator() * G2Scalar::from(30u128),
+        G2Element::generator() * G2Scalar::from(40u128),
+    ]
+    .iter()
+    .map(|pk| Hex::encode_with_format(&bcs::to_bytes(pk).unwrap()))
+    .collect();
+    (
+        key_server_pk,
+        master_share,
+        serde_yaml::to_string(&partial_pks).expect("partial pk YAML should serialize"),
+    )
+}
+
+/// Persist process outputs into a temp config and return the resulting error text.
+fn persist_process_outputs_error(
+    test_name: &str,
+    config_content: &str,
+    next_version: u32,
+    key_server_pk: &[u8],
+    old_key_server_pk: Option<&[u8]>,
+    partial_pks_yaml: &str,
+    master_share: &[u8],
+) -> String {
+    let config_path = write_temp_config(test_name, config_content);
+    persist_process_outputs(
+        &config_path,
+        next_version,
+        key_server_pk,
+        old_key_server_pk,
+        partial_pks_yaml.trim(),
+        master_share,
+    )
+    .unwrap_err()
+    .to_string()
+}
+
+#[test]
+fn test_committee_ids_follow_fresh_and_rotation_config_shapes() {
+    let initial_fresh_config: serde_yaml::Value =
+        serde_yaml::from_str(&initial_init_params_yaml()).unwrap();
+    assert!(get_committee_id(&initial_fresh_config).is_err());
+    assert!(get_committee_pkg(&initial_fresh_config).is_err());
+
+    let fresh_config: serde_yaml::Value = serde_yaml::from_str(&format!(
+        "\
+{}publish-and-init:
+  COMMITTEE_PKG: {COMMITTEE_PKG}
+  COMMITTEE_ID: {COMMITTEE_ID}
+  COORDINATOR_ADDRESS: {MEMBER_0}
+",
+        initial_init_params_yaml()
+    ))
+    .unwrap();
+    assert_eq!(
+        get_committee_id(&fresh_config).unwrap(),
+        Address::from_str(COMMITTEE_ID).unwrap()
+    );
+    assert_eq!(
+        get_committee_pkg(&fresh_config).unwrap(),
+        Address::from_str(COMMITTEE_PKG).unwrap()
+    );
+
+    let rotation_committee = "0x4444444444444444444444444444444444444444444444444444444444444444";
+    let rotation_pkg = "0x6666666666666666666666666666666666666666666666666666666666666666";
+    let key_server_obj_id = "0x7777777777777777777777777777777777777777777777777777777777777777";
+    let rotation_config: serde_yaml::Value = serde_yaml::from_str(&format!(
+        "\
+{}init-rotation-params:
+  KEY_SERVER_OBJ_ID: {key_server_obj_id}
+init-rotation:
+  COMMITTEE_ID: {rotation_committee}
+  COMMITTEE_PKG: {rotation_pkg}
+",
+        initial_init_params_yaml()
+    ))
+    .unwrap();
+
+    assert_eq!(
+        get_key_server_obj_id(&rotation_config).unwrap(),
+        Address::from_str(key_server_obj_id).unwrap()
+    );
+    assert_eq!(
+        get_committee_id(&rotation_config).unwrap(),
+        Address::from_str(rotation_committee).unwrap()
+    );
+    assert_eq!(
+        get_committee_pkg(&rotation_config).unwrap(),
+        Address::from_str(rotation_pkg).unwrap()
+    );
+}
+
+#[test]
+fn test_config_step_updates_add_fields_without_overwriting_existing_sections() {
+    let config_path = write_temp_config("step-field-updates", &initial_init_params_yaml());
+    update_config_bytes_val(
+        &config_path,
+        "publish-and-init",
+        vec![
+            (
+                "COMMITTEE_PKG",
+                Address::from_str(COMMITTEE_PKG).unwrap().inner(),
+            ),
+            (
+                "COMMITTEE_ID",
+                Address::from_str(COMMITTEE_ID).unwrap().inner(),
+            ),
+            (
+                "COORDINATOR_ADDRESS",
+                Address::from_str(MEMBER_0).unwrap().inner(),
+            ),
+        ],
+    )
+    .unwrap();
+
+    let enc_sk = PrivateKey::<G1Element>::new(&mut thread_rng());
+    let enc_pk = PublicKey::from_private_key(&enc_sk);
+    let signing_kp = BLS12381KeyPair::generate(&mut thread_rng());
+    let signing_pk = signing_kp.public().clone();
+    let enc_pk_bytes = bcs::to_bytes(&enc_pk).unwrap();
+    let signing_pk_bytes = bcs::to_bytes(&signing_pk).unwrap();
+
+    update_config_bytes_val(
+        &config_path,
+        "genkey-and-register",
+        vec![
+            ("MY_ADDRESS", Address::from_str(MEMBER_0).unwrap().inner()),
+            ("DKG_ENC_PK", &enc_pk_bytes),
+            ("DKG_SIGNING_PK", &signing_pk_bytes),
+        ],
+    )
+    .unwrap();
+    update_config_string_val(
+        &config_path,
+        "genkey-and-register",
+        vec![
+            ("MY_SERVER_URL", "http://localhost:4000"),
+            ("MY_SERVER_NAME", "server-mainnet-0"),
+        ],
+    )
+    .unwrap();
+
+    let config = load_config(&config_path).unwrap();
+    assert_eq!(get_network(&config).unwrap(), Network::Testnet);
+    assert_eq!(get_threshold(&config).unwrap(), 2);
+    assert_eq!(
+        get_members(&config).unwrap(),
+        vec![
+            Address::from_str(MEMBER_0).unwrap(),
+            Address::from_str(MEMBER_1).unwrap(),
+            Address::from_str(MEMBER_2).unwrap(),
+        ]
+    );
+    assert_eq!(
+        config_str_field(&config, &["publish-and-init"], "COMMITTEE_ID"),
+        COMMITTEE_ID
+    );
+    assert_eq!(
+        config_str_field(&config, &["publish-and-init"], "COMMITTEE_PKG"),
+        COMMITTEE_PKG
+    );
+    assert_eq!(get_my_address(&config).unwrap().to_string(), MEMBER_0);
+    assert_eq!(
+        config_str_field(&config, &["genkey-and-register"], "MY_SERVER_URL"),
+        "http://localhost:4000"
+    );
+    assert_eq!(
+        config_str_field(&config, &["genkey-and-register"], "MY_SERVER_NAME"),
+        "server-mainnet-0"
+    );
+
+    let registered_enc_pk: PublicKey<G1Element> =
+        config_bcs_hex_field(&config, &["genkey-and-register"], "DKG_ENC_PK");
+    let registered_signing_pk: BLS12381PublicKey =
+        config_bcs_hex_field(&config, &["genkey-and-register"], "DKG_SIGNING_PK");
+    assert_eq!(bcs::to_bytes(&registered_enc_pk).unwrap(), enc_pk_bytes);
+    assert_eq!(
+        bcs::to_bytes(&registered_signing_pk).unwrap(),
+        signing_pk_bytes
+    );
+}
+
+#[test]
+fn test_dkg_key_file_matches_registered_public_keys() {
+    let mut rng = thread_rng();
+    let enc_sk = PrivateKey::<G1Element>::new(&mut rng);
+    let enc_pk = PublicKey::from_private_key(&enc_sk);
+    let signing_kp = BLS12381KeyPair::generate(&mut rng);
+    let signing_pk = signing_kp.public().clone();
+    let signing_sk = signing_kp.private();
+    let keys = KeysFile {
+        enc_sk,
+        enc_pk,
+        signing_sk,
+        signing_pk,
+    };
+    let dkg_enc_pk = Hex::encode_with_format(&bcs::to_bytes(&keys.enc_pk).unwrap());
+    let dkg_signing_pk = Hex::encode_with_format(&bcs::to_bytes(&keys.signing_pk).unwrap());
+
+    let config: serde_yaml::Value = serde_yaml::from_str(&format!(
+        "\
+genkey-and-register:
+  DKG_ENC_PK: {dkg_enc_pk}
+  DKG_SIGNING_PK: {dkg_signing_pk}
+"
+    ))
+    .unwrap();
+
+    let keys_path = write_temp_file(
+        "dkg-key",
+        "dkg.key",
+        &serde_json::to_string_pretty(&keys).expect("keys should serialize"),
+    );
+    let keys = KeysFile::load(&keys_path).expect("dkg.key should load");
+    let registered_enc_pk: PublicKey<G1Element> =
+        config_bcs_hex_field(&config, &["genkey-and-register"], "DKG_ENC_PK");
+    let registered_signing_pk: BLS12381PublicKey =
+        config_bcs_hex_field(&config, &["genkey-and-register"], "DKG_SIGNING_PK");
+    assert_eq!(
+        bcs::to_bytes(&keys.enc_pk).unwrap(),
+        bcs::to_bytes(&registered_enc_pk).unwrap()
+    );
+    assert_eq!(
+        bcs::to_bytes(&keys.signing_pk).unwrap(),
+        bcs::to_bytes(&registered_signing_pk).unwrap()
+    );
+}
+
+#[test]
+fn test_persist_process_outputs_for_fresh_dkg_writes_v0_fields() {
+    let config_path = write_temp_config("fresh-process-outputs", "init-params: {}\n");
+    let (key_server_pk, master_share, partial_pks_yaml) = valid_process_output_material();
+
+    persist_process_outputs(
+        &config_path,
+        0,
+        &key_server_pk,
+        None,
+        partial_pks_yaml.trim(),
+        &master_share,
+    )
+    .unwrap();
+
+    let config = load_config(&config_path).unwrap();
+    assert_eq!(
+        config_str_field(&config, &["process-all-and-propose"], "KEY_SERVER_PK"),
+        Hex::encode_with_format(&key_server_pk)
+    );
+    assert_eq!(
+        config_str_field(&config, &["process-all-and-propose"], "MASTER_SHARE_V0"),
+        Hex::encode_with_format(&master_share)
+    );
+    let _: G2Element = config_bcs_hex_field(&config, &["process-all-and-propose"], "KEY_SERVER_PK");
+    let _: G2Scalar =
+        config_bcs_hex_field(&config, &["process-all-and-propose"], "MASTER_SHARE_V0");
+
+    let partial_pks = process_field(&config, "PARTIAL_PKS_V0")
+        .as_sequence()
+        .expect("PARTIAL_PKS_V0 should be a YAML list");
+    assert_eq!(partial_pks.len(), 2);
+    for partial_pk in partial_pks {
+        let bytes = Hex::decode(partial_pk.as_str().expect("partial pk should be a string"))
+            .expect("partial pk should be hex");
+        let _: G2Element = bcs::from_bytes(&bytes).expect("partial pk should parse");
+    }
+}
+
+#[test]
+fn test_persist_process_outputs_for_rotation_preserves_key_server_pk() {
+    let (key_server_pk, master_share, partial_pks_yaml) = valid_process_output_material();
+    let existing_key_server_pk = Hex::encode_with_format(&key_server_pk);
+    let config_path = write_temp_config(
+        "rotation-process-outputs",
+        &format!(
+            "\
+process-all-and-propose:
+  KEY_SERVER_PK: '{existing_key_server_pk}'
+  MASTER_SHARE_V0: '0x8888'
+"
+        ),
+    );
+
+    persist_process_outputs(
+        &config_path,
+        1,
+        &key_server_pk,
+        Some(&key_server_pk),
+        partial_pks_yaml.trim(),
+        &master_share,
+    )
+    .unwrap();
+
+    let config = load_config(&config_path).unwrap();
+    assert_eq!(
+        config_str_field(&config, &["process-all-and-propose"], "KEY_SERVER_PK"),
+        existing_key_server_pk
+    );
+    assert_eq!(
+        config_str_field(&config, &["process-all-and-propose"], "MASTER_SHARE_V0"),
+        "0x8888"
+    );
+    assert_eq!(
+        config_str_field(&config, &["process-all-and-propose"], "MASTER_SHARE_V1"),
+        Hex::encode_with_format(&master_share)
+    );
+    let _: G2Scalar =
+        config_bcs_hex_field(&config, &["process-all-and-propose"], "MASTER_SHARE_V1");
+
+    let partial_pks = process_field(&config, "PARTIAL_PKS_V1")
+        .as_sequence()
+        .expect("PARTIAL_PKS_V1 should be a YAML list");
+    assert_eq!(partial_pks.len(), 2);
+    for partial_pk in partial_pks {
+        let bytes = Hex::decode(partial_pk.as_str().expect("partial pk should be a string"))
+            .expect("partial pk should be hex");
+        let _: G2Element = bcs::from_bytes(&bytes).expect("partial pk should parse");
+    }
+}
+
+#[test]
+fn test_validate_rotation_quorum_rejects_too_few_continuing_members() {
+    let old_committee_id = Address::from_str(COMMITTEE_ID).unwrap();
+
+    validate_rotation_quorum(&old_committee_id, 2, 2).unwrap();
+
+    let err = validate_rotation_quorum(&old_committee_id, 3, 2)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("requires 3 continuing member message"));
+    assert!(err.contains("only 2 new committee member"));
+}
+
+#[test]
+fn test_validate_rotation_message_senders_rejects_new_members() {
+    let mut new_to_old_mapping = HashMap::new();
+    new_to_old_mapping.insert(0, 1);
+    new_to_old_mapping.insert(1, 0);
+
+    let valid_senders = HashSet::from([0, 1]);
+    validate_rotation_message_senders(2, &new_to_old_mapping, &valid_senders).unwrap();
+
+    let new_member_sender = HashSet::from([0, 2]);
+    let err = validate_rotation_message_senders(2, &new_to_old_mapping, &new_member_sender)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("Invalid new party ID"));
+    assert!(err.contains("[2]"));
+
+    let missing_sender = HashSet::from([0]);
+    let err = validate_rotation_message_senders(2, &new_to_old_mapping, &missing_sender)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("requires exactly 2 messages"));
+}
+
+#[test]
+fn test_validate_continuing_member_old_share_matches_onchain_pk() {
+    let my_address = Address::from_str(MEMBER_0).unwrap();
+    let old_committee_id = Address::from_str(COMMITTEE_ID).unwrap();
+    let old_share = G2Scalar::from(50u128);
+    let expected_old_pk = G2Element::generator() * old_share;
+
+    let mut new_to_old_mapping = HashMap::new();
+    new_to_old_mapping.insert(1, 0);
+    let mut expected_old_pks = HashMap::new();
+    expected_old_pks.insert(0, expected_old_pk.clone());
+
+    validate_continuing_member_old_share(
+        &my_address,
+        &old_committee_id,
+        1,
+        &new_to_old_mapping,
+        &expected_old_pks,
+        &expected_old_pk,
+    )
+    .unwrap();
+
+    let wrong_old_pk = G2Element::generator() * G2Scalar::from(51u128);
+    let err = validate_continuing_member_old_share(
+        &my_address,
+        &old_committee_id,
+        1,
+        &new_to_old_mapping,
+        &expected_old_pks,
+        &wrong_old_pk,
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("Invalid --old-share"));
+    assert!(err.contains("party 0"));
+}
+
+#[test]
+fn test_persist_process_outputs_rejects_version_mismatch() {
+    let (key_server_pk, master_share, partial_pks_yaml) = valid_process_output_material();
+    let err = persist_process_outputs_error(
+        "existing-version-output",
+        "\
+process-all-and-propose:
+  MASTER_SHARE_V1: '0x1234'
+",
+        1,
+        &key_server_pk,
+        Some(&key_server_pk),
+        &partial_pks_yaml,
+        &master_share,
+    );
+    assert!(err.contains("already contains output field"));
+
+    let err = persist_process_outputs_error(
+        "missing-old-key-server-pk",
+        "init-params: {}\n",
+        1,
+        &key_server_pk,
+        None,
+        &partial_pks_yaml,
+        &master_share,
+    );
+    assert!(err.contains("requires the old onchain KEY_SERVER_PK"));
+
+    let mismatched_key_server_pk =
+        bcs::to_bytes(&(G2Element::generator() * G2Scalar::from(99u128))).unwrap();
+    let mismatched_key_server_pk_hex = Hex::encode_with_format(&mismatched_key_server_pk);
+    let err = persist_process_outputs_error(
+        "mismatched-key-server-pk",
+        &format!(
+            "\
+process-all-and-propose:
+  KEY_SERVER_PK: '{mismatched_key_server_pk_hex}'
+"
+        ),
+        1,
+        &key_server_pk,
+        Some(&key_server_pk),
+        &partial_pks_yaml,
+        &master_share,
+    );
+    assert!(err.contains("process-all-and-propose.KEY_SERVER_PK mismatch"));
+}
+
+#[test]
+fn test_persist_process_outputs_rejects_invalid_key_material() {
+    let (key_server_pk, master_share, partial_pks_yaml) = valid_process_output_material();
+    let err = persist_process_outputs_error(
+        "invalid-key-server-pk",
+        "init-params: {}\n",
+        0,
+        &[0, 0],
+        None,
+        &partial_pks_yaml,
+        &master_share,
+    );
+    assert!(err.contains("KEY_SERVER_PK must be a valid BCS G2Element"));
+
+    let err = persist_process_outputs_error(
+        "invalid-master-share",
+        "init-params: {}\n",
+        1,
+        &key_server_pk,
+        Some(&key_server_pk),
+        &partial_pks_yaml,
+        &[0],
+    );
+    assert!(err.contains("MASTER_SHARE_V1 must be a valid BCS scalar"));
+
+    let err = persist_process_outputs_error(
+        "invalid-partial-pk",
+        "init-params: {}\n",
+        1,
+        &key_server_pk,
+        Some(&key_server_pk),
+        "- 0xaa\n",
+        &master_share,
+    );
+    assert!(err.contains("PARTIAL_PKS_V1[0] must be a valid BCS G2Element"));
+}

--- a/crates/seal-committee-cli/src/types.rs
+++ b/crates/seal-committee-cli/src/types.rs
@@ -3,7 +3,7 @@
 
 //! Type definitions for DKG CLI.
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use fastcrypto::bls12381::min_sig::{BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature};
 use fastcrypto::encoding::{Encoding, Hex};
 use fastcrypto::groups::bls12381::{G1Element, G2Element, Scalar as G2Scalar};
@@ -69,7 +69,7 @@ impl KeysFile {
         let keys_content = fs::read_to_string(path)
             .map_err(|e| anyhow::anyhow!("Failed to read keys file {}: {}", path.display(), e))?;
         serde_json::from_str(&keys_content)
-            .map_err(|e| anyhow::anyhow!("Failed to parse keys file: {}", e))
+            .map_err(|e| anyhow::anyhow!("Failed to parse keys file {}: {}", path.display(), e))
     }
 }
 
@@ -94,8 +94,6 @@ pub struct InitializedConfig {
     pub expected_old_pks: Option<HashMap<u16, G2Element>>,
     /// Old partial key share for key rotation, for continuing members for key rotation.
     pub my_old_share: Option<G2Scalar>,
-    /// Old partial public key for key rotation, for continuing members for key rotation.
-    pub my_old_pk: Option<G2Element>,
 }
 
 /// Local state for DKG protocol, used for storing messages and output.
@@ -121,17 +119,22 @@ pub struct DkgState {
 impl DkgState {
     /// Save state to the given directory.
     pub(crate) fn save(&self, state_dir: &Path) -> Result<()> {
-        fs::create_dir_all(state_dir)?;
+        fs::create_dir_all(state_dir)
+            .with_context(|| format!("Failed to create state directory {}", state_dir.display()))?;
         let path = state_dir.join("state.json");
-        let json = serde_json::to_string_pretty(self)?;
-        fs::write(path, json)?;
+        let json =
+            serde_json::to_string_pretty(self).context("Failed to serialize DKG state to JSON")?;
+        fs::write(&path, json)
+            .with_context(|| format!("Failed to write DKG state {}", path.display()))?;
         Ok(())
     }
 
     pub(crate) fn load(state_dir: &Path) -> Result<Self> {
         let path = state_dir.join("state.json");
-        let json = fs::read_to_string(path)?;
-        Ok(serde_json::from_str(&json)?)
+        let json = fs::read_to_string(&path)
+            .with_context(|| format!("Failed to read DKG state {}", path.display()))?;
+        serde_json::from_str(&json)
+            .with_context(|| format!("Failed to parse DKG state {}", path.display()))
     }
 }
 
@@ -201,53 +204,4 @@ pub(crate) fn verify_signature(
     let payload_bytes = bcs::to_bytes(&payload)?;
     pk.verify(&payload_bytes, &signed_msg.signature)?;
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use fastcrypto::bls12381::min_sig::BLS12381KeyPair;
-    use fastcrypto::traits::KeyPair;
-    use rand::thread_rng;
-
-    #[test]
-    fn test_keys_file_serde() {
-        // Generate random keys
-        let mut rng = thread_rng();
-        let enc_sk = PrivateKey::<G1Element>::new(&mut rng);
-        let enc_pk = PublicKey::from_private_key(&enc_sk);
-
-        let signing_kp = BLS12381KeyPair::generate(&mut rng);
-        let signing_pk = signing_kp.public().clone();
-        let signing_sk = signing_kp.private();
-
-        let keys = KeysFile {
-            enc_sk,
-            enc_pk,
-            signing_sk,
-            signing_pk,
-        };
-
-        // Round trip.
-        let json = serde_json::to_string_pretty(&keys).expect("Failed to serialize KeysFile");
-        let deserialized: KeysFile =
-            serde_json::from_str(&json).expect("Failed to deserialize KeysFile");
-
-        assert_eq!(
-            bcs::to_bytes(&keys.enc_sk).unwrap(),
-            bcs::to_bytes(&deserialized.enc_sk).unwrap()
-        );
-        assert_eq!(
-            bcs::to_bytes(&keys.enc_pk).unwrap(),
-            bcs::to_bytes(&deserialized.enc_pk).unwrap()
-        );
-        assert_eq!(
-            bcs::to_bytes(&keys.signing_sk).unwrap(),
-            bcs::to_bytes(&deserialized.signing_sk).unwrap()
-        );
-        assert_eq!(
-            bcs::to_bytes(&keys.signing_pk).unwrap(),
-            bcs::to_bytes(&deserialized.signing_pk).unwrap()
-        );
-    }
 }

--- a/crates/seal-committee-cli/src/types.rs
+++ b/crates/seal-committee-cli/src/types.rs
@@ -94,6 +94,8 @@ pub struct InitializedConfig {
     pub expected_old_pks: Option<HashMap<u16, G2Element>>,
     /// Old partial key share for key rotation, for continuing members for key rotation.
     pub my_old_share: Option<G2Scalar>,
+    /// Old partial public key for key rotation, for continuing members for key rotation.
+    pub my_old_pk: Option<G2Element>,
 }
 
 /// Local state for DKG protocol, used for storing messages and output.

--- a/crates/seal-committee-cli/src/types.rs
+++ b/crates/seal-committee-cli/src/types.rs
@@ -17,6 +17,8 @@ use std::collections::HashMap;
 use std::{fs, path::Path};
 use sui_sdk_types::Address;
 
+const DST_DKG_MESSAGE_SIGNATURE: &str = "SEAL_DKG_MESSAGE_SIGNATURE_V0";
+
 // JSON hex serializers/deserializers using serde modules.
 macro_rules! json_hex_serde_module {
     ($module:ident, $type:ty) => {
@@ -133,9 +135,11 @@ impl DkgState {
     }
 }
 
-/// Wrapper struct for message and NIZK proof.
+/// Domain-separated payload signed for a DKG message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct MessageWithProof {
+struct MessageSignaturePayload {
+    domain: String,
+    committee_id: Address,
     message: Message<G2Element, G1Element>,
     nizk_proof: DLNizk<G2Element>,
 }
@@ -158,18 +162,22 @@ impl std::str::FromStr for SignedMessage {
     }
 }
 
-/// Create BLS signature for signed message. Signs over both the message and NIZK proof.
+/// Create BLS signature for signed message. Signs over a domain separator, committee ID,
+/// message, and NIZK proof.
 pub(crate) fn sign_message(
+    committee_id: &Address,
     message: Message<G2Element, G1Element>,
     sk: &BLS12381PrivateKey,
     nizk_proof: DLNizk<G2Element>,
 ) -> SignedMessage {
-    let wrapper = MessageWithProof {
+    let payload = MessageSignaturePayload {
+        domain: DST_DKG_MESSAGE_SIGNATURE.to_string(),
+        committee_id: *committee_id,
         message: message.clone(),
         nizk_proof: nizk_proof.clone(),
     };
-    let wrapper_bytes = bcs::to_bytes(&wrapper).expect("Serialization failed");
-    let signature = sk.sign(&wrapper_bytes);
+    let payload_bytes = bcs::to_bytes(&payload).expect("Serialization failed");
+    let signature = sk.sign(&payload_bytes);
     SignedMessage {
         message,
         signature,
@@ -177,14 +185,21 @@ pub(crate) fn sign_message(
     }
 }
 
-/// Verify BLS signature for signed message. Verifies both the message and NIZK proof.
-pub(crate) fn verify_signature(signed_msg: &SignedMessage, pk: &BLS12381PublicKey) -> Result<()> {
-    let wrapper = MessageWithProof {
+/// Verify BLS signature for signed message. Verifies the domain separator, committee ID,
+/// message, and NIZK proof.
+pub(crate) fn verify_signature(
+    committee_id: &Address,
+    signed_msg: &SignedMessage,
+    pk: &BLS12381PublicKey,
+) -> Result<()> {
+    let payload = MessageSignaturePayload {
+        domain: DST_DKG_MESSAGE_SIGNATURE.to_string(),
+        committee_id: *committee_id,
         message: signed_msg.message.clone(),
         nizk_proof: signed_msg.nizk_proof.clone(),
     };
-    let wrapper_bytes = bcs::to_bytes(&wrapper)?;
-    pk.verify(&wrapper_bytes, &signed_msg.signature)?;
+    let payload_bytes = bcs::to_bytes(&payload)?;
+    pk.verify(&payload_bytes, &signed_msg.signature)?;
     Ok(())
 }
 

--- a/crates/seal-committee-cli/src/types.rs
+++ b/crates/seal-committee-cli/src/types.rs
@@ -3,7 +3,7 @@
 
 //! Type definitions for DKG CLI.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use fastcrypto::bls12381::min_sig::{BLS12381PrivateKey, BLS12381PublicKey, BLS12381Signature};
 use fastcrypto::encoding::{Encoding, Hex};
 use fastcrypto::groups::bls12381::{G1Element, G2Element, Scalar as G2Scalar};
@@ -121,22 +121,17 @@ pub struct DkgState {
 impl DkgState {
     /// Save state to the given directory.
     pub(crate) fn save(&self, state_dir: &Path) -> Result<()> {
-        fs::create_dir_all(state_dir)
-            .with_context(|| format!("Failed to create state directory {}", state_dir.display()))?;
+        fs::create_dir_all(state_dir)?;
         let path = state_dir.join("state.json");
-        let json =
-            serde_json::to_string_pretty(self).context("Failed to serialize DKG state to JSON")?;
-        fs::write(&path, json)
-            .with_context(|| format!("Failed to write DKG state {}", path.display()))?;
+        let json = serde_json::to_string_pretty(self)?;
+        fs::write(&path, json)?;
         Ok(())
     }
 
     pub(crate) fn load(state_dir: &Path) -> Result<Self> {
         let path = state_dir.join("state.json");
-        let json = fs::read_to_string(&path)
-            .with_context(|| format!("Failed to read DKG state {}", path.display()))?;
-        serde_json::from_str(&json)
-            .with_context(|| format!("Failed to parse DKG state {}", path.display()))
+        let json = fs::read_to_string(path)?;
+        Ok(serde_json::from_str(&json)?)
     }
 }
 

--- a/crates/seal-committee/src/grpc_helper.rs
+++ b/crates/seal-committee/src/grpc_helper.rs
@@ -27,20 +27,15 @@ struct UpgradeManagerKey {
     dummy_field: bool,
 }
 
-/// Create gRPC client for a given network. Use custom_rpc_url if provided.
-pub fn create_grpc_client_with_url(
-    network: &Network,
-    custom_rpc_url: Option<&str>,
-) -> Result<Client> {
-    let rpc_url = custom_rpc_url
-        .or_else(|| network.default_rpc_url())
-        .ok_or_else(|| anyhow!("Custom network requires NODE_URL in config or --rpc-url flag"))?;
+/// Create gRPC client from a network config and optional RPC URL override.
+pub fn create_grpc_client_from_config(network: &Network, rpc_url: Option<&str>) -> Result<Client> {
+    let rpc_url = rpc_url.unwrap_or_else(|| network.default_rpc_url());
     Ok(Client::new(rpc_url)?)
 }
 
 /// Create gRPC client for a given network using default URLs.
 pub fn create_grpc_client(network: &Network) -> Result<Client> {
-    create_grpc_client_with_url(network, None)
+    create_grpc_client_from_config(network, None)
 }
 
 pub fn extract_object(response: GetObjectResponse) -> Result<Object> {

--- a/crates/seal-committee/src/grpc_helper.rs
+++ b/crates/seal-committee/src/grpc_helper.rs
@@ -27,15 +27,18 @@ struct UpgradeManagerKey {
     dummy_field: bool,
 }
 
-/// Create gRPC client from a network config and optional RPC URL override.
-pub fn create_grpc_client_from_config(network: &Network, rpc_url: Option<&str>) -> Result<Client> {
-    let rpc_url = rpc_url.unwrap_or_else(|| network.default_rpc_url());
+/// Create gRPC client from a network and optional RPC URL override.
+pub fn create_grpc_client_with_url(
+    network: &Network,
+    custom_rpc_url: Option<&str>,
+) -> Result<Client> {
+    let rpc_url = custom_rpc_url.unwrap_or_else(|| network.default_rpc_url());
     Ok(Client::new(rpc_url)?)
 }
 
 /// Create gRPC client for a given network using default URLs.
 pub fn create_grpc_client(network: &Network) -> Result<Client> {
-    create_grpc_client_from_config(network, None)
+    create_grpc_client_with_url(network, None)
 }
 
 pub fn extract_object(response: GetObjectResponse) -> Result<Object> {
@@ -284,13 +287,13 @@ pub async fn fetch_upgrade_manager(
     Ok(upgrade_manager)
 }
 
-/// Get next committee version and key server pk if exists. For fresh DKG, the next version is 0,
-/// old pk is None. For rotation, the next version is the old committee's KeyServer version + 1.
-/// Old pk is returned as Some from the key server object.
+/// Get next committee version, old key server pk, and old committee ID if they exist.
+/// For fresh DKG, the next version is 0 and the old values are None. For rotation, the next
+/// version is the old committee's KeyServer version + 1.
 pub async fn get_committee_rotation_info(
     grpc_client: &mut Client,
     committee_id: &Address,
-) -> RpcResult<(u32, Option<Vec<u8>>)> {
+) -> RpcResult<(u32, Option<Vec<u8>>, Option<Address>)> {
     let committee = fetch_committee_data(grpc_client, committee_id).await?;
 
     if let Some(old_committee_id) = committee.old_committee_id {
@@ -305,12 +308,12 @@ pub async fn get_committee_rotation_info(
                     version,
                     version + 1
                 );
-                Ok((version + 1, Some(pk)))
+                Ok((version + 1, Some(pk), Some(old_committee_id)))
             }
             _ => Err(RpcError::new("Old KeyServer is not of type Committee")),
         }
     } else {
-        Ok((0, None))
+        Ok((0, None, None))
     }
 }
 

--- a/crates/seal-committee/src/lib.rs
+++ b/crates/seal-committee/src/lib.rs
@@ -8,7 +8,7 @@ pub mod types;
 pub mod utils;
 
 pub use grpc_helper::{
-    create_grpc_client, create_grpc_client_with_url, fetch_committee_data,
+    create_grpc_client, create_grpc_client_from_config, fetch_committee_data,
     fetch_committee_from_key_server, fetch_key_server_by_committee, fetch_key_server_by_id,
     fetch_upgrade_manager, fetch_upgrade_proposal, get_committee_rotation_info,
 };

--- a/crates/seal-committee/src/lib.rs
+++ b/crates/seal-committee/src/lib.rs
@@ -8,7 +8,7 @@ pub mod types;
 pub mod utils;
 
 pub use grpc_helper::{
-    create_grpc_client, create_grpc_client_from_config, fetch_committee_data,
+    create_grpc_client, create_grpc_client_with_url, fetch_committee_data,
     fetch_committee_from_key_server, fetch_key_server_by_committee, fetch_key_server_by_id,
     fetch_upgrade_manager, fetch_upgrade_proposal, get_committee_rotation_info,
 };

--- a/crates/seal-committee/src/types.rs
+++ b/crates/seal-committee/src/types.rs
@@ -9,7 +9,6 @@ use std::{fmt::Display, str::FromStr};
 pub enum Network {
     Testnet,
     Mainnet,
-    Custom,
 }
 
 impl FromStr for Network {
@@ -20,9 +19,8 @@ impl FromStr for Network {
         match lower.as_str() {
             "mainnet" => Ok(Network::Mainnet),
             "testnet" => Ok(Network::Testnet),
-            "custom" => Ok(Network::Custom),
             _ => Err(format!(
-                "Unknown network: {s}. Supported networks: 'mainnet', 'testnet', 'custom'"
+                "Unknown network: {s}. Supported networks: 'mainnet', 'testnet'"
             )),
         }
     }
@@ -33,18 +31,16 @@ impl Display for Network {
         match self {
             Network::Mainnet => write!(f, "Mainnet"),
             Network::Testnet => write!(f, "Testnet"),
-            Network::Custom => write!(f, "Custom"),
         }
     }
 }
 
 impl Network {
-    /// Get the default RPC URL for the network, if any.
-    pub fn default_rpc_url(&self) -> Option<&'static str> {
+    /// Get the default RPC URL for the network.
+    pub fn default_rpc_url(&self) -> &'static str {
         match self {
-            Network::Mainnet => Some(sui_rpc::client::Client::MAINNET_FULLNODE),
-            Network::Testnet => Some(sui_rpc::client::Client::TESTNET_FULLNODE),
-            Network::Custom => None,
+            Network::Mainnet => sui_rpc::client::Client::MAINNET_FULLNODE,
+            Network::Testnet => sui_rpc::client::Client::TESTNET_FULLNODE,
         }
     }
 }

--- a/docs/content/KeyServerCommitteeOps.mdx
+++ b/docs/content/KeyServerCommitteeOps.mdx
@@ -497,7 +497,7 @@ cargo run --bin seal-committee-cli -- init-state
 
 4. **Process messages and propose the rotation (Phase C: Finalization)**
 
-Wait for the coordinator to announce **Phase C (Finalization)** and provide a directory containing all DKG messages (for example, `path/to/dkg-messages`).
+Wait for the coordinator to announce **Phase C (Finalization)** and provide a directory containing exactly the old committee threshold number of DKG messages from continuing members (for example, `path/to/dkg-messages`).
 
 Move the directory into `dkg-state` and process the messages:
 ```bash

--- a/move/seal/sources/key_server.move
+++ b/move/seal/sources/key_server.move
@@ -74,7 +74,7 @@ public enum ServerType has drop, store {
 
 /// PartialKeyServer struct for a committee member.
 public struct PartialKeyServer has copy, drop, store {
-    /// Unique name of the partial key server.
+    /// Unique name of the partial key server. Information only.
     name: String,
     /// Server URL, can be updated by the owning member.
     url: String,


### PR DESCRIPTION
## Description 

- resolve package environments for custom networks via wallet/RPC context, including package-digest --rpc-url for cli
- harden DKG message signing by adding a domain separator and committee_id to the signed payload
- reject duplicate senders when process dkg message
- hash one sender-sorted message vector to preserve message boundaries
- add some more logs

## Test plan 

How did you test the new or updated feature?