### PR TITLE
[Key Server] Reduce gas budget for the evaluation of Seal policies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8263,9 +8263,7 @@ dependencies = [
  "seal-sdk",
  "serde",
  "serde_json",
- "sui-sdk",
  "sui-sdk-types 0.3.0",
- "sui-types",
  "tokio",
 ]
 

--- a/crates/key-server/src/aggregator/server.rs
+++ b/crates/key-server/src/aggregator/server.rs
@@ -42,7 +42,6 @@ use std::collections::{HashMap, HashSet};
 use std::env;
 use std::sync::Arc;
 use sui_rpc::client::Client as SuiGrpcClient;
-use sui_sdk::SuiClientBuilder;
 use sui_sdk_types::Address;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
@@ -771,12 +770,8 @@ async fn load_committee_state(
 ) -> Result<AppState> {
     let grpc_client =
         SuiGrpcClient::new(options.node_url()).context("Failed to create SuiGrpcClient")?;
-    let sui_client = SuiClientBuilder::default()
-        .build(&options.node_url())
-        .await
-        .context("Failed to build SuiClient")?;
-    let sui_rpc_client = SuiRpcClient::new(
-        sui_client,
+    let sui_rpc_client = SuiRpcClient::new_with_optional_sui_client(
+        None,
         grpc_client,
         options.rpc_config.retry_config.clone(),
         Some(metrics.sui_rpc_request_duration_millis.clone()),

--- a/crates/key-server/src/aggregator/server.rs
+++ b/crates/key-server/src/aggregator/server.rs
@@ -995,12 +995,8 @@ mod tests {
         let registry = Registry::new();
         let metrics = Arc::new(AggregatorMetrics::new(&registry));
         let grpc_client = SuiGrpcClient::new(options.node_url()).unwrap();
-        let sui_client = SuiClientBuilder::default()
-            .build(&options.node_url())
-            .await
-            .unwrap();
-        let sui_rpc_client = SuiRpcClient::new(
-            sui_client,
+        let sui_rpc_client = SuiRpcClient::new_with_optional_sui_client(
+            None,
             grpc_client,
             options.rpc_config.retry_config.clone(),
             None,

--- a/crates/key-server/src/externals.rs
+++ b/crates/key-server/src/externals.rs
@@ -90,7 +90,6 @@ mod tests {
     use sui_sdk::types::crypto::{get_key_pair, Signature};
     use sui_sdk::types::signature::GenericSignature;
     use sui_sdk::verify_personal_message_signature::verify_personal_message_signature;
-    use sui_sdk::SuiClientBuilder;
     use sui_types::base_types::ObjectID;
     #[tokio::test]
     async fn test_fetch_first_pkg_id() {
@@ -98,13 +97,8 @@ mod tests {
             "0xac7890f847ac6973ca615af9d7bbb642541f175e35e340e5d1241d0ffda9ed04",
         )
         .unwrap();
-        let sui_rpc_client = SuiRpcClient::new(
-            SuiClientBuilder::default()
-                .build(&Network::Testnet.default_node_url())
-                .await
-                .expect(
-                    "SuiClientBuilder should not failed unless provided with invalid network url",
-                ),
+        let sui_rpc_client = SuiRpcClient::new_with_optional_sui_client(
+            None,
             SuiGrpcClient::new(Network::Testnet.default_node_url())
                 .expect("Failed to create SuiGrpcClient"),
             RetryConfig::default(),
@@ -126,13 +120,8 @@ mod tests {
     #[tokio::test]
     async fn test_fetch_first_pkg_id_with_invalid_id() {
         let invalid_address = ObjectID::ZERO;
-        let sui_rpc_client = SuiRpcClient::new(
-            SuiClientBuilder::default()
-                .build(&Network::Mainnet.default_node_url())
-                .await
-                .expect(
-                    "SuiClientBuilder should not failed unless provided with invalid network url",
-                ),
+        let sui_rpc_client = SuiRpcClient::new_with_optional_sui_client(
+            None,
             SuiGrpcClient::new(Network::Mainnet.default_node_url())
                 .expect("Failed to create SuiGrpcClient"),
             RetryConfig::default(),

--- a/crates/key-server/src/mvr.rs
+++ b/crates/key-server/src/mvr.rs
@@ -28,7 +28,6 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::str::FromStr;
 use sui_rpc::client::Client as SuiGrpcClient;
-use sui_sdk::SuiClientBuilder;
 use sui_sdk_types::{Address, StructTag as SdkStructTag, TypeTag as SdkTypeTag};
 use sui_types::base_types::ObjectID;
 use sui_types::collection_types::Table;
@@ -111,12 +110,8 @@ pub(crate) async fn mvr_forward_resolution(
         Network::Testnet => {
             let networks: HashMap<_, _> = get_from_mvr_registry(
                 mvr_name,
-                &SuiRpcClient::new(
-                    SuiClientBuilder::default()
-                        .request_timeout(key_server_options.rpc_config.timeout)
-                        .build_mainnet()
-                        .await
-                        .map_err(|_| Failure("Failed to build sui client".to_string()))?,
+                &SuiRpcClient::new_with_optional_sui_client(
+                    None,
                     SuiGrpcClient::new(Network::Mainnet.default_node_url())
                         .expect("Failed to create SuiGrpcClient"),
                     key_server_options.rpc_config.retry_config.clone(),
@@ -222,14 +217,13 @@ mod tests {
     use mvr_types::name::VersionedName;
     use std::str::FromStr;
     use sui_rpc::client::Client as SuiGrpcClient;
-    use sui_sdk::SuiClientBuilder;
     use sui_types::base_types::ObjectID;
     #[tokio::test]
     async fn test_forward_resolution() {
         assert!(crate::externals::check_mvr_package_id(
             &Some("@mysten/kiosk".to_string()),
-            &SuiRpcClient::new(
-                SuiClientBuilder::default().build_mainnet().await.unwrap(),
+            &SuiRpcClient::new_with_optional_sui_client(
+                None,
                 SuiGrpcClient::new(Network::Mainnet.default_node_url()).unwrap(),
                 RetryConfig::default(),
                 None,
@@ -256,8 +250,8 @@ mod tests {
         );
         assert_eq!(
             mvr_forward_resolution(
-                &SuiRpcClient::new(
-                    SuiClientBuilder::default().build_testnet().await.unwrap(),
+                &SuiRpcClient::new_with_optional_sui_client(
+                    None,
                     SuiGrpcClient::new(Network::Testnet.default_node_url()).unwrap(),
                     RetryConfig::default(),
                     None,
@@ -276,8 +270,8 @@ mod tests {
         // This MVR name is not registered on mainnet.
         assert_eq!(
             mvr_forward_resolution(
-                &SuiRpcClient::new(
-                    SuiClientBuilder::default().build_mainnet().await.unwrap(),
+                &SuiRpcClient::new_with_optional_sui_client(
+                    None,
                     SuiGrpcClient::new(Network::Mainnet.default_node_url())
                         .expect("Failed to create SuiGrpcClient"),
                     RetryConfig::default(),
@@ -295,8 +289,8 @@ mod tests {
         // ..but it is on testnet.
         assert_eq!(
             mvr_forward_resolution(
-                &SuiRpcClient::new(
-                    SuiClientBuilder::default().build_testnet().await.unwrap(),
+                &SuiRpcClient::new_with_optional_sui_client(
+                    None,
                     SuiGrpcClient::new(Network::Testnet.default_node_url())
                         .expect("Failed to create SuiGrpcClient"),
                     RetryConfig::default(),
@@ -318,8 +312,8 @@ mod tests {
     async fn test_invalid_name() {
         assert_eq!(
             mvr_forward_resolution(
-                &SuiRpcClient::new(
-                    SuiClientBuilder::default().build_mainnet().await.unwrap(),
+                &SuiRpcClient::new_with_optional_sui_client(
+                    None,
                     SuiGrpcClient::new(Network::Mainnet.default_node_url())
                         .expect("Failed to create SuiGrpcClient"),
                     RetryConfig::default(),
@@ -336,8 +330,8 @@ mod tests {
 
         assert_eq!(
             mvr_forward_resolution(
-                &SuiRpcClient::new(
-                    SuiClientBuilder::default().build_mainnet().await.unwrap(),
+                &SuiRpcClient::new_with_optional_sui_client(
+                    None,
                     SuiGrpcClient::new(Network::Mainnet.default_node_url())
                         .expect("Failed to create SuiGrpcClient"),
                     RetryConfig::default(),

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -95,7 +95,7 @@ mod seal_package;
 pub mod tests;
 mod time;
 
-const GAS_BUDGET: u64 = 500_000_000;
+const MAX_COMPUTATION_UNITS: u64 = 55_000; // 50K tier + 10% extra buffer
 const GIT_VERSION: &str = crate::git_version!();
 const DEFAULT_PORT: u16 = 2024;
 
@@ -425,11 +425,12 @@ impl Server {
             .add_staleness_check_to_ptb(self.options.allowed_staleness, vptb.ptb().clone())?;
 
         // Evaluate the `seal_approve*` function
+        let gas_budget = MAX_COMPUTATION_UNITS * gas_price;
         let tx_data = TransactionData::new_with_gas_coins(
             TransactionKind::ProgrammableTransaction(ptb),
             sender,
             vec![], // Empty gas payment for dry run
-            GAS_BUDGET,
+            gas_budget,
             gas_price,
         );
         let simulate_res = self

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -205,9 +205,11 @@ impl Server {
     }
 
     async fn new(mut options: KeyServerOptions, metrics: Option<Arc<KeyServerMetrics>>) -> Self {
-        // The legacy JSON-RPC client is only used by the event monitors, only
-        // initialize it when event monitoring is enabled.
-        let sui_client = if options.enable_event_monitoring {
+        // The legacy JSON-RPC client is only used by the event monitors, which
+        // only run in committee mode. Only initialize it when event monitoring
+        // is enabled and the server is in committee mode.
+        let is_committee_mode = matches!(options.server_mode, ServerMode::Committee { .. });
+        let sui_client = if options.enable_event_monitoring && is_committee_mode {
             info!("Event monitoring enabled; initializing legacy Sui JSON-RPC client");
             Some(
                 SuiClientBuilder::default()

--- a/crates/seal-cli/Cargo.toml
+++ b/crates/seal-cli/Cargo.toml
@@ -19,6 +19,4 @@ bcs.workspace = true
 reqwest.workspace = true
 tokio.workspace = true
 
-sui_sdk.workspace = true
 sui-sdk-types.workspace = true
-sui_types.workspace = true

--- a/crates/seal-cli/src/main.rs
+++ b/crates/seal-cli/src/main.rs
@@ -16,17 +16,15 @@ use fastcrypto::groups::bls12381::{G1Element, G2Element, Scalar};
 use fastcrypto::serde_helpers::ToFromByteArray;
 use rand::thread_rng;
 use reqwest::Body;
-use seal_committee::Network;
+use seal_committee::grpc_helper::fetch_object;
+use seal_committee::move_types::Field;
+use seal_committee::{create_grpc_client_with_url, Network};
 use seal_sdk::types::{FetchKeyRequest, FetchKeyResponse};
 use seal_sdk::IBEPublicKey;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
-use sui_sdk::rpc_types::SuiParsedData;
-use sui_sdk::SuiClientBuilder;
-use sui_sdk_types::Address as NewObjectID;
-use sui_types::dynamic_field::DynamicFieldName;
-use sui_types::TypeTag;
+use sui_sdk_types::{Address as NewObjectID, TypeTag};
 
 const KEY_LENGTH: usize = 32;
 
@@ -39,118 +37,50 @@ pub struct KeyServerInfo {
     pub public_key: String,
 }
 
-/// Fetch and parse key server object from fullnode.
-/// TODO: rewrite with sui-rust-sdk
+/// Legacy (V1) key server object, stored as a `u64`-keyed (value `1`) dynamic
+/// field on the KeyServer object. Independent key servers expose their `url`
+/// here directly. Field order must match the `KeyServerV1` Move struct for BCS.
+#[derive(Deserialize)]
+struct KeyServerV1 {
+    name: String,
+    url: String,
+    #[allow(dead_code)]
+    key_type: u8,
+    pk: Vec<u8>,
+}
+
+/// Fetch and parse key server objects from a fullnode over gRPC.
+///
+/// Reads the legacy `KeyServerV1` value stored as a `u64`-keyed (value `1`)
+/// dynamic field on each KeyServer object, which carries the `url`/`name`/`pk`
+/// of an independent key server.
 pub async fn fetch_key_server_urls(
     network: &Network,
     key_server_ids: &[ObjectID],
     custom_rpc_url: Option<String>,
 ) -> Result<Vec<KeyServerInfo>, FastCryptoError> {
-    let sui_rpc = custom_rpc_url.unwrap_or_else(|| network.default_rpc_url().to_string());
-    let sui_client = SuiClientBuilder::default()
-        .build(sui_rpc)
-        .await
+    let mut grpc_client = create_grpc_client_with_url(network, custom_rpc_url.as_deref())
         .map_err(|e| FastCryptoError::GeneralError(format!("Failed to build Sui client: {e}")))?;
+    // Key type: u64, key value: 1 (V1). Regular dynamic field, not a dynamic object field.
+    let v1_field_name_bcs = bcs::to_bytes(&1u64).expect("BCS serialization failed");
     let mut key_servers = Vec::new();
     for object_id in key_server_ids {
-        // Get the dynamic field object for version 1
-        let dynamic_field_name = DynamicFieldName {
-            type_: TypeTag::U64,
-            value: serde_json::Value::String("1".to_string()),
-        };
-
-        match sui_client
-            .read_api()
-            .get_dynamic_field_object(
-                sui_types::base_types::ObjectID::new(object_id.into_inner()),
-                dynamic_field_name,
-            )
+        let ks_addr = NewObjectID::new(object_id.into_inner());
+        let field_id = ks_addr.derive_dynamic_child_id(&TypeTag::U64, &v1_field_name_bcs);
+        let field: Field<u64, KeyServerV1> = fetch_object(&mut grpc_client, &field_id)
             .await
-        {
-            Ok(response) => {
-                if let Some(object_data) = response.data {
-                    if let Some(content) = object_data.content {
-                        if let SuiParsedData::MoveObject(parsed_data) = content {
-                            let fields = &parsed_data.fields;
-
-                            // Convert fields to JSON value for access
-                            let fields_json = serde_json::to_value(fields).map_err(|e| {
-                                FastCryptoError::GeneralError(format!(
-                                    "Failed to serialize fields: {e}"
-                                ))
-                            })?;
-
-                            // Extract URL and name from the nested 'value' field
-                            let value_struct = fields_json.get("value").ok_or_else(|| {
-                                FastCryptoError::GeneralError(format!(
-                                    "Missing 'value' field for object {object_id}"
-                                ))
-                            })?;
-
-                            let value_fields = value_struct.get("fields").ok_or_else(|| {
-                                FastCryptoError::GeneralError(format!(
-                                    "Missing 'fields' in value struct for object {object_id}"
-                                ))
-                            })?;
-
-                            let url = value_fields.get("url")
-                                .and_then(|v| match v {
-                                    serde_json::Value::String(s) => Some(s.clone()),
-                                    _ => None,
-                                })
-                                .ok_or_else(|| FastCryptoError::GeneralError(format!("Missing or invalid 'url' field in value fields for object {object_id}")))?;
-
-                            let name = value_fields
-                                .get("name")
-                                .map(|v| match v {
-                                    serde_json::Value::String(s) => s.clone(),
-                                    _ => "Unknown".to_string(),
-                                })
-                                .unwrap_or_else(|| "Unknown".to_string());
-
-                            let public_key = value_fields.get("pk")
-                                .and_then(|v| match v {
-                                    serde_json::Value::Array(arr) => {
-                                        // Convert array of numbers to bytes then to hex string
-                                        let bytes: Result<Vec<u8>, _> = arr.iter()
-                                            .map(|n| n.as_u64().and_then(|n| u8::try_from(n).ok()))
-                                            .collect::<Option<Vec<_>>>()
-                                            .ok_or("Invalid byte values in pk array");
-                                        bytes.ok().map(|b| Hex::encode(&b))
-                                    },
-                                    serde_json::Value::String(s) => Some(s.clone()),
-                                    _ => None,
-                                })
-                                .ok_or_else(|| FastCryptoError::GeneralError(format!("Missing or invalid 'pk' field in value fields for object {object_id}")))?;
-
-                            key_servers.push(KeyServerInfo {
-                                object_id: *object_id,
-                                name,
-                                url,
-                                public_key,
-                            });
-                        } else {
-                            return Err(FastCryptoError::GeneralError(format!(
-                                "Unexpected content type for object {object_id}"
-                            )));
-                        }
-                    } else {
-                        return Err(FastCryptoError::GeneralError(format!(
-                            "No content found for object {object_id}"
-                        )));
-                    }
-                } else {
-                    return Err(FastCryptoError::GeneralError(format!(
-                        "Object {object_id} not found"
-                    )));
-                }
-            }
-            Err(e) => {
-                return Err(FastCryptoError::GeneralError(format!(
+            .map_err(|e| {
+                FastCryptoError::GeneralError(format!(
                     "Failed to fetch dynamic field for object {object_id}: {e}"
-                )));
-            }
-        }
+                ))
+            })?;
+
+        key_servers.push(KeyServerInfo {
+            object_id: *object_id,
+            name: field.value.name,
+            url: field.value.url,
+            public_key: Hex::encode(&field.value.pk),
+        });
     }
 
     Ok(key_servers)


### PR DESCRIPTION
The key server calls the dry run / simulate API to evaluate Seal policies. To prevent abuse, the server currently uses a fixed gas budget of [500M](https://github.com/MystenLabs/seal/blob/main/crates/key-server/src/server.rs#L96) MIST, which is 1% of the [maximum value](https://docs.sui.io/concepts/tokenomics/gas-in-sui), to limit the cost of these calls.

Since Seal policies should not incur storage fees anyhow, this PR reduces the gas budget to the cost of ~50,000 computation units to further limit potential abuse. The rationale is as follows:

- With a reference gas price (RGP) of 500, the currently used budget corresponds to the [tier](https://docs.sui.io/concepts/tokenomics/gas-in-sui#computation) costing 1M computation units.

- 50,000 computation units, two tiers lower, is still above the cost of any policies we have observed.

- Since the "cost" of dry run is independent of the load on the chain (as it does not compete with other transactions), the enforced limit should not depend on the current Reference Gas Price, and instead be defined with regards to computation units.

- Increasing this value in the future will be backward compatible.

Feedback on the proposed value is welcome.