### PR TITLE
Add key server staleness check

### DIFF
--- a/crates/key-server/src/metrics.rs
+++ b/crates/key-server/src/metrics.rs
@@ -77,6 +77,9 @@ pub struct KeyServerMetrics {
     /// Total number of requests failed due to stale FN
     pub requests_failed_due_to_staleness: IntCounter,
 
+    /// Total number of requests failed due to a stale key server
+    pub requests_failed_due_to_key_server_staleness: IntCounter,
+
     /// The current key server version
     pub key_server_version: IntCounterVec,
 
@@ -182,6 +185,12 @@ impl KeyServerMetrics {
             requests_failed_due_to_staleness: register_int_counter_with_registry!(
                 "requests_failed_due_to_staleness",
                 "Total number of requests that failed due to a stale fullnode",
+                registry
+            )
+            .unwrap(),
+            requests_failed_due_to_key_server_staleness: register_int_counter_with_registry!(
+                "requests_failed_due_to_key_server_staleness",
+                "Total number of requests that failed due to a stale key server",
                 registry
             )
             .unwrap(),

--- a/crates/key-server/src/seal_package.rs
+++ b/crates/key-server/src/seal_package.rs
@@ -17,10 +17,20 @@ const TESTNET_PACKAGE_ID: &str =
 const MAINNET_PACKAGE_ID: &str =
     "0x931739224160073d8e391c9aa6e7ade9818e9814b4907066b7efa058636c4e45";
 
-/// This should be equal to the corresponding error code from the staleness Seal Move package.
-pub const STALENESS_ERROR_CODE: u64 = 93492;
+/// These should be equal to the corresponding error codes from the staleness Seal Move package.
+pub const STALE_FULLNODE_ERROR_CODE: u64 = 93492;
+pub const STALE_KEY_SERVER_ERROR_CODE: u64 = 93493;
 pub const STALENESS_MODULE: &str = "time";
 pub const STALENESS_FUNCTION: &str = "check_staleness";
+
+/// The kind of staleness detected by the on-chain `check_staleness` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Staleness {
+    /// The fullnode's on-chain time lags the key server's time by more than the allowed amount.
+    Fullnode,
+    /// The key server's time lags the fullnode's on-chain time by more than the allowed amount.
+    KeyServer,
+}
 
 #[derive(Debug)]
 pub enum SealPackage {
@@ -38,18 +48,26 @@ impl SealPackage {
         }
     }
 
-    pub fn is_staleness_error(&self, simulate_response: &SimulateTransactionResponse) -> bool {
+    /// Returns the kind of staleness if the simulation aborted in the staleness check of this
+    /// package, or `None` otherwise.
+    pub fn staleness_error(
+        &self,
+        simulate_response: &SimulateTransactionResponse,
+    ) -> Option<Staleness> {
         let status = simulate_response.transaction().effects().status();
         if let Some(error) = &status.error
             && let Some(ErrorDetails::Abort(abort)) = &error.error_details
-            && abort.abort_code() == STALENESS_ERROR_CODE
             && let Some(location) = &abort.location
             && location.package.as_deref() == Some(&self.package_id().to_string())
             && location.module.as_deref() == Some(STALENESS_MODULE)
         {
-            return true;
+            return match abort.abort_code() {
+                STALE_FULLNODE_ERROR_CODE => Some(Staleness::Fullnode),
+                STALE_KEY_SERVER_ERROR_CODE => Some(Staleness::KeyServer),
+                _ => None,
+            };
         }
-        false
+        None
     }
 
     pub fn add_staleness_check_to_ptb(

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -92,6 +92,8 @@ mod seal_package;
 pub mod tests;
 mod time;
 
+use seal_package::Staleness;
+
 const MAX_COMPUTATION_UNITS: u64 = 55_000; // 50K tier + 10% extra buffer
 const EVENT_MONITOR_RETRY_DELAY: Duration = Duration::from_secs(30);
 const GIT_VERSION: &str = crate::git_version!();
@@ -531,17 +533,24 @@ impl Server {
         }
 
         // Check if the staleness check failed
-        if self
+        if let Some(staleness) = self
             .options
             .network
             .seal_package()
-            .is_staleness_error(&simulate_res)
+            .staleness_error(&simulate_res)
         {
-            debug!("Fullnode is stale (req_id: {:?})", req_id);
+            let message = match staleness {
+                Staleness::Fullnode => "Fullnode is stale",
+                Staleness::KeyServer => "Key server is stale",
+            };
+            debug!("{} (req_id: {:?})", message, req_id);
             if let Some(m) = metrics {
-                m.requests_failed_due_to_staleness.inc()
+                match staleness {
+                    Staleness::Fullnode => m.requests_failed_due_to_staleness.inc(),
+                    Staleness::KeyServer => m.requests_failed_due_to_key_server_staleness.inc(),
+                }
             }
-            return Err(InternalError::Failure("Fullnode is stale".to_string()));
+            return Err(InternalError::Failure(message.to_string()));
         }
 
         // Handle errors in the simulation

--- a/move/seal_staleness/sources/staleness.move
+++ b/move/seal_staleness/sources/staleness.move
@@ -3,12 +3,18 @@ module seal_staleness::time;
 use sui::clock;
 
 const EStaleFullnode: u64 = 93492;
+const EStaleKeyServer: u64 = 93493;
 
-/// Check that the state of the chain is not stale: Abort if the on-chain time is more than `allowed_staleness_in_ms` behind `now`.
+/// The maximum amount the key server's time (`now`) may lag behind the on-chain time.
+const ALLOWED_KEY_SERVER_STALENESS_IN_MS: u64 = 60_000;
+
+/// Check that neither the full-node nor the key server is stale, where `now` is the key server's time:
+/// - Abort with `EStaleFullnode` if the on-chain time is more than `allowed_staleness_in_ms` behind `now`.
+/// - Abort with `EStaleKeyServer` if `now` is more than `ALLOWED_KEY_SERVER_STALENESS_IN_MS` behind the on-chain time.
 public fun check_staleness(now: u64, allowed_staleness_in_ms: u64, clock: &clock::Clock) {
-    // If the clock timestamp is more recent, the check passes
     let timestamp = clock.timestamp_ms();
     if (now < timestamp) {
+        assert!(timestamp - now <= ALLOWED_KEY_SERVER_STALENESS_IN_MS, EStaleKeyServer);
         return
     };
     assert!(now - timestamp <= allowed_staleness_in_ms, EStaleFullnode);
@@ -27,6 +33,19 @@ fun test_is_stale() {
 }
 
 #[test]
+#[expected_failure(abort_code = EStaleKeyServer)]
+fun test_key_server_is_stale() {
+    let mut ctx = tx_context::dummy();
+    let mut clock = clock::create_for_testing(&mut ctx);
+
+    // `now` lags the on-chain time by more than the allowed key server staleness
+    clock.increment_for_testing(ALLOWED_KEY_SERVER_STALENESS_IN_MS + 1);
+    check_staleness(0, 9, &clock);
+
+    clock.destroy_for_testing();
+}
+
+#[test]
 fun test_is_ok() {
     let mut ctx = tx_context::dummy();
     let mut clock = clock::create_for_testing(&mut ctx);
@@ -34,9 +53,13 @@ fun test_is_ok() {
     check_staleness(9, 10, &clock);
     check_staleness(99, 100, &clock);
 
-    // `now` in the past should also work
+    // `now` slightly in the past should also work
     clock.increment_for_testing(10);
     check_staleness(9, 0, &clock);
+
+    // `now` at exactly the allowed key server staleness limit should pass
+    clock.increment_for_testing(ALLOWED_KEY_SERVER_STALENESS_IN_MS - 10);
+    check_staleness(0, 0, &clock);
 
     clock.destroy_for_testing();
 }


### PR DESCRIPTION
Aborts decryption if the key server's clock lags the chain's by more than a fixed 1 min (mirroring the existing fullnode staleness check in the other direction). Counts the condition via `requests_failed_due_to_key_server_staleness` so operators can alert on it. Implemented in the standalone `seal_staleness` package.