### PR TITLE
[aggregator][key-server] sparse buckets for histogram

### DIFF
--- a/crates/key-server/src/aggregator/server.rs
+++ b/crates/key-server/src/aggregator/server.rs
@@ -817,11 +817,6 @@ async fn monitor_members_update(state: AppState) {
                 .collect()
         };
 
-        info!(
-            "Fetched updated committee: {} members, current: {} members",
-            member_count,
-            current_names.len()
-        );
         for member in &committee.members {
             if !current_names.contains(&member.name)
                 && !state.options.api_credentials.contains_key(&member.name)

--- a/crates/key-server/src/metrics.rs
+++ b/crates/key-server/src/metrics.rs
@@ -167,7 +167,7 @@ impl KeyServerMetrics {
                 "sui_rpc_request_duration_millis",
                 "Sui RPC request duration and status in milliseconds",
                 &["method", "status"],
-                default_fast_call_duration_buckets(),
+                default_network_call_duration_buckets(),
                 registry
             )
             .unwrap(),
@@ -258,6 +258,13 @@ fn buckets(start: f64, end: f64, step: f64) -> Vec<f64> {
 
 fn default_fast_call_duration_buckets() -> Vec<f64> {
     buckets(10.0, 100.0, 10.0)
+}
+
+/// Buckets for network-bound calls (Sui RPC, upstream key server fetches).
+fn default_network_call_duration_buckets() -> Vec<f64> {
+    vec![
+        100.0, 200.0, 500.0, 1000.0, 2000.0, 5000.0, 8000.0,
+    ]
 }
 
 /// Collector that tracks the uptime of the server.
@@ -373,7 +380,7 @@ impl AggregatorMetrics {
                 "key_server_fetch_duration_millis",
                 "Upstream key server fetch latency in milliseconds by server name",
                 &["key_server_name"],
-                default_fast_call_duration_buckets(),
+                default_network_call_duration_buckets(),
                 registry
             )
             .unwrap(),
@@ -388,7 +395,7 @@ impl AggregatorMetrics {
                 "sui_rpc_request_duration_millis",
                 "Sui RPC request duration and status in milliseconds",
                 &["method", "status"],
-                default_fast_call_duration_buckets(),
+                default_network_call_duration_buckets(),
                 registry
             )
             .unwrap(),

--- a/crates/key-server/src/metrics.rs
+++ b/crates/key-server/src/metrics.rs
@@ -262,9 +262,7 @@ fn default_fast_call_duration_buckets() -> Vec<f64> {
 
 /// Buckets for network-bound calls (Sui RPC, upstream key server fetches).
 fn default_network_call_duration_buckets() -> Vec<f64> {
-    vec![
-        100.0, 200.0, 500.0, 1000.0, 2000.0, 5000.0, 8000.0,
-    ]
+    vec![100.0, 200.0, 500.0, 1000.0, 2000.0, 5000.0, 8000.0]
 }
 
 /// Collector that tracks the uptime of the server.


### PR DESCRIPTION
## Description 

currently all metrics are clipped to 1ms. that external calls can easily go over (e.g. key server -> grpc, aggregator -> grpc, aggregator -> key server). this is to increase the buckets

## Test plan 

How did you test the new or updated feature?