### PR TITLE
[key-server] track /v1/debug/committee_partial_pk in route metrics

### DIFF
--- a/crates/key-server/src/metrics.rs
+++ b/crates/key-server/src/metrics.rs
@@ -14,7 +14,16 @@ use std::time::Instant;
 /// Known valid routes for metrics labeling.
 /// Any route not in this list will be normalized to "unknown" to prevent
 /// high-cardinality label explosion from malicious requests.
-const KNOWN_ROUTES: &[&str] = &["/v1/fetch_key", "/v1/service", "/health"];
+///
+/// When adding a new route to the key-server or aggregator router, also add it
+/// here so its requests are tracked under their own label instead of being
+/// lumped into "unknown" alongside scanner/bot traffic.
+const KNOWN_ROUTES: &[&str] = &[
+    "/v1/fetch_key",
+    "/v1/service",
+    "/v1/debug/committee_partial_pk",
+    "/health",
+];
 
 /// Normalize a route path to a known route or "unknown".
 /// This prevents high-cardinality metrics from malicious/invalid request paths.
@@ -484,6 +493,10 @@ mod tests {
     fn test_normalize_route_known_routes() {
         assert_eq!(normalize_route("/v1/fetch_key"), "/v1/fetch_key");
         assert_eq!(normalize_route("/v1/service"), "/v1/service");
+        assert_eq!(
+            normalize_route("/v1/debug/committee_partial_pk"),
+            "/v1/debug/committee_partial_pk"
+        );
         assert_eq!(normalize_route("/health"), "/health");
     }
 


### PR DESCRIPTION
## Description

The HTTP request metrics middleware normalizes any path that's not in the
`KNOWN_ROUTES` whitelist to `"unknown"` to prevent label cardinality blowups
from scanner/bot traffic. `/v1/debug/committee_partial_pk` is a real handler
registered on the key-server router but was missing from the whitelist, so all
requests to it (~1–2 req/min per pod across the testnet/mainnet fleet, both
`200`s from committee-mode servers and `400 "Unsupported"` responses from
standalone servers) were being lumped into the `unknown` bucket.

This had two side effects:

- The `unknown` bucket on the key-servers was polluted with real operational
  traffic, making it useless as a signal for malicious probes.
- We had no per-route visibility into the debug endpoint's request rate and
  error breakdown (e.g. to spot committee-mode servers incorrectly returning
  `400`).

This PR:

- Adds `/v1/debug/committee_partial_pk` to `KNOWN_ROUTES`.
- Adds a comment on the whitelist reminding future contributors to register
  any new router routes here.
- Extends the existing `test_normalize_route_known_routes` unit test to cover
  the new route.

After this rolls out:

- `route="unknown"` on key-servers should drop to essentially zero (just true
  scanner/bot noise).
- `/v1/debug/committee_partial_pk` gets its own bucket in
  `http_requests_total` / `http_request_duration_millis`, with proper `status`
  breakdown.
- The known-route counts for `/v1/fetch_key` and `/v1/service` are unchanged
  (they were never deflated; the unknown traffic was to a different route).

## Test plan

- `cargo test -p key-server --lib metrics::` — both `test_normalize_route_known_routes`
  and `test_normalize_route_unknown_routes` pass locally.
- `cargo clippy -p key-server --lib --all-features -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Post-deploy validation: confirm in Grafana (`Seal Key Servers Committee -
  Testnet` dashboard) that `http_requests_total{route="unknown"}` on the
  key-server pods drops to near-zero and a new
  `route="/v1/debug/committee_partial_pk"` series appears.