### PR TITLE
Optimize GF(256) interpolation in decrypt

### DIFF
--- a/move/seal/sources/bf_hmac_encryption.move
+++ b/move/seal/sources/bf_hmac_encryption.move
@@ -152,7 +152,7 @@ public fun decrypt(
     );
 
     // Interpolate polynomials from the decrypted shares.
-    let polynomials = interpolate_all(&given_indices.map!(|i| indices[i]), &decrypted_shares);
+    let polynomials = interpolate_all(given_indices.map!(|i| indices[i]), &decrypted_shares);
 
     // A correctly formed ciphertext uses Shamir polynomials of degree threshold - 1. Reject
     // ciphertexts whose recovered polynomials have a higher degree.

--- a/move/seal/sources/gf256.move
+++ b/move/seal/sources/gf256.move
@@ -8,6 +8,7 @@ module seal::gf256;
 #[test_only]
 use std::unit_test::assert_eq;
 
+const ELogOfZero: u64 = 1;
 const EDivideByZero: u64 = 2;
 
 /// The size of the multiplicative group of GF(2^8).
@@ -58,14 +59,23 @@ const LOG: vector<u8> = vector[
 /// this once with `new` and reuse it: its `mul`/`div` index the (borrowed) tables held in the
 /// struct rather than re-materializing the constants on every operation.
 public struct GF256 has copy, drop {
-    exp: vector<u8>,
-    log: vector<u8>,
+    exp_table: vector<u8>,
+    log_table: vector<u8>,
 }
 
 /// Construct the GF(2^8) arithmetic tables. Materializes the EXP/LOG constants once.
 #[allow(implicit_const_copy)]
 public(package) fun new(): GF256 {
-    GF256 { exp: EXP, log: LOG }
+    GF256 { exp_table: EXP, log_table: LOG }
+}
+
+fun log(self: &GF256, x: u8): u16 {
+    assert!(x != 0, ELogOfZero);
+    self.log_table[(x - 1) as u64] as u16
+}
+
+fun exp(self: &GF256, x: u16): u8 {
+    self.exp_table[(x % MULTIPLICATIVE_GROUP_SIZE) as u64]
 }
 
 public(package) fun add(x: u8, y: u8): u8 {
@@ -80,20 +90,12 @@ public(package) fun mul(self: &GF256, x: u8, y: u8): u8 {
     if (x == 0 || y == 0) {
         return 0
     };
-    let l = (self.log[(x - 1) as u64] as u16) + (self.log[(y - 1) as u64] as u16);
-    self.exp[(l % MULTIPLICATIVE_GROUP_SIZE) as u64]
+    self.exp(self.log(x) + self.log(y))
 }
 
 public(package) fun div(self: &GF256, x: u8, y: u8): u8 {
     assert!(y != 0, EDivideByZero);
-    if (x == 0) {
-        return 0
-    };
-    // x / y = g^(log(x) - log(y)). Add the group size before subtracting to stay non-negative.
-    let l =
-        (self.log[(x - 1) as u64] as u16) + MULTIPLICATIVE_GROUP_SIZE -
-            (self.log[(y - 1) as u64] as u16);
-    self.exp[(l % MULTIPLICATIVE_GROUP_SIZE) as u64]
+    self.mul(x, self.exp(MULTIPLICATIVE_GROUP_SIZE - self.log(y)))
 }
 
 #[test]

--- a/move/seal/sources/gf256.move
+++ b/move/seal/sources/gf256.move
@@ -8,7 +8,6 @@ module seal::gf256;
 #[test_only]
 use std::unit_test::assert_eq;
 
-const ELogOfZero: u64 = 1;
 const EDivideByZero: u64 = 2;
 
 /// The size of the multiplicative group of GF(2^8).
@@ -54,15 +53,19 @@ const LOG: vector<u8> = vector[
     0x4a, 0xed, 0xde, 0xc5, 0x31, 0xfe, 0x18, 0x0d, 0x63, 0x8c, 0x80, 0xc0, 0xf7, 0x70, 0x07,
 ];
 
-#[allow(implicit_const_copy)]
-fun log(x: u8): u16 {
-    assert!(x != 0, ELogOfZero);
-    LOG[(x - 1) as u64] as u16
+/// Holds the exp and log tables for GF(2^8) arithmetic. Indexing a `const vector` materializes the
+/// entire constant on every access, so callers performing many field operations should construct
+/// this once with `new` and reuse it: its `mul`/`div` index the (borrowed) tables held in the
+/// struct rather than re-materializing the constants on every operation.
+public struct GF256 has copy, drop {
+    exp: vector<u8>,
+    log: vector<u8>,
 }
 
+/// Construct the GF(2^8) arithmetic tables. Materializes the EXP/LOG constants once.
 #[allow(implicit_const_copy)]
-fun exp(x: u16): u8 {
-    EXP[(x % MULTIPLICATIVE_GROUP_SIZE) as u64]
+public(package) fun new(): GF256 {
+    GF256 { exp: EXP, log: LOG }
 }
 
 public(package) fun add(x: u8, y: u8): u8 {
@@ -73,72 +76,50 @@ public(package) fun sub(x: u8, y: u8): u8 {
     add(x, y)
 }
 
-public(package) fun mul(x: u8, y: u8): u8 {
+public(package) fun mul(self: &GF256, x: u8, y: u8): u8 {
     if (x == 0 || y == 0) {
         return 0
     };
-    exp(log(x) + log(y))
+    let l = (self.log[(x - 1) as u64] as u16) + (self.log[(y - 1) as u64] as u16);
+    self.exp[(l % MULTIPLICATIVE_GROUP_SIZE) as u64]
 }
 
-public(package) fun div(x: u8, y: u8): u8 {
-    assert!(y != 0, EDivideByZero);
-    mul(x, exp(MULTIPLICATIVE_GROUP_SIZE - log(y)))
-}
-
-/// Return copies of the exp and log tables. Indexing a `const vector` materializes the entire
-/// constant on every access, so callers performing many field operations should fetch the tables
-/// once with this function and use the `*_t` operations below, which index the (borrowed) tables
-/// instead of re-materializing the constants.
-#[allow(implicit_const_copy)]
-public(package) fun tables(): (vector<u8>, vector<u8>) {
-    (EXP, LOG)
-}
-
-/// Multiply using preloaded tables. `exp` and `log` must be the vectors returned by `tables()`.
-public(package) fun mul_t(exp: &vector<u8>, log: &vector<u8>, x: u8, y: u8): u8 {
-    if (x == 0 || y == 0) {
-        return 0
-    };
-    let l = (log[(x - 1) as u64] as u16) + (log[(y - 1) as u64] as u16);
-    exp[(l % MULTIPLICATIVE_GROUP_SIZE) as u64]
-}
-
-/// Divide using preloaded tables. `exp` and `log` must be the vectors returned by `tables()`.
-public(package) fun div_t(exp: &vector<u8>, log: &vector<u8>, x: u8, y: u8): u8 {
+public(package) fun div(self: &GF256, x: u8, y: u8): u8 {
     assert!(y != 0, EDivideByZero);
     if (x == 0) {
         return 0
     };
     // x / y = g^(log(x) - log(y)). Add the group size before subtracting to stay non-negative.
     let l =
-        (log[(x - 1) as u64] as u16) + MULTIPLICATIVE_GROUP_SIZE - (log[(y - 1) as u64] as u16);
-    exp[(l % MULTIPLICATIVE_GROUP_SIZE) as u64]
+        (self.log[(x - 1) as u64] as u16) + MULTIPLICATIVE_GROUP_SIZE -
+            (self.log[(y - 1) as u64] as u16);
+    self.exp[(l % MULTIPLICATIVE_GROUP_SIZE) as u64]
 }
 
 #[test]
 fun test_field_ops() {
     // Test vector, partly from https://en.wikipedia.org/wiki/Finite_field_arithmetic#Rijndael's_(AES)_finite_field
+    let g = new();
     let a = 0x53;
     let b = 0xca;
     assert_eq!(add(a, b), 0x99);
     assert_eq!(sub(a, b), 0x99);
-    assert_eq!(mul(a, b), 0x01);
-    assert_eq!(div(a, b), 0xb5);
+    assert_eq!(g.mul(a, b), 0x01);
+    assert_eq!(g.div(a, b), 0xb5);
 }
 
 #[test]
-fun test_table_ops_match() {
-    // The table-based operations must agree with the constant-based ones. Sweep x over the whole
-    // field against a set of y values that includes the edge cases (0, 1) and a spread of others;
-    // a full 256x256 sweep exceeds the unit-test gas budget.
-    let (exp, log) = tables();
-    let ys = vector[0u8, 1, 2, 3, 0x53, 0xca, 0xfe, 0xff];
+fun test_field_axioms() {
+    // Self-consistency over the whole field: division inverts multiplication, and every nonzero
+    // element has a multiplicative inverse.
+    let g = new();
+    let ys = vector[1u8, 2, 3, 0x53, 0xca, 0xfe, 0xff];
     256u64.do!(|xi| {
         let x = xi as u8;
         ys.do!(|y| {
-            assert_eq!(mul_t(&exp, &log, x, y), mul(x, y));
-            if (y != 0) {
-                assert_eq!(div_t(&exp, &log, x, y), div(x, y));
+            assert_eq!(g.div(g.mul(x, y), y), x);
+            if (x != 0) {
+                assert_eq!(g.mul(x, g.div(1, x)), 1);
             };
         });
     });

--- a/move/seal/sources/gf256.move
+++ b/move/seal/sources/gf256.move
@@ -93,7 +93,11 @@ public(package) fun mul(self: &GF256, x: u8, y: u8): u8 {
 
 public(package) fun div(self: &GF256, x: u8, y: u8): u8 {
     assert!(y != 0, EDivideByZero);
-    self.mul(x, self.exp(MULTIPLICATIVE_GROUP_SIZE - self.log(y)))
+    if (x == 0) {
+        return 0
+    };
+    // x / y = g^(log(x) - log(y)). Add the group size before subtracting to stay non-negative.
+    self.exp(self.log(x) + MULTIPLICATIVE_GROUP_SIZE - self.log(y))
 }
 
 #[test]

--- a/move/seal/sources/gf256.move
+++ b/move/seal/sources/gf256.move
@@ -85,6 +85,36 @@ public(package) fun div(x: u8, y: u8): u8 {
     mul(x, exp(MULTIPLICATIVE_GROUP_SIZE - log(y)))
 }
 
+/// Return copies of the exp and log tables. Indexing a `const vector` materializes the entire
+/// constant on every access, so callers performing many field operations should fetch the tables
+/// once with this function and use the `*_t` operations below, which index the (borrowed) tables
+/// instead of re-materializing the constants.
+#[allow(implicit_const_copy)]
+public(package) fun tables(): (vector<u8>, vector<u8>) {
+    (EXP, LOG)
+}
+
+/// Multiply using preloaded tables. `exp` and `log` must be the vectors returned by `tables()`.
+public(package) fun mul_t(exp: &vector<u8>, log: &vector<u8>, x: u8, y: u8): u8 {
+    if (x == 0 || y == 0) {
+        return 0
+    };
+    let l = (log[(x - 1) as u64] as u16) + (log[(y - 1) as u64] as u16);
+    exp[(l % MULTIPLICATIVE_GROUP_SIZE) as u64]
+}
+
+/// Divide using preloaded tables. `exp` and `log` must be the vectors returned by `tables()`.
+public(package) fun div_t(exp: &vector<u8>, log: &vector<u8>, x: u8, y: u8): u8 {
+    assert!(y != 0, EDivideByZero);
+    if (x == 0) {
+        return 0
+    };
+    // x / y = g^(log(x) - log(y)). Add the group size before subtracting to stay non-negative.
+    let l =
+        (log[(x - 1) as u64] as u16) + MULTIPLICATIVE_GROUP_SIZE - (log[(y - 1) as u64] as u16);
+    exp[(l % MULTIPLICATIVE_GROUP_SIZE) as u64]
+}
+
 #[test]
 fun test_field_ops() {
     // Test vector, partly from https://en.wikipedia.org/wiki/Finite_field_arithmetic#Rijndael's_(AES)_finite_field
@@ -94,4 +124,22 @@ fun test_field_ops() {
     assert_eq!(sub(a, b), 0x99);
     assert_eq!(mul(a, b), 0x01);
     assert_eq!(div(a, b), 0xb5);
+}
+
+#[test]
+fun test_table_ops_match() {
+    // The table-based operations must agree with the constant-based ones. Sweep x over the whole
+    // field against a set of y values that includes the edge cases (0, 1) and a spread of others;
+    // a full 256x256 sweep exceeds the unit-test gas budget.
+    let (exp, log) = tables();
+    let ys = vector[0u8, 1, 2, 3, 0x53, 0xca, 0xfe, 0xff];
+    256u64.do!(|xi| {
+        let x = xi as u8;
+        ys.do!(|y| {
+            assert_eq!(mul_t(&exp, &log, x, y), mul(x, y));
+            if (y != 0) {
+                assert_eq!(div_t(&exp, &log, x, y), div(x, y));
+            };
+        });
+    });
 }

--- a/move/seal/sources/gf256.move
+++ b/move/seal/sources/gf256.move
@@ -56,7 +56,7 @@ const LOG: vector<u8> = vector[
 
 /// The Galois field GF(2^8). Constructing an instance (with `new`) has a cost, so reuse a single
 /// one across many field operations rather than creating one per call.
-public struct GF256 has copy, drop {
+public struct GF256 has drop {
     exp_table: vector<u8>,
     log_table: vector<u8>,
 }
@@ -96,7 +96,6 @@ public(package) fun div(self: &GF256, x: u8, y: u8): u8 {
     if (x == 0) {
         return 0
     };
-    // x / y = g^(log(x) - log(y)). Add the group size before subtracting to stay non-negative.
     self.exp(self.log(x) + MULTIPLICATIVE_GROUP_SIZE - self.log(y))
 }
 

--- a/move/seal/sources/gf256.move
+++ b/move/seal/sources/gf256.move
@@ -54,10 +54,8 @@ const LOG: vector<u8> = vector[
     0x4a, 0xed, 0xde, 0xc5, 0x31, 0xfe, 0x18, 0x0d, 0x63, 0x8c, 0x80, 0xc0, 0xf7, 0x70, 0x07,
 ];
 
-/// Holds the exp and log tables for GF(2^8) arithmetic. Indexing a `const vector` materializes the
-/// entire constant on every access, so callers performing many field operations should construct
-/// this once with `new` and reuse it: its `mul`/`div` index the (borrowed) tables held in the
-/// struct rather than re-materializing the constants on every operation.
+/// The Galois field GF(2^8). Constructing an instance (with `new`) has a cost, so reuse a single
+/// one across many field operations rather than creating one per call.
 public struct GF256 has copy, drop {
     exp_table: vector<u8>,
     log_table: vector<u8>,

--- a/move/seal/sources/gf256.move
+++ b/move/seal/sources/gf256.move
@@ -61,7 +61,7 @@ public struct GF256 has copy, drop {
     log_table: vector<u8>,
 }
 
-/// Construct the GF(2^8) arithmetic tables. Materializes the EXP/LOG constants once.
+/// Construct an instance of the field.
 #[allow(implicit_const_copy)]
 public(package) fun new(): GF256 {
     GF256 { exp_table: EXP, log_table: LOG }
@@ -106,21 +106,4 @@ fun test_field_ops() {
     assert_eq!(sub(a, b), 0x99);
     assert_eq!(g.mul(a, b), 0x01);
     assert_eq!(g.div(a, b), 0xb5);
-}
-
-#[test]
-fun test_field_axioms() {
-    // Self-consistency over the whole field: division inverts multiplication, and every nonzero
-    // element has a multiplicative inverse.
-    let g = new();
-    let ys = vector[1u8, 2, 3, 0x53, 0xca, 0xfe, 0xff];
-    256u64.do!(|xi| {
-        let x = xi as u8;
-        ys.do!(|y| {
-            assert_eq!(g.div(g.mul(x, y), y), x);
-            if (x != 0) {
-                assert_eq!(g.mul(x, g.div(1, x)), 1);
-            };
-        });
-    });
 }

--- a/move/seal/sources/polynomial.move
+++ b/move/seal/sources/polynomial.move
@@ -93,7 +93,7 @@ fun interpolate_with_numerators(
 fun compute_numerators(g: &GF256, x: vector<u8>): vector<Polynomial> {
     // The full numerator depends only on x, so we can compute it here
     let full_numerator = x.fold!(Polynomial { coefficients: vector[1] }, |product, x_j| {
-        mul_g(g, &product, &monic_linear(&x_j))
+        mul(g, &product, &monic_linear(&x_j))
     });
     x.map_ref!(|x_j| div_by_monic_linear(g, &full_numerator, *x_j))
 }
@@ -137,7 +137,7 @@ fun add(x: &Polynomial, y: &Polynomial): Polynomial {
     Polynomial { coefficients }
 }
 
-fun mul_g(g: &GF256, x: &Polynomial, y: &Polynomial): Polynomial {
+fun mul(g: &GF256, x: &Polynomial, y: &Polynomial): Polynomial {
     if (x.coefficients.is_empty() || y.coefficients.is_empty()) {
         return Polynomial { coefficients: vector[] }
     };
@@ -165,21 +165,15 @@ fun monic_linear(c: &u8): Polynomial {
     Polynomial { coefficients: vector[*c, 1] }
 }
 
-#[test_only]
-fun mul(x: &Polynomial, y: &Polynomial): Polynomial {
-    // A non-`_g` wrapper so the unit tests can use method-call syntax (`a.mul(&b)`) without
-    // threading a GF256 through. `mul_g` keeps its suffix to disambiguate from this.
-    mul_g(&gf256::new(), x, y)
-}
-
 #[test]
 fun test_arithmetic() {
+    let g = gf256::new();
     let x = Polynomial { coefficients: vector[1, 2, 3] };
     let y = Polynomial { coefficients: vector[4, 5] };
     let z = Polynomial { coefficients: vector[2] };
     assert_eq!(x.add(&y).coefficients, vector[5, 7, 3]);
-    assert_eq!(x.mul(&z).coefficients, vector[2, 4, 6]);
-    assert_eq!(x.mul(&y).coefficients, x"040d060f");
+    assert_eq!(mul(&g, &x, &z).coefficients, vector[2, 4, 6]);
+    assert_eq!(mul(&g, &x, &y).coefficients, x"040d060f");
 }
 
 #[test]
@@ -233,9 +227,10 @@ fun test_interpolate_all() {
 
 #[test]
 fun test_div_exact_by_monic_linear() {
+    let g = gf256::new();
     let x = Polynomial { coefficients: vector[1, 2, 3, 4, 5, 6, 7] };
     let monic_linear = monic_linear(&2);
-    let y = mul(&x, &monic_linear);
-    let z = div_by_monic_linear(&gf256::new(), &y, 2);
+    let y = mul(&g, &x, &monic_linear);
+    let z = div_by_monic_linear(&g, &y, 2);
     assert_eq!(z, x);
 }

--- a/move/seal/sources/polynomial.move
+++ b/move/seal/sources/polynomial.move
@@ -105,7 +105,7 @@ fun compute_numerators(g: &GF256, x: vector<u8>): vector<Polynomial> {
 /// The length of the input vectors must be the same.
 /// The length of each vector in y must be the same (equal to the l above).
 /// Aborts if the input lengths are not compatible or if the vectors are empty.
-public(package) fun interpolate_all(x: &vector<u8>, y: &vector<vector<u8>>): vector<Polynomial> {
+public(package) fun interpolate_all(x: vector<u8>, y: &vector<vector<u8>>): vector<Polynomial> {
     assert!(x.length() == y.length(), EIncompatibleInputLengths);
     let l = y[0].length();
     assert!(y.all!(|yi| yi.length() == l), EIncompatibleInputLengths);
@@ -113,12 +113,12 @@ public(package) fun interpolate_all(x: &vector<u8>, y: &vector<vector<u8>>): vec
     // Construct the field tables once
     let g = gf256::new();
 
-    let numerators = compute_numerators(&g, *x);
-    let weights = compute_weights(&g, x);
+    let weights = compute_weights(&g, &x);
+    let numerators = compute_numerators(&g, x);
 
     vector::tabulate!(l, |i| {
         let yi = y.map_ref!(|yj| yj[i]);
-        interpolate_with_numerators(&g, x, &yi, &numerators, &weights)
+        interpolate_with_numerators(&g, &x, &yi, &numerators, &weights)
     })
 }
 
@@ -220,7 +220,7 @@ fun test_interpolate() {
 fun test_interpolate_all() {
     let x = vector[1, 2, 3];
     let y = vector[vector[7, 8], vector[11, 12], vector[17, 18]];
-    let ps = interpolate_all(&x, &y);
+    let ps = interpolate_all(x, &y);
     assert_eq!(ps.length(), 2);
     x.zip_do!(y, |x, y| {
         assert_eq!(ps[0].evaluate(x), y[0]);

--- a/move/seal/sources/polynomial.move
+++ b/move/seal/sources/polynomial.move
@@ -65,12 +65,11 @@ fun div_by_monic_linear(g: &GF256, x: &Polynomial, c: u8): Polynomial {
 /// Compute the barycentric weights w_j = 1 / prod_{i != j} (x[j] - x[i]).
 /// These depend only on the x values, so the Lagrange interpolation can reuse them across all
 /// output polynomials.
-fun compute_weights(g: &GF256, x: &vector<u8>): vector<u8> {
+fun compute_weights(g: &GF256, x: vector<u8>): vector<u8> {
     // The interpolation nodes are distinct, so x[i] == x[j] iff i == j.
     x.map_ref!(|xj| {
         let xj = *xj;
-        let denominator = (*x).fold!(1u8, |acc, xi| if (xi == xj) acc else g.mul(acc, gf256::sub(xj, xi)));
-        g.div(1, denominator)
+        g.div(1, x.fold!(1u8, |acc, xi| if (xi == xj) acc else g.mul(acc, gf256::sub(xj, xi))))
     })
 }
 
@@ -113,7 +112,7 @@ public(package) fun interpolate_all(x: vector<u8>, y: &vector<vector<u8>>): vect
     // Construct the field tables once
     let g = gf256::new();
 
-    let weights = compute_weights(&g, &x);
+    let weights = compute_weights(&g, x);
     let numerators = compute_numerators(&g, x);
 
     vector::tabulate!(l, |i| {
@@ -211,7 +210,7 @@ fun test_interpolate() {
     let x = vector[1, 2, 3];
     let y = vector[7, 11, 17];
     let g = gf256::new();
-    let p = interpolate_with_numerators(&g, &x, &y, &compute_numerators(&g, x), &compute_weights(&g, &x));
+    let p = interpolate_with_numerators(&g, &x, &y, &compute_numerators(&g, x), &compute_weights(&g, x));
     assert_eq!(p.coefficients, x"1d150f");
     x.zip_do!(y, |x, y| assert!(p.evaluate(x) == y));
 }

--- a/move/seal/sources/polynomial.move
+++ b/move/seal/sources/polynomial.move
@@ -19,10 +19,10 @@ public struct Polynomial has copy, drop, store {
 
 /// Evaluate a polynomial at a given point.
 public fun evaluate(p: &Polynomial, x: u8): u8 {
-    evaluate_g(&gf256::new(), p, x)
+    evaluate_with_g(&gf256::new(), p, x)
 }
 
-fun evaluate_g(g: &GF256, p: &Polynomial, x: u8): u8 {
+fun evaluate_with_g(g: &GF256, p: &Polynomial, x: u8): u8 {
     if (p.coefficients.is_empty()) {
         return 0
     };
@@ -66,14 +66,10 @@ fun div_by_monic_linear(g: &GF256, x: &Polynomial, c: u8): Polynomial {
 /// These depend only on the x values, so the Lagrange interpolation can reuse them across all
 /// output polynomials.
 fun compute_weights(g: &GF256, x: &vector<u8>): vector<u8> {
-    let n = x.length();
-    vector::tabulate!(n, |j| {
-        let mut denominator = 1;
-        n.do!(|i| {
-            if (i != j) {
-                denominator = g.mul(denominator, gf256::sub(x[j], x[i]));
-            };
-        });
+    // The interpolation nodes are distinct, so x[i] == x[j] iff i == j.
+    vector::tabulate!(x.length(), |j| {
+        let xj = x[j];
+        let denominator = (*x).fold!(1u8, |acc, xi| if (xi == xj) acc else g.mul(acc, gf256::sub(xj, xi)));
         g.div(1, denominator)
     })
 }

--- a/move/seal/sources/polynomial.move
+++ b/move/seal/sources/polynomial.move
@@ -19,13 +19,18 @@ public struct Polynomial has copy, drop, store {
 
 /// Evaluate a polynomial at a given point.
 public fun evaluate(p: &Polynomial, x: u8): u8 {
+    let (exp, log) = gf256::tables();
+    evaluate_t(&exp, &log, p, x)
+}
+
+fun evaluate_t(exp: &vector<u8>, log: &vector<u8>, p: &Polynomial, x: u8): u8 {
     if (p.coefficients.is_empty()) {
         return 0
     };
     let n = p.coefficients.length();
     let mut result = p.coefficients[n - 1];
     (n - 1).do!(|i| {
-        result = gf256::add(gf256::mul(result, x), p.coefficients[n - i - 2]);
+        result = gf256::add(gf256::mul_t(exp, log, result, x), p.coefficients[n - i - 2]);
     });
     result
 }
@@ -43,14 +48,14 @@ public(package) fun degree(p: &Polynomial): u64 {
 }
 
 // Divide a polynomial by the monic linear polynomial x + c.
-fun div_by_monic_linear(x: &Polynomial, c: u8): Polynomial {
+fun div_by_monic_linear_t(exp: &vector<u8>, log: &vector<u8>, x: &Polynomial, c: u8): Polynomial {
     let n = x.coefficients.length();
     let mut coefficients = vector[];
     if (n > 1) {
         let mut previous = x.coefficients[n - 1];
         coefficients.push_back(previous);
         range_do_eq!(1, n - 2, |i| {
-            previous = gf256::sub(x.coefficients[n - i - 1], gf256::mul(previous, c));
+            previous = gf256::sub(x.coefficients[n - i - 1], gf256::mul_t(exp, log, previous, c));
             coefficients.push_back(previous);
         });
         coefficients.reverse();
@@ -58,40 +63,52 @@ fun div_by_monic_linear(x: &Polynomial, c: u8): Polynomial {
     Polynomial { coefficients }
 }
 
-/// Same as interpolate, but the numerator product, \prod_i (x - x_i), is precomputed.
-fun interpolate_with_numerators(
+/// Compute the barycentric weights w_j = 1 / prod_{i != j} (x[j] - x[i]).
+/// These depend only on the x values, so the Lagrange interpolation can reuse them across all
+/// output polynomials.
+fun compute_weights(exp: &vector<u8>, log: &vector<u8>, x: &vector<u8>): vector<u8> {
+    let n = x.length();
+    vector::tabulate!(n, |j| {
+        let mut denominator = 1;
+        n.do!(|i| {
+            if (i != j) {
+                denominator = gf256::mul_t(exp, log, denominator, gf256::sub(x[j], x[i]));
+            };
+        });
+        gf256::div_t(exp, log, 1, denominator)
+    })
+}
+
+/// Same as interpolate, but the numerator products, \prod_i (x - x_i), and the barycentric weights,
+/// 1 / \prod_{i != j} (x[j] - x[i]), are precomputed (both depend only on x).
+fun interpolate_with_numerators_t(
+    exp: &vector<u8>,
+    log: &vector<u8>,
     x: &vector<u8>,
     y: &vector<u8>,
     numerators: &vector<Polynomial>,
+    weights: &vector<u8>,
 ): Polynomial {
     assert!(x.length() == y.length(), EIncompatibleInputLengths);
     let n = x.length();
     let mut sum = Polynomial { coefficients: vector[] };
     n.do!(|j| {
-        let mut denominator = 1;
-        n.do!(|i| {
-            if (i != j) {
-                denominator = gf256::mul(denominator, gf256::sub(x[j], x[i]));
-            };
-        });
         sum =
             add(
                 &sum,
-                &numerators[j].scale(
-                    gf256::div(y[j], denominator),
-                ),
+                &scale_t(exp, log, &numerators[j], gf256::mul_t(exp, log, y[j], weights[j])),
             );
     });
     sum
 }
 
 /// Compute the numerators of the Lagrange polynomials for the given x values.
-fun compute_numerators(x: vector<u8>): vector<Polynomial> {
+fun compute_numerators_t(exp: &vector<u8>, log: &vector<u8>, x: vector<u8>): vector<Polynomial> {
     // The full numerator depends only on x, so we can compute it here
     let full_numerator = x.fold!(Polynomial { coefficients: vector[1] }, |product, x_j| {
-        product.mul(&monic_linear(&x_j))
+        mul_t(exp, log, &product, &monic_linear(&x_j))
     });
-    x.map_ref!(|x_j| div_by_monic_linear(&full_numerator, *x_j))
+    x.map_ref!(|x_j| div_by_monic_linear_t(exp, log, &full_numerator, *x_j))
 }
 
 /// Interpolate l polynomials p_1, ..., p_l such that p_i(x_j) = y[j][i] for all i, j.
@@ -103,11 +120,17 @@ public(package) fun interpolate_all(x: &vector<u8>, y: &vector<vector<u8>>): vec
     let l = y[0].length();
     assert!(y.all!(|yi| yi.length() == l), EIncompatibleInputLengths);
 
-    // The numerators depend only on x, so we can compute them here
-    let numerators = compute_numerators(*x);
+    // Load the field tables once instead of materializing the constants on every field operation.
+    let (exp, log) = gf256::tables();
+
+    // The numerators and the barycentric weights depend only on x, so compute them once and reuse
+    // them for every one of the l output polynomials.
+    let numerators = compute_numerators_t(&exp, &log, *x);
+    let weights = compute_weights(&exp, &log, x);
+
     vector::tabulate!(l, |i| {
         let yi = y.map_ref!(|yj| yj[i]);
-        interpolate_with_numerators(x, &yi, &numerators)
+        interpolate_with_numerators_t(&exp, &log, x, &yi, &numerators, &weights)
     })
 }
 
@@ -129,7 +152,7 @@ fun add(x: &Polynomial, y: &Polynomial): Polynomial {
     Polynomial { coefficients }
 }
 
-fun mul(x: &Polynomial, y: &Polynomial): Polynomial {
+fun mul_t(exp: &vector<u8>, log: &vector<u8>, x: &Polynomial, y: &Polynomial): Polynomial {
     if (x.coefficients.is_empty() || y.coefficients.is_empty()) {
         return Polynomial { coefficients: vector[] }
     };
@@ -139,7 +162,11 @@ fun mul(x: &Polynomial, y: &Polynomial): Polynomial {
             let mut sum = 0;
             i.do_eq!(|j| {
                 if (j < x.coefficients.length() && i - j < y.coefficients.length()) {
-                    sum = gf256::add(sum, gf256::mul(x.coefficients[j], y.coefficients[i - j]));
+                    sum =
+                        gf256::add(
+                            sum,
+                            gf256::mul_t(exp, log, x.coefficients[j], y.coefficients[i - j]),
+                        );
                 }
             });
             sum
@@ -148,13 +175,46 @@ fun mul(x: &Polynomial, y: &Polynomial): Polynomial {
     Polynomial { coefficients }
 }
 
-fun scale(x: &Polynomial, s: u8): Polynomial {
-    Polynomial { coefficients: x.coefficients.map_ref!(|c| gf256::mul(*c, s)) }
+fun scale_t(exp: &vector<u8>, log: &vector<u8>, x: &Polynomial, s: u8): Polynomial {
+    Polynomial { coefficients: x.coefficients.map_ref!(|c| gf256::mul_t(exp, log, *c, s)) }
 }
 
 /// Return x - c (same as x + c since GF256 is a binary field)
 fun monic_linear(c: &u8): Polynomial {
     Polynomial { coefficients: vector[*c, 1] }
+}
+
+// === Test-only wrappers ===
+// These keep the original (constant-copying) call shapes available for the unit tests below, which
+// exercise the arithmetic at small sizes where the table-copy cost is irrelevant.
+
+#[test_only]
+fun mul(x: &Polynomial, y: &Polynomial): Polynomial {
+    let (exp, log) = gf256::tables();
+    mul_t(&exp, &log, x, y)
+}
+
+#[test_only]
+fun div_by_monic_linear(x: &Polynomial, c: u8): Polynomial {
+    let (exp, log) = gf256::tables();
+    div_by_monic_linear_t(&exp, &log, x, c)
+}
+
+#[test_only]
+fun compute_numerators(x: vector<u8>): vector<Polynomial> {
+    let (exp, log) = gf256::tables();
+    compute_numerators_t(&exp, &log, x)
+}
+
+#[test_only]
+fun interpolate_with_numerators(
+    x: &vector<u8>,
+    y: &vector<u8>,
+    numerators: &vector<Polynomial>,
+): Polynomial {
+    let (exp, log) = gf256::tables();
+    let weights = compute_weights(&exp, &log, x);
+    interpolate_with_numerators_t(&exp, &log, x, y, numerators, &weights)
 }
 
 #[test]

--- a/move/seal/sources/polynomial.move
+++ b/move/seal/sources/polynomial.move
@@ -65,9 +65,7 @@ fun div_by_monic_linear(g: &GF256, x: &Polynomial, c: u8): Polynomial {
 /// Compute the barycentric weights w_j = 1 / prod_{i != j} (x[j] - x[i]).
 fun compute_weights(g: &GF256, x: vector<u8>): vector<u8> {
     // The interpolation nodes are distinct, so x[i] == x[j] iff i == j.
-    x.map!(|xj| {
-        x.fold!(1u8, |acc, xi| if (xi == xj) acc else g.div(acc, gf256::sub(xj, xi)))
-    })
+    x.map!(|xj| x.fold!(1u8, |acc, xi| if (xi == xj) acc else g.div(acc, gf256::sub(xj, xi))))
 }
 
 /// Same as interpolate, but the numerator products, \prod_i (x - x_i), and the barycentric weights,
@@ -80,10 +78,10 @@ fun interpolate_with_numerators(
     weights: &vector<u8>,
 ): Polynomial {
     let n = x.length();
-    assert!(y.length() == n, EIncompatibleInputLengths);
-    assert!(numerators.length() == n, EIncompatibleInputLengths);
-    assert!(weights.length() == n, EIncompatibleInputLengths);
-   
+    assert!(
+        y.length() == n && numerators.length() == n && weights.length() == n,
+        EIncompatibleInputLengths,
+    );
     let mut sum = Polynomial { coefficients: vector[] };
     n.do!(|j| {
         sum = add(&sum, &scale(g, &numerators[j], g.mul(y[j], weights[j])));

--- a/move/seal/sources/polynomial.move
+++ b/move/seal/sources/polynomial.move
@@ -67,8 +67,8 @@ fun div_by_monic_linear(g: &GF256, x: &Polynomial, c: u8): Polynomial {
 /// output polynomials.
 fun compute_weights(g: &GF256, x: &vector<u8>): vector<u8> {
     // The interpolation nodes are distinct, so x[i] == x[j] iff i == j.
-    vector::tabulate!(x.length(), |j| {
-        let xj = x[j];
+    x.map_ref!(|xj| {
+        let xj = *xj;
         let denominator = (*x).fold!(1u8, |acc, xi| if (xi == xj) acc else g.mul(acc, gf256::sub(xj, xi)));
         g.div(1, denominator)
     })

--- a/move/seal/sources/polynomial.move
+++ b/move/seal/sources/polynomial.move
@@ -3,7 +3,7 @@
 
 module seal::polynomial;
 
-use seal::gf256;
+use seal::gf256::{Self, GF256};
 use std::u64::range_do_eq;
 
 #[test_only]
@@ -19,18 +19,17 @@ public struct Polynomial has copy, drop, store {
 
 /// Evaluate a polynomial at a given point.
 public fun evaluate(p: &Polynomial, x: u8): u8 {
-    let (exp, log) = gf256::tables();
-    evaluate_t(&exp, &log, p, x)
+    evaluate_g(&gf256::new(), p, x)
 }
 
-fun evaluate_t(exp: &vector<u8>, log: &vector<u8>, p: &Polynomial, x: u8): u8 {
+fun evaluate_g(g: &GF256, p: &Polynomial, x: u8): u8 {
     if (p.coefficients.is_empty()) {
         return 0
     };
     let n = p.coefficients.length();
     let mut result = p.coefficients[n - 1];
     (n - 1).do!(|i| {
-        result = gf256::add(gf256::mul_t(exp, log, result, x), p.coefficients[n - i - 2]);
+        result = gf256::add(g.mul(result, x), p.coefficients[n - i - 2]);
     });
     result
 }
@@ -48,14 +47,14 @@ public(package) fun degree(p: &Polynomial): u64 {
 }
 
 // Divide a polynomial by the monic linear polynomial x + c.
-fun div_by_monic_linear_t(exp: &vector<u8>, log: &vector<u8>, x: &Polynomial, c: u8): Polynomial {
+fun div_by_monic_linear_g(g: &GF256, x: &Polynomial, c: u8): Polynomial {
     let n = x.coefficients.length();
     let mut coefficients = vector[];
     if (n > 1) {
         let mut previous = x.coefficients[n - 1];
         coefficients.push_back(previous);
         range_do_eq!(1, n - 2, |i| {
-            previous = gf256::sub(x.coefficients[n - i - 1], gf256::mul_t(exp, log, previous, c));
+            previous = gf256::sub(x.coefficients[n - i - 1], g.mul(previous, c));
             coefficients.push_back(previous);
         });
         coefficients.reverse();
@@ -66,24 +65,23 @@ fun div_by_monic_linear_t(exp: &vector<u8>, log: &vector<u8>, x: &Polynomial, c:
 /// Compute the barycentric weights w_j = 1 / prod_{i != j} (x[j] - x[i]).
 /// These depend only on the x values, so the Lagrange interpolation can reuse them across all
 /// output polynomials.
-fun compute_weights(exp: &vector<u8>, log: &vector<u8>, x: &vector<u8>): vector<u8> {
+fun compute_weights(g: &GF256, x: &vector<u8>): vector<u8> {
     let n = x.length();
     vector::tabulate!(n, |j| {
         let mut denominator = 1;
         n.do!(|i| {
             if (i != j) {
-                denominator = gf256::mul_t(exp, log, denominator, gf256::sub(x[j], x[i]));
+                denominator = g.mul(denominator, gf256::sub(x[j], x[i]));
             };
         });
-        gf256::div_t(exp, log, 1, denominator)
+        g.div(1, denominator)
     })
 }
 
 /// Same as interpolate, but the numerator products, \prod_i (x - x_i), and the barycentric weights,
 /// 1 / \prod_{i != j} (x[j] - x[i]), are precomputed (both depend only on x).
-fun interpolate_with_numerators_t(
-    exp: &vector<u8>,
-    log: &vector<u8>,
+fun interpolate_with_numerators_g(
+    g: &GF256,
     x: &vector<u8>,
     y: &vector<u8>,
     numerators: &vector<Polynomial>,
@@ -93,22 +91,18 @@ fun interpolate_with_numerators_t(
     let n = x.length();
     let mut sum = Polynomial { coefficients: vector[] };
     n.do!(|j| {
-        sum =
-            add(
-                &sum,
-                &scale_t(exp, log, &numerators[j], gf256::mul_t(exp, log, y[j], weights[j])),
-            );
+        sum = add(&sum, &scale_g(g, &numerators[j], g.mul(y[j], weights[j])));
     });
     sum
 }
 
 /// Compute the numerators of the Lagrange polynomials for the given x values.
-fun compute_numerators_t(exp: &vector<u8>, log: &vector<u8>, x: vector<u8>): vector<Polynomial> {
+fun compute_numerators_g(g: &GF256, x: vector<u8>): vector<Polynomial> {
     // The full numerator depends only on x, so we can compute it here
     let full_numerator = x.fold!(Polynomial { coefficients: vector[1] }, |product, x_j| {
-        mul_t(exp, log, &product, &monic_linear(&x_j))
+        mul_g(g, &product, &monic_linear(&x_j))
     });
-    x.map_ref!(|x_j| div_by_monic_linear_t(exp, log, &full_numerator, *x_j))
+    x.map_ref!(|x_j| div_by_monic_linear_g(g, &full_numerator, *x_j))
 }
 
 /// Interpolate l polynomials p_1, ..., p_l such that p_i(x_j) = y[j][i] for all i, j.
@@ -120,17 +114,17 @@ public(package) fun interpolate_all(x: &vector<u8>, y: &vector<vector<u8>>): vec
     let l = y[0].length();
     assert!(y.all!(|yi| yi.length() == l), EIncompatibleInputLengths);
 
-    // Load the field tables once instead of materializing the constants on every field operation.
-    let (exp, log) = gf256::tables();
+    // Construct the field tables once instead of materializing the constants on every operation.
+    let g = gf256::new();
 
     // The numerators and the barycentric weights depend only on x, so compute them once and reuse
     // them for every one of the l output polynomials.
-    let numerators = compute_numerators_t(&exp, &log, *x);
-    let weights = compute_weights(&exp, &log, x);
+    let numerators = compute_numerators_g(&g, *x);
+    let weights = compute_weights(&g, x);
 
     vector::tabulate!(l, |i| {
         let yi = y.map_ref!(|yj| yj[i]);
-        interpolate_with_numerators_t(&exp, &log, x, &yi, &numerators, &weights)
+        interpolate_with_numerators_g(&g, x, &yi, &numerators, &weights)
     })
 }
 
@@ -152,7 +146,7 @@ fun add(x: &Polynomial, y: &Polynomial): Polynomial {
     Polynomial { coefficients }
 }
 
-fun mul_t(exp: &vector<u8>, log: &vector<u8>, x: &Polynomial, y: &Polynomial): Polynomial {
+fun mul_g(g: &GF256, x: &Polynomial, y: &Polynomial): Polynomial {
     if (x.coefficients.is_empty() || y.coefficients.is_empty()) {
         return Polynomial { coefficients: vector[] }
     };
@@ -162,11 +156,7 @@ fun mul_t(exp: &vector<u8>, log: &vector<u8>, x: &Polynomial, y: &Polynomial): P
             let mut sum = 0;
             i.do_eq!(|j| {
                 if (j < x.coefficients.length() && i - j < y.coefficients.length()) {
-                    sum =
-                        gf256::add(
-                            sum,
-                            gf256::mul_t(exp, log, x.coefficients[j], y.coefficients[i - j]),
-                        );
+                    sum = gf256::add(sum, g.mul(x.coefficients[j], y.coefficients[i - j]));
                 }
             });
             sum
@@ -175,8 +165,8 @@ fun mul_t(exp: &vector<u8>, log: &vector<u8>, x: &Polynomial, y: &Polynomial): P
     Polynomial { coefficients }
 }
 
-fun scale_t(exp: &vector<u8>, log: &vector<u8>, x: &Polynomial, s: u8): Polynomial {
-    Polynomial { coefficients: x.coefficients.map_ref!(|c| gf256::mul_t(exp, log, *c, s)) }
+fun scale_g(g: &GF256, x: &Polynomial, s: u8): Polynomial {
+    Polynomial { coefficients: x.coefficients.map_ref!(|c| g.mul(*c, s)) }
 }
 
 /// Return x - c (same as x + c since GF256 is a binary field)
@@ -185,25 +175,22 @@ fun monic_linear(c: &u8): Polynomial {
 }
 
 // === Test-only wrappers ===
-// These keep the original (constant-copying) call shapes available for the unit tests below, which
-// exercise the arithmetic at small sizes where the table-copy cost is irrelevant.
+// These keep the original call shapes available for the unit tests below, which exercise the
+// arithmetic at small sizes.
 
 #[test_only]
 fun mul(x: &Polynomial, y: &Polynomial): Polynomial {
-    let (exp, log) = gf256::tables();
-    mul_t(&exp, &log, x, y)
+    mul_g(&gf256::new(), x, y)
 }
 
 #[test_only]
 fun div_by_monic_linear(x: &Polynomial, c: u8): Polynomial {
-    let (exp, log) = gf256::tables();
-    div_by_monic_linear_t(&exp, &log, x, c)
+    div_by_monic_linear_g(&gf256::new(), x, c)
 }
 
 #[test_only]
 fun compute_numerators(x: vector<u8>): vector<Polynomial> {
-    let (exp, log) = gf256::tables();
-    compute_numerators_t(&exp, &log, x)
+    compute_numerators_g(&gf256::new(), x)
 }
 
 #[test_only]
@@ -212,9 +199,9 @@ fun interpolate_with_numerators(
     y: &vector<u8>,
     numerators: &vector<Polynomial>,
 ): Polynomial {
-    let (exp, log) = gf256::tables();
-    let weights = compute_weights(&exp, &log, x);
-    interpolate_with_numerators_t(&exp, &log, x, y, numerators, &weights)
+    let g = gf256::new();
+    let weights = compute_weights(&g, x);
+    interpolate_with_numerators_g(&g, x, y, numerators, &weights)
 }
 
 #[test]

--- a/move/seal/sources/polynomial.move
+++ b/move/seal/sources/polynomial.move
@@ -67,8 +67,7 @@ fun div_by_monic_linear(g: &GF256, x: &Polynomial, c: u8): Polynomial {
 /// output polynomials.
 fun compute_weights(g: &GF256, x: vector<u8>): vector<u8> {
     // The interpolation nodes are distinct, so x[i] == x[j] iff i == j.
-    x.map_ref!(|xj| {
-        let xj = *xj;
+    x.map!(|xj| {
         g.div(1, x.fold!(1u8, |acc, xi| if (xi == xj) acc else g.mul(acc, gf256::sub(xj, xi))))
     })
 }

--- a/move/seal/sources/polynomial.move
+++ b/move/seal/sources/polynomial.move
@@ -167,10 +167,10 @@ fun monic_linear(c: &u8): Polynomial {
     Polynomial { coefficients: vector[*c, 1] }
 }
 
-// A non-`_g` wrapper for the unit tests below, so they can use method-call syntax (`a.mul(&b)`)
-// without threading a GF256 through. `mul_g` keeps its suffix to disambiguate from this.
 #[test_only]
 fun mul(x: &Polynomial, y: &Polynomial): Polynomial {
+    // A non-`_g` wrapper so the unit tests can use method-call syntax (`a.mul(&b)`) without
+    // threading a GF256 through. `mul_g` keeps its suffix to disambiguate from this.
     mul_g(&gf256::new(), x, y)
 }
 
@@ -210,7 +210,13 @@ fun test_interpolate() {
     let x = vector[1, 2, 3];
     let y = vector[7, 11, 17];
     let g = gf256::new();
-    let p = interpolate_with_numerators(&g, &x, &y, &compute_numerators(&g, x), &compute_weights(&g, x));
+    let p = interpolate_with_numerators(
+        &g,
+        &x,
+        &y,
+        &compute_numerators(&g, x),
+        &compute_weights(&g, x),
+    );
     assert_eq!(p.coefficients, x"1d150f");
     x.zip_do!(y, |x, y| assert!(p.evaluate(x) == y));
 }

--- a/move/seal/sources/polynomial.move
+++ b/move/seal/sources/polynomial.move
@@ -63,12 +63,10 @@ fun div_by_monic_linear(g: &GF256, x: &Polynomial, c: u8): Polynomial {
 }
 
 /// Compute the barycentric weights w_j = 1 / prod_{i != j} (x[j] - x[i]).
-/// These depend only on the x values, so the Lagrange interpolation can reuse them across all
-/// output polynomials.
 fun compute_weights(g: &GF256, x: vector<u8>): vector<u8> {
     // The interpolation nodes are distinct, so x[i] == x[j] iff i == j.
     x.map!(|xj| {
-        g.div(1, x.fold!(1u8, |acc, xi| if (xi == xj) acc else g.mul(acc, gf256::sub(xj, xi))))
+        x.fold!(1u8, |acc, xi| if (xi == xj) acc else g.div(acc, gf256::sub(xj, xi)))
     })
 }
 
@@ -81,8 +79,11 @@ fun interpolate_with_numerators(
     numerators: &vector<Polynomial>,
     weights: &vector<u8>,
 ): Polynomial {
-    assert!(x.length() == y.length(), EIncompatibleInputLengths);
     let n = x.length();
+    assert!(y.length() == n, EIncompatibleInputLengths);
+    assert!(numerators.length() == n, EIncompatibleInputLengths);
+    assert!(weights.length() == n, EIncompatibleInputLengths);
+   
     let mut sum = Polynomial { coefficients: vector[] };
     n.do!(|j| {
         sum = add(&sum, &scale(g, &numerators[j], g.mul(y[j], weights[j])));

--- a/move/seal/sources/polynomial.move
+++ b/move/seal/sources/polynomial.move
@@ -47,7 +47,7 @@ public(package) fun degree(p: &Polynomial): u64 {
 }
 
 // Divide a polynomial by the monic linear polynomial x + c.
-fun div_by_monic_linear_g(g: &GF256, x: &Polynomial, c: u8): Polynomial {
+fun div_by_monic_linear(g: &GF256, x: &Polynomial, c: u8): Polynomial {
     let n = x.coefficients.length();
     let mut coefficients = vector[];
     if (n > 1) {
@@ -80,7 +80,7 @@ fun compute_weights(g: &GF256, x: &vector<u8>): vector<u8> {
 
 /// Same as interpolate, but the numerator products, \prod_i (x - x_i), and the barycentric weights,
 /// 1 / \prod_{i != j} (x[j] - x[i]), are precomputed (both depend only on x).
-fun interpolate_with_numerators_g(
+fun interpolate_with_numerators(
     g: &GF256,
     x: &vector<u8>,
     y: &vector<u8>,
@@ -91,18 +91,18 @@ fun interpolate_with_numerators_g(
     let n = x.length();
     let mut sum = Polynomial { coefficients: vector[] };
     n.do!(|j| {
-        sum = add(&sum, &scale_g(g, &numerators[j], g.mul(y[j], weights[j])));
+        sum = add(&sum, &scale(g, &numerators[j], g.mul(y[j], weights[j])));
     });
     sum
 }
 
 /// Compute the numerators of the Lagrange polynomials for the given x values.
-fun compute_numerators_g(g: &GF256, x: vector<u8>): vector<Polynomial> {
+fun compute_numerators(g: &GF256, x: vector<u8>): vector<Polynomial> {
     // The full numerator depends only on x, so we can compute it here
     let full_numerator = x.fold!(Polynomial { coefficients: vector[1] }, |product, x_j| {
         mul_g(g, &product, &monic_linear(&x_j))
     });
-    x.map_ref!(|x_j| div_by_monic_linear_g(g, &full_numerator, *x_j))
+    x.map_ref!(|x_j| div_by_monic_linear(g, &full_numerator, *x_j))
 }
 
 /// Interpolate l polynomials p_1, ..., p_l such that p_i(x_j) = y[j][i] for all i, j.
@@ -114,17 +114,15 @@ public(package) fun interpolate_all(x: &vector<u8>, y: &vector<vector<u8>>): vec
     let l = y[0].length();
     assert!(y.all!(|yi| yi.length() == l), EIncompatibleInputLengths);
 
-    // Construct the field tables once instead of materializing the constants on every operation.
+    // Construct the field tables once
     let g = gf256::new();
 
-    // The numerators and the barycentric weights depend only on x, so compute them once and reuse
-    // them for every one of the l output polynomials.
-    let numerators = compute_numerators_g(&g, *x);
+    let numerators = compute_numerators(&g, *x);
     let weights = compute_weights(&g, x);
 
     vector::tabulate!(l, |i| {
         let yi = y.map_ref!(|yj| yj[i]);
-        interpolate_with_numerators_g(&g, x, &yi, &numerators, &weights)
+        interpolate_with_numerators(&g, x, &yi, &numerators, &weights)
     })
 }
 
@@ -165,7 +163,7 @@ fun mul_g(g: &GF256, x: &Polynomial, y: &Polynomial): Polynomial {
     Polynomial { coefficients }
 }
 
-fun scale_g(g: &GF256, x: &Polynomial, s: u8): Polynomial {
+fun scale(g: &GF256, x: &Polynomial, s: u8): Polynomial {
     Polynomial { coefficients: x.coefficients.map_ref!(|c| g.mul(*c, s)) }
 }
 
@@ -174,34 +172,11 @@ fun monic_linear(c: &u8): Polynomial {
     Polynomial { coefficients: vector[*c, 1] }
 }
 
-// === Test-only wrappers ===
-// These keep the original call shapes available for the unit tests below, which exercise the
-// arithmetic at small sizes.
-
+// A non-`_g` wrapper for the unit tests below, so they can use method-call syntax (`a.mul(&b)`)
+// without threading a GF256 through. `mul_g` keeps its suffix to disambiguate from this.
 #[test_only]
 fun mul(x: &Polynomial, y: &Polynomial): Polynomial {
     mul_g(&gf256::new(), x, y)
-}
-
-#[test_only]
-fun div_by_monic_linear(x: &Polynomial, c: u8): Polynomial {
-    div_by_monic_linear_g(&gf256::new(), x, c)
-}
-
-#[test_only]
-fun compute_numerators(x: vector<u8>): vector<Polynomial> {
-    compute_numerators_g(&gf256::new(), x)
-}
-
-#[test_only]
-fun interpolate_with_numerators(
-    x: &vector<u8>,
-    y: &vector<u8>,
-    numerators: &vector<Polynomial>,
-): Polynomial {
-    let g = gf256::new();
-    let weights = compute_weights(&g, x);
-    interpolate_with_numerators_g(&g, x, y, numerators, &weights)
 }
 
 #[test]
@@ -239,7 +214,8 @@ fun test_evaluate() {
 fun test_interpolate() {
     let x = vector[1, 2, 3];
     let y = vector[7, 11, 17];
-    let p = interpolate_with_numerators(&x, &y, &compute_numerators(x));
+    let g = gf256::new();
+    let p = interpolate_with_numerators(&g, &x, &y, &compute_numerators(&g, x), &compute_weights(&g, &x));
     assert_eq!(p.coefficients, x"1d150f");
     x.zip_do!(y, |x, y| assert!(p.evaluate(x) == y));
 }
@@ -261,6 +237,6 @@ fun test_div_exact_by_monic_linear() {
     let x = Polynomial { coefficients: vector[1, 2, 3, 4, 5, 6, 7] };
     let monic_linear = monic_linear(&2);
     let y = mul(&x, &monic_linear);
-    let z = div_by_monic_linear(&y, 2);
+    let z = div_by_monic_linear(&gf256::new(), &y, 2);
     assert_eq!(z, x);
 }


### PR DESCRIPTION
Speeds up `interpolate_all` (~65% of `decrypt` gas): load the EXP/LOG tables once instead of copying the constants on every field op, and precompute the Lagrange weights once. ~6× less gas for a decryption.