### PR TITLE
build: cache cargo registry/git/target via BuildKit mounts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,21 @@ COPY ./Cargo.toml ./Cargo.lock ./
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
 
-RUN cargo build --bin key-server --profile $PROFILE --config net.git-fetch-with-cli=true
+# BuildKit cargo cache mounts: registry/git/target persist on the mp3
+# stateful-pool PVC across commits. Cache-mount contents aren't committed to
+# the image layer, so copy the binary out to a stable path in the same RUN.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/work/target,sharing=locked \
+    cargo build --bin key-server --profile $PROFILE --config net.git-fetch-with-cli=true \
+    && cp /work/target/release/key-server /work/key-server
 FROM debian:bullseye-slim AS runtime
 
 EXPOSE 2024
 
 RUN apt-get update && apt-get install -y cmake clang libpq5 ca-certificates libpq-dev postgresql
 
-COPY --from=builder /work/target/release/key-server /opt/key-server/bin/
+COPY --from=builder /work/key-server /opt/key-server/bin/
 
 # Handle all environment variables
 RUN echo '#!/bin/bash\n\

--- a/Dockerfile.aggregator
+++ b/Dockerfile.aggregator
@@ -11,7 +11,14 @@ COPY ./Cargo.toml ./Cargo.lock ./
 ARG GIT_REVISION
 ENV GIT_REVISION=$GIT_REVISION
 
-RUN cargo build --bin aggregator-server --profile $PROFILE --config net.git-fetch-with-cli=true
+# BuildKit cargo cache mounts: registry/git/target persist on the mp3
+# stateful-pool PVC across commits. Cache-mount contents aren't committed to
+# the image layer, so copy the binary out to a stable path in the same RUN.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/work/target,sharing=locked \
+    cargo build --bin aggregator-server --profile $PROFILE --config net.git-fetch-with-cli=true \
+    && cp /work/target/release/aggregator-server /work/aggregator-server
 
 FROM debian:bullseye-slim AS runtime
 
@@ -19,7 +26,7 @@ EXPOSE 2024
 
 RUN apt-get update && apt-get install -y ca-certificates
 
-COPY --from=builder /work/target/release/aggregator-server /opt/aggregator-server/bin/
+COPY --from=builder /work/aggregator-server /opt/aggregator-server/bin/
 COPY ./crates/key-server/src/aggregator/aggregator-config.yaml /opt/aggregator-server/config/
 
 # Set default CONFIG_PATH


### PR DESCRIPTION
## What
Add BuildKit cargo cache mounts to both builder Dockerfiles (`Dockerfile` → `key-server`, `Dockerfile.aggregator` → `aggregator-server`):

```
RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
    --mount=type=cache,target=/work/target,sharing=locked \
    cargo build --bin <bin> --profile $PROFILE --config net.git-fetch-with-cli=true \
    && cp /work/target/release/<bin> /work/<bin>
```
…and the runtime stage now copies the binary from `/work/<bin>` (cache-mount contents aren't committed to the image layer, so the binary is `cp`'d out within the same `RUN`).

## Why
Both images do a single `cargo build` of the workspace with no caching, so **every build recompiles all dependencies + the workspace from scratch** (p50 ~5 min). The cache mounts let the cargo **registry/git** (downloaded crates) and **target** (compiled deps + incremental workspace output) persist across builds.

## Requirements / pairing
- **Requires BuildKit** — the production build path (mp3's builder) uses it, same as the `--mount=type=cache` mounts mp3 already injects for sui/walrus images. (Local `docker build` needs BuildKit enabled, which is the default on modern Docker.)
- Cross-build persistence comes from the cache mounts living on mp3's **stateful-pool PVC** — routed via **MystenLabs/sui-operations#8028** (adds these images to the stateful-pool allowlist). This Dockerfile change is the prerequisite; the win lands once both are in.

## Notes
- `GIT_REVISION` is unchanged (already declared after the source COPYs; only stamped into the build env, not the cached layers).
- `sharing=locked` serializes concurrent builds that share a cache mount on the same pod — safe for a cargo target dir; mp3 sticky-routes same-image builds to one pod, so contention is minimal.

## Test plan
- I could not run a full local `docker build` (slow Rust workspace), so **CI is the build gate** — please confirm both images build green here.
- After merge + #8028: confirm the `key-server`/`aggregator-server` builds reuse the cargo cache on subsequent commits (build time drops once the cache is warm) and that the runtime images still contain a working binary at `/opt/<svc>/bin/<svc>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)