### PR TITLE
Migrate committee rotation event monitor to gRPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -292,7 +292,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1030,7 +1030,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -1050,7 +1050,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -2046,7 +2046,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_with",
- "sui-sdk-types 0.3.0",
+ "sui-sdk-types 0.3.1",
  "sui-types",
  "typenum",
 ]
@@ -2818,7 +2818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3912,7 +3912,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4235,7 +4235,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4577,10 +4577,10 @@ dependencies = [
  "shared-crypto",
  "snap",
  "sui-move-build",
- "sui-rpc",
+ "sui-rpc 0.3.1",
  "sui-rpc-api",
  "sui-sdk",
- "sui-sdk-types 0.3.0",
+ "sui-sdk-types 0.3.1",
  "sui-types",
  "tap",
  "temp-env",
@@ -6153,7 +6153,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7179,8 +7179,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -7201,7 +7201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7214,7 +7214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7385,7 +7385,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7423,7 +7423,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7990,7 +7990,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8244,7 +8244,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sui-sdk",
- "sui-sdk-types 0.3.0",
+ "sui-sdk-types 0.3.1",
  "sui-types",
  "tokio",
 ]
@@ -8259,8 +8259,8 @@ dependencies = [
  "fastcrypto-tbls",
  "prost-types 0.14.3",
  "serde",
- "sui-rpc",
- "sui-sdk-types 0.3.0",
+ "sui-rpc 0.3.1",
+ "sui-sdk-types 0.3.1",
  "sui-types",
  "tokio",
  "tonic 0.14.6",
@@ -8287,10 +8287,10 @@ dependencies = [
  "sui-keys",
  "sui-move-build",
  "sui-package-alt",
- "sui-rpc",
+ "sui-rpc 0.3.1",
  "sui-rpc-api",
  "sui-sdk",
- "sui-sdk-types 0.3.0",
+ "sui-sdk-types 0.3.1",
  "sui-types",
  "tokio",
 ]
@@ -8336,7 +8336,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sui-sdk-types 0.3.0",
+ "sui-sdk-types 0.3.1",
  "sui-types",
  "tracing",
 ]
@@ -8862,7 +8862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9370,7 +9370,7 @@ dependencies = [
  "sui-macros",
  "sui-network",
  "sui-protocol-config",
- "sui-rpc",
+ "sui-rpc 0.3.0",
  "sui-simulator",
  "sui-storage",
  "sui-swarm-config",
@@ -9414,6 +9414,17 @@ dependencies = [
  "sha2 0.10.9",
  "signature 2.2.0",
  "sui-sdk-types 0.3.0",
+]
+
+[[package]]
+name = "sui-crypto"
+version = "0.3.0"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f383e14deec809886aa5e67ce734105a3883f1d4#f383e14deec809886aa5e67ce734105a3883f1d4"
+dependencies = [
+ "blst",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "sui-sdk-types 0.3.1",
 ]
 
 [[package]]
@@ -9942,7 +9953,7 @@ dependencies = [
  "sui-http",
  "sui-macros",
  "sui-protocol-config",
- "sui-rpc",
+ "sui-rpc 0.3.0",
  "sui-simulator",
  "sui-storage",
  "sui-swarm-config",
@@ -10154,6 +10165,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sui-rpc"
+version = "0.3.1"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f383e14deec809886aa5e67ce734105a3883f1d4#f383e14deec809886aa5e67ce734105a3883f1d4"
+dependencies = [
+ "base64 0.22.1",
+ "bcs",
+ "bytes",
+ "futures",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "serde",
+ "serde_json",
+ "sui-crypto 0.3.0 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f383e14deec809886aa5e67ce734105a3883f1d4)",
+ "sui-sdk-types 0.3.1",
+ "tap",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tower 0.5.3",
+]
+
+[[package]]
 name = "sui-rpc-api"
 version = "0.1.0"
 source = "git+https://github.com/mystenlabs/sui?rev=a3cc4467c9de48410a01fc2b6f3c1bff48780e5f#a3cc4467c9de48410a01fc2b6f3c1bff48780e5f"
@@ -10180,13 +10215,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sui-config",
- "sui-crypto",
+ "sui-crypto 0.3.0 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e494a36a76a0aab8c5d66d5557995faee5c1fb09)",
  "sui-display",
  "sui-macros",
  "sui-name-service",
  "sui-package-resolver",
  "sui-protocol-config",
- "sui-rpc",
+ "sui-rpc 0.3.0",
  "sui-sdk-types 0.3.0",
  "sui-transaction-builder",
  "sui-transaction-checks",
@@ -10225,12 +10260,12 @@ dependencies = [
  "serde_with",
  "shared-crypto",
  "sui-config",
- "sui-crypto",
+ "sui-crypto 0.3.0 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e494a36a76a0aab8c5d66d5557995faee5c1fb09)",
  "sui-json",
  "sui-json-rpc-api",
  "sui-json-rpc-types",
  "sui-keys",
- "sui-rpc",
+ "sui-rpc 0.3.0",
  "sui-rpc-api",
  "sui-sdk-types 0.3.0",
  "sui-transaction-builder",
@@ -10257,6 +10292,27 @@ dependencies = [
 name = "sui-sdk-types"
 version = "0.3.0"
 source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=e494a36a76a0aab8c5d66d5557995faee5c1fb09#e494a36a76a0aab8c5d66d5557995faee5c1fb09"
+dependencies = [
+ "base64ct",
+ "bcs",
+ "blake2",
+ "bnum 0.13.0",
+ "bs58 0.5.1",
+ "bytes",
+ "bytestring",
+ "itertools 0.14.0",
+ "roaring 0.11.3",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "sui-sdk-types"
+version = "0.3.1"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=f383e14deec809886aa5e67ce734105a3883f1d4#f383e14deec809886aa5e67ce734105a3883f1d4"
 dependencies = [
  "base64ct",
  "bcs",
@@ -10368,7 +10424,7 @@ dependencies = [
  "sui-config",
  "sui-json-rpc-types",
  "sui-protocol-config",
- "sui-rpc",
+ "sui-rpc 0.3.0",
  "sui-types",
  "tap",
  "telemetry-subscribers",
@@ -10575,7 +10631,7 @@ dependencies = [
  "sui-enum-compat-util",
  "sui-macros",
  "sui-protocol-config",
- "sui-rpc",
+ "sui-rpc 0.3.0",
  "sui-sdk-types 0.3.0",
  "tap",
  "thiserror 1.0.69",
@@ -10826,7 +10882,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11733,7 +11789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.6",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -12244,7 +12300,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ sui-package-alt = { git = "https://github.com/mystenlabs/sui", rev = "a3cc4467c9
 sui-rpc-api = { git = "https://github.com/mystenlabs/sui", rev = "a3cc4467c9de48410a01fc2b6f3c1bff48780e5f", package = "sui-rpc-api" }
 sui_keys = { git = "https://github.com/mystenlabs/sui", rev = "a3cc4467c9de48410a01fc2b6f3c1bff48780e5f", package = "sui-keys" }
 
-sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "e494a36a76a0aab8c5d66d5557995faee5c1fb09", package = "sui-sdk-types", features = ["serde"] }
-sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "e494a36a76a0aab8c5d66d5557995faee5c1fb09", package = "sui-rpc" }
+sui-sdk-types = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "f383e14deec809886aa5e67ce734105a3883f1d4", package = "sui-sdk-types", features = ["serde"] }
+sui-rpc = { git = "https://github.com/MystenLabs/sui-rust-sdk.git", rev = "f383e14deec809886aa5e67ce734105a3883f1d4", package = "sui-rpc", features = ["unstable"] }
 
 [profile.release]
 panic = 'abort'

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -54,14 +54,17 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use sui_rpc::client::Client as SuiGrpcClient;
 use sui_rpc::proto::sui::rpc::v2::execution_error::ExecutionErrorKind;
-use sui_sdk::rpc_types::EventFilter;
+use sui_rpc::proto::sui::rpc::v2alpha::{
+    event_literal, event_predicate, list_events_response, EventFilter as SuiGrpcEventFilter,
+    EventItem as SuiGrpcEventItem, EventLiteral, EventPredicate, EventTerm, EventTypeFilter,
+    ListEventsRequest, Ordering as EventQueryOrdering, QueryEndReason, QueryOptions, Watermark,
+};
 use sui_sdk::types::base_types::{ObjectID, SuiAddress};
 use sui_sdk::types::signature::GenericSignature;
 use sui_sdk::types::transaction::{ProgrammableTransaction, TransactionData, TransactionKind};
 use sui_sdk::verify_personal_message_signature::verify_personal_message_signature;
 use sui_sdk::SuiClientBuilder;
 use sui_sdk_types::Address;
-use sui_types::event::EventID;
 use sui_types::{derived_object, SUI_ADDRESS_ALIAS_STATE_OBJECT_ID, SUI_FRAMEWORK_ADDRESS};
 use tap::tap::TapFallible;
 use tap::Tap;
@@ -362,11 +365,25 @@ impl Server {
             }
         }
 
+        let signature_verification_client = self
+            .options
+            .node_url
+            .as_deref()
+            .or_else(|| match &self.options.network {
+                #[cfg(test)]
+                Network::TestCluster { .. } => None,
+                network => Some(network.default_node_url()),
+            })
+            .map(|node_url| {
+                sui_sdk::sui_rpc::Client::new(node_url)
+                    .expect("SuiClientBuilder should not have accepted an invalid node url")
+            });
+
         verify_personal_message_signature(
             cert.signature.clone(),
             msg.as_bytes(),
             cert.user,
-            Some(self.sui_rpc_client.sui_grpc_client()),
+            signature_verification_client,
         )
         .await
         .tap_err(|e| {
@@ -773,17 +790,16 @@ impl Server {
             key_server_obj_id
         );
 
-        let sui_client = self.sui_rpc_client.sui_client().clone();
         let sui_rpc_client = self.sui_rpc_client.clone();
 
-        // Spawn the background task to poll for events.
+        // Spawn the background task to poll the filtered gRPC event stream.
         tokio::spawn(async move {
             info!("Committee rotation event monitor task started");
-            let mut last_event_seq: Option<EventID> = None;
-            let mut initialized = false;
+            let mut active_event_type = None;
+            let mut event_cursor = None;
 
             loop {
-                // Fetch current committee ID and package ID from key server object
+                // Fetch current committee ID and package ID from key server object.
                 let (committee_id, committee_pkg_id) = match sui_rpc_client
                     .fetch_committee_from_key_server(&key_server_obj_id)
                     .await
@@ -802,28 +818,19 @@ impl Server {
                     }
                 };
 
-                let event_filter = EventFilter::MoveEventType(
-                    format!(
-                        "{}::seal_committee::CommitteeRotationInitiated",
-                        committee_pkg_id
-                    )
-                    .parse()
-                    .expect("Parsing should not fail"),
-                );
-
-                if !initialized {
-                    match sui_client
-                        .event_api()
-                        .query_events(event_filter.clone(), None, Some(1), true)
+                let event_type = committee_rotation_event_type(committee_pkg_id);
+                if active_event_type.as_deref() != Some(event_type.as_str()) {
+                    match initialize_committee_rotation_event_cursor(&sui_rpc_client, &event_type)
                         .await
                     {
-                        Ok(page) => {
-                            last_event_seq = page.data.first().map(|event| event.id);
-                            initialized = true;
+                        Ok(cursor) => {
                             debug!(
-                                "Committee rotation event monitor initialized at cursor: {:?}",
-                                last_event_seq
+                                "Committee rotation event monitor initialized for type {} at cursor present={}",
+                                event_type,
+                                cursor.is_some()
                             );
+                            active_event_type = Some(event_type);
+                            event_cursor = cursor;
                         }
                         Err(e) => {
                             warn!(
@@ -837,44 +844,19 @@ impl Server {
                     continue;
                 }
 
-                let events_result = sui_client
-                    .event_api()
-                    .query_events(
-                        event_filter,
-                        last_event_seq,
-                        Some(1), // Fetch the next unseen event.
-                        false,   // ascending order
-                    )
-                    .await;
-
-                match events_result {
-                    Ok(page) => {
-                        for event in &page.data {
-                            let event_data = bcs::from_bytes::<CommitteeRotationInitiatedEvent>(
-                                event.bcs.bytes(),
-                            )
-                            .expect("BCS should not fail");
-
-                            if event_data.old_committee_id != committee_id {
-                                // This means a different committee is initialized with this committee package ID and being rotated, should never happen.
-                                error!(
-                                    "Committee ID mismatch detected! Event committee_id: {}, old_committee_id: {}, Current committee_id: {}",
-                                    event_data.committee_id, event_data.old_committee_id, committee_id
-                                );
-                            }
-
-                            warn!(
-                                "Committee rotation initiation detected! New committee_id: {}, Old committee_id: {}",
-                                event_data.committee_id, event_data.old_committee_id
-                            );
-
-                            metrics.committee_mode_rotation_initiated_total.inc();
-
-                            last_event_seq = Some(event.id);
-                        }
-                    }
+                match process_committee_rotation_event_page(
+                    &sui_rpc_client,
+                    &event_type,
+                    &mut event_cursor,
+                    committee_id,
+                    &metrics,
+                )
+                .await
+                {
+                    Ok(reached_item_limit) if reached_item_limit => continue,
+                    Ok(_) => {}
                     Err(e) => {
-                        warn!("Failed to query committee rotation events: {}", e);
+                        warn!("Failed to list committee rotation events over gRPC: {}", e);
                     }
                 }
 
@@ -954,6 +936,195 @@ impl Server {
             }
         });
     }
+}
+
+fn committee_rotation_event_type(committee_pkg_id: Address) -> String {
+    format!("{committee_pkg_id}::seal_committee::CommitteeRotationInitiated")
+}
+
+fn committee_rotation_event_filter(event_type: &str) -> SuiGrpcEventFilter {
+    let mut event_type_filter = EventTypeFilter::default();
+    event_type_filter.r#type = Some(event_type.to_owned());
+
+    let mut event_predicate = EventPredicate::default();
+    event_predicate.predicate = Some(event_predicate::Predicate::EventType(event_type_filter));
+
+    let mut event_literal = EventLiteral::default();
+    event_literal.polarity = Some(event_literal::Polarity::Include(event_predicate));
+
+    let mut event_term = EventTerm::default();
+    event_term.literals = vec![event_literal];
+
+    let mut filter = SuiGrpcEventFilter::default();
+    filter.terms = vec![event_term];
+    filter
+}
+
+fn committee_rotation_events_request(
+    event_type: &str,
+    after_cursor: Option<Vec<u8>>,
+    ordering: EventQueryOrdering,
+    limit_items: u32,
+) -> ListEventsRequest {
+    let mut options = QueryOptions::default();
+    options.limit_items = Some(limit_items);
+    options.after = after_cursor.map(Into::into);
+    options.ordering = ordering as i32;
+
+    let mut request = ListEventsRequest::default();
+    request.filter = Some(committee_rotation_event_filter(event_type));
+    request.options = Some(options);
+    request
+}
+
+async fn initialize_committee_rotation_event_cursor(
+    sui_rpc_client: &SuiRpcClient,
+    event_type: &str,
+) -> Result<Option<Vec<u8>>> {
+    let request =
+        committee_rotation_events_request(event_type, None, EventQueryOrdering::Descending, 1);
+    let mut stream = sui_rpc_client
+        .list_events(request)
+        .await
+        .context("Failed to start committee rotation event cursor query")?;
+    let mut cursor = None;
+
+    while let Some(response) = stream
+        .message()
+        .await
+        .context("Committee rotation event cursor query failed")?
+    {
+        match response.response {
+            Some(list_events_response::Response::Item(item)) => {
+                let Some(watermark) = item.watermark.as_ref() else {
+                    anyhow::bail!(
+                        "Committee rotation event cursor query returned an item without a watermark"
+                    );
+                };
+                update_committee_rotation_event_cursor(&mut cursor, Some(watermark));
+            }
+            Some(list_events_response::Response::Watermark(watermark)) => {
+                update_committee_rotation_event_cursor(&mut cursor, Some(&watermark));
+            }
+            Some(list_events_response::Response::End(_)) | None => break,
+            Some(_) => break,
+        }
+    }
+
+    Ok(cursor)
+}
+
+async fn process_committee_rotation_event_page(
+    sui_rpc_client: &SuiRpcClient,
+    event_type: &str,
+    event_cursor: &mut Option<Vec<u8>>,
+    committee_id: Address,
+    metrics: &KeyServerMetrics,
+) -> Result<bool> {
+    let request = committee_rotation_events_request(
+        event_type,
+        event_cursor.clone(),
+        EventQueryOrdering::Ascending,
+        100,
+    );
+    let mut stream = sui_rpc_client
+        .list_events(request)
+        .await
+        .context("Failed to start committee rotation event query")?;
+    let mut reached_item_limit = false;
+
+    while let Some(response) = stream
+        .message()
+        .await
+        .context("Committee rotation event query failed")?
+    {
+        match response.response {
+            Some(list_events_response::Response::Item(item)) => {
+                let Some(watermark) = item.watermark.as_ref() else {
+                    anyhow::bail!(
+                        "Committee rotation event query returned an item without a watermark"
+                    );
+                };
+                update_committee_rotation_event_cursor(event_cursor, Some(watermark));
+                handle_committee_rotation_event_item(&item, event_type, committee_id, metrics);
+            }
+            Some(list_events_response::Response::Watermark(watermark)) => {
+                update_committee_rotation_event_cursor(event_cursor, Some(&watermark));
+            }
+            Some(list_events_response::Response::End(end)) => {
+                reached_item_limit = matches!(
+                    QueryEndReason::try_from(end.reason).ok(),
+                    Some(QueryEndReason::ItemLimit | QueryEndReason::ScanLimit)
+                );
+                break;
+            }
+            None => break,
+            Some(_) => break,
+        }
+    }
+
+    Ok(reached_item_limit)
+}
+
+fn update_committee_rotation_event_cursor(
+    event_cursor: &mut Option<Vec<u8>>,
+    watermark: Option<&Watermark>,
+) {
+    if let Some(cursor) = watermark.and_then(|watermark| watermark.cursor.as_ref()) {
+        *event_cursor = Some(cursor.to_vec());
+    }
+}
+
+fn handle_committee_rotation_event_item(
+    item: &SuiGrpcEventItem,
+    event_type: &str,
+    committee_id: Address,
+    metrics: &KeyServerMetrics,
+) {
+    let event_location = format!(
+        "checkpoint {:?}, transaction {:?}, event {:?}",
+        item.checkpoint, item.transaction_digest, item.event_index
+    );
+    let Some(event) = item.event.as_ref() else {
+        warn!("Committee rotation event item was missing event data at {event_location}");
+        return;
+    };
+    if event.event_type.as_deref() != Some(event_type) {
+        warn!(
+            "Committee rotation event query returned unexpected event type {:?} at {}",
+            event.event_type, event_location
+        );
+        return;
+    }
+
+    let Some(contents) = event.contents.as_ref().and_then(|bcs| bcs.value.as_deref()) else {
+        warn!("Committee rotation event was missing BCS contents at {event_location}");
+        return;
+    };
+
+    let event_data = match bcs::from_bytes::<CommitteeRotationInitiatedEvent>(contents) {
+        Ok(event_data) => event_data,
+        Err(e) => {
+            warn!("Failed to deserialize committee rotation event at {event_location}: {e}");
+            return;
+        }
+    };
+
+    if event_data.old_committee_id != committee_id {
+        // This means a different committee is initialized with this committee package ID
+        // and being rotated, which should never happen.
+        error!(
+            "Committee ID mismatch detected! Event committee_id: {}, old_committee_id: {}, Current committee_id: {}",
+            event_data.committee_id, event_data.old_committee_id, committee_id
+        );
+    }
+
+    warn!(
+        "Committee rotation initiation detected! New committee_id: {}, Old committee_id: {}",
+        event_data.committee_id, event_data.old_committee_id
+    );
+
+    metrics.committee_mode_rotation_initiated_total.inc();
 }
 
 #[allow(clippy::single_match)]

--- a/crates/key-server/src/sui_rpc_client.rs
+++ b/crates/key-server/src/sui_rpc_client.rs
@@ -23,6 +23,7 @@ use sui_rpc::proto::sui::rpc::v2::{
     Bcs, GetEpochRequest, GetObjectRequest, SimulateTransactionRequest,
     SimulateTransactionResponse, Transaction,
 };
+use sui_rpc::proto::sui::rpc::v2alpha::{ListEventsRequest, ListEventsResponse};
 use sui_sdk::SuiClient;
 use sui_sdk_types::Address;
 use sui_types::object::Data;
@@ -424,6 +425,25 @@ impl SuiRpcClient {
                 .await
                 .map(|r| r.into_inner().epoch().reference_gas_price())
                 .map_err(RpcError::from_grpc)
+        })
+        .await
+    }
+
+    /// Lists events via the v2alpha gRPC ledger API.
+    pub async fn list_events(
+        &self,
+        request: ListEventsRequest,
+    ) -> RpcResult<tonic::codec::Streaming<ListEventsResponse>> {
+        self.run_grpc_with_retries("list_events", move |mut grpc_client| {
+            let request = request.clone();
+            async move {
+                grpc_client
+                    .ledger_client_alpha()
+                    .list_events(request)
+                    .await
+                    .map(|r| r.into_inner())
+                    .map_err(RpcError::from_grpc)
+            }
         })
         .await
     }

--- a/crates/key-server/src/tests/e2e.rs
+++ b/crates/key-server/src/tests/e2e.rs
@@ -35,6 +35,7 @@ use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use sui_rpc::client::Client as SuiGrpcClient;
 use sui_sdk_types::Address as NewObjectID;
 use sui_types::base_types::ObjectID;
 use sui_types::crypto::get_key_pair_from_rng;
@@ -387,7 +388,8 @@ async fn test_e2e_permissioned() {
         .with_num_validators(1)
         .build()
         .await;
-    let grpc_client = cluster.grpc_client();
+    let grpc_client =
+        SuiGrpcClient::new(cluster.rpc_url()).expect("Failed to create SuiGrpcClient");
     // Publish the seal package first, then patterns
     let seal_package = SealTestCluster::publish_internal(&cluster, "seal", vec![])
         .await
@@ -522,7 +524,8 @@ async fn test_e2e_imported_key() {
         .with_num_validators(1)
         .build()
         .await;
-    let grpc_client = cluster.grpc_client();
+    let grpc_client =
+        SuiGrpcClient::new(cluster.rpc_url()).expect("Failed to create SuiGrpcClient");
     // Publish seal first, then patterns
     let seal_package = SealTestCluster::publish_internal(&cluster, "seal", vec![])
         .await
@@ -692,7 +695,8 @@ async fn test_e2e_committee_mode_with_rotation() {
         .with_num_validators(1)
         .build()
         .await;
-    let grpc_client = cluster.grpc_client();
+    let grpc_client =
+        SuiGrpcClient::new(cluster.rpc_url()).expect("Failed to create SuiGrpcClient");
 
     // Publish the seal package first, then patterns
     let seal_package = SealTestCluster::publish_internal(&cluster, "seal", vec![])

--- a/crates/key-server/src/tests/mod.rs
+++ b/crates/key-server/src/tests/mod.rs
@@ -26,9 +26,10 @@ use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use sui_move_build::BuildConfig;
-use sui_rpc::proto::sui::rpc::v2::GetServiceInfoRequest;
+use sui_rpc::client::Client as SuiGrpcClient;
 use sui_rpc_api::client::ExecutedTransaction;
 use sui_sdk::json::SuiJsonValue;
+use sui_sdk::sui_rpc::proto::sui::rpc::v2::GetServiceInfoRequest;
 use sui_sdk_types::Address;
 use sui_types::base_types::{ObjectID, SuiAddress};
 use sui_types::crypto::get_key_pair_from_rng;
@@ -197,7 +198,8 @@ impl SealTestCluster {
                     sui_rpc_client: SuiRpcClient::new(
                         #[allow(deprecated)]
                         self.cluster.sui_client().clone(),
-                        self.cluster.grpc_client().into_inner(),
+                        SuiGrpcClient::new(self.cluster.rpc_url())
+                            .expect("Failed to create SuiGrpcClient"),
                         RetryConfig::default(),
                         None,
                     ),
@@ -453,7 +455,8 @@ impl SealTestCluster {
     pub async fn get_public_keys(&self, object_ids: &[ObjectID]) -> Vec<ibe::PublicKey> {
         let mut pks = Vec::new();
         for id in object_ids {
-            let mut grpc_client = self.cluster.grpc_client().into_inner();
+            let mut grpc_client =
+                SuiGrpcClient::new(self.cluster.rpc_url()).expect("Failed to create SuiGrpcClient");
             let address = Address::new(id.into_bytes());
             let key_server_v2 = fetch_key_server_by_id(&mut grpc_client, &address)
                 .await

--- a/crates/key-server/src/tests/test_utils.rs
+++ b/crates/key-server/src/tests/test_utils.rs
@@ -17,6 +17,7 @@ use std::{
     sync::{Arc, RwLock},
     time::Duration,
 };
+use sui_rpc::client::Client as SuiGrpcClient;
 use sui_sdk::SuiClient;
 use sui_sdk_types::Address;
 use sui_types::base_types::ObjectID;
@@ -24,7 +25,7 @@ use sui_types::base_types::ObjectID;
 /// Helper function to create a test server with any ServerMode.
 pub(crate) async fn create_test_server(
     sui_client: SuiClient,
-    grpc_client: sui_rpc_api::Client,
+    grpc_client: SuiGrpcClient,
     seal_package: ObjectID,
     server_mode: ServerMode,
     onchain_version: Option<u32>,
@@ -45,12 +46,7 @@ pub(crate) async fn create_test_server(
         metrics_push_config: None,
     };
 
-    let sui_rpc_client = SuiRpcClient::new(
-        sui_client,
-        grpc_client.into_inner(),
-        RetryConfig::default(),
-        None,
-    );
+    let sui_rpc_client = SuiRpcClient::new(sui_client, grpc_client, RetryConfig::default(), None);
 
     // Use MasterKeys::load() for all modes.
     let vars_encoded = vars
@@ -73,7 +69,7 @@ pub(crate) async fn create_test_server(
 /// Helper function to create a permissioned server.
 pub(crate) async fn create_server(
     sui_client: SuiClient,
-    grpc_client: sui_rpc_api::Client,
+    grpc_client: SuiGrpcClient,
     seal_package: ObjectID,
     client_configs: Vec<ClientConfig>,
     vars: impl AsRef<[(&str, &[u8])]>,
@@ -93,7 +89,7 @@ pub(crate) async fn create_server(
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn create_committee_servers(
     sui_client: SuiClient,
-    grpc_client: sui_rpc_api::Client,
+    grpc_client: SuiGrpcClient,
     seal_package: ObjectID,
     key_server_obj_id: Address,
     member_addresses: Vec<Address>,


### PR DESCRIPTION
Summary:
- Bump sui-rpc/sui-sdk-types to the latest SDK rev with the unstable v2alpha API enabled.
- Replace JSON-RPC event polling with v2alpha LedgerService.ListEvents filtered by CommitteeRotationInitiated event type.
- Track v2alpha event watermarks for resume and update tests to use the direct latest gRPC client where needed.

Tests:
- cargo fmt --all -- --check
- cargo check -p key-server
- cargo test -p key-server
- cargo clippy -p key-server --all-targets --all-features -- -D warnings -Wclippy::all -Wclippy::disallowed_methods -Aclippy::unnecessary_get_then_check