### PR TITLE
[docs] Add frontmatter evaluation pipeline and GEO/AEO fields

### DIFF
--- a/docs/content/Aggregator.mdx
+++ b/docs/content/Aggregator.mdx
@@ -1,6 +1,9 @@
 ---
 title: Aggregator Server
-description: Learn how the Aggregator Server acts as a gateway between clients and Seal decentralized (committee mode) key servers, aggregating encrypted partial key shares.
+description: >-
+  Learn how the Aggregator Server acts as a gateway between clients and Seal
+  decentralized (committee mode) key servers, aggregating encrypted partial
+  key shares.
 keywords:
   - aggregator server
   - Seal MPC
@@ -11,6 +14,33 @@ keywords:
   - DKG
   - API credentials
   - Lagrange interpolation
+goal:
+  description: >-
+    Reader understands the aggregator server's role and can deploy and
+    configure one for a Seal committee
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 200
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - What is the Seal aggregator server?
+  - How does the aggregator server work with committee key servers?
+  - How do I deploy a Seal aggregator server?
+  - What is Lagrange interpolation in Seal?
+answer: >-
+  The Seal aggregator server acts as a gateway between clients and
+  decentralized (committee mode) key servers. It collects encrypted partial
+  key shares from committee members, verifies their signatures, and combines
+  them using Lagrange interpolation to produce the final decryption key for
+  the client.
 ---
 
 import InfrastructureRequirements from './_InfrastructureRequirements.mdx';

--- a/docs/content/Design.mdx
+++ b/docs/content/Design.mdx
@@ -1,6 +1,8 @@
 ---
 title: Seal Design
-description: Learn how Seal uses Identity-Based Encryption (IBE) to provide secure, policy-driven data encryption with decentralized key management on Sui.
+description: >-
+  Learn how Seal uses Identity-Based Encryption (IBE) to provide secure,
+  policy-driven data encryption with decentralized key management on Sui.
 keywords:
   - Seal design
   - identity-based encryption
@@ -13,6 +15,34 @@ keywords:
   - MPC committee
   - threshold encryption
   - decentralization
+goal:
+  description: >-
+    Reader understands Seal's cryptographic design — IBE, onchain access
+    policies, key server architecture, and the trust model
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 500
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How does Seal's Identity-Based Encryption work?
+  - What is Seal's cryptographic design?
+  - How do Seal key servers manage decryption keys?
+  - What is the trust model for Seal?
+  - How does Seal handle access policies onchain?
+answer: >-
+  Seal uses Identity-Based Encryption (IBE) with BLS12-381 curves so that
+  data can be encrypted to an identity derived from onchain access policies
+  without needing the recipient's public key in advance. Key servers hold
+  master keys and release user-specific decryption keys only after verifying
+  that a Sui programmable transaction block satisfies the access policy.
 ---
 
 > For a comprehensive technical analysis and formal security proofs, see the [Seal Whitepaper](./Seal_White_Paper_v2.pdf). The latest version (v2) incorporates the design and analysis of MPC committees for the decentralized mode key server. 

--- a/docs/content/ExamplePatterns.mdx
+++ b/docs/content/ExamplePatterns.mdx
@@ -1,6 +1,8 @@
 ---
 title: Access Policy Example Patterns
-description: Explore common Seal access policy patterns including private data, allowlists, subscriptions, time-lock encryption, and secure voting implementations.
+description: >-
+  Explore common Seal access policy patterns including private data, allowlists,
+  subscriptions, time-lock encryption, and secure voting implementations.
 keywords:
   - access policy
   - Seal patterns
@@ -11,6 +13,35 @@ keywords:
   - secure voting
   - encrypted content
   - IBE
+goal:
+  description: >-
+    Reader can identify and implement the right Seal access policy pattern for
+    their use case — private data, allowlists, subscriptions, time-lock, or
+    voting
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - What access policy patterns does Seal support?
+  - How do I implement an allowlist with Seal?
+  - How do I create a subscription-based access policy?
+  - How does time-lock encryption work in Seal?
+  - How do I implement secure voting with Seal?
+answer: >-
+  Seal provides several access policy patterns implemented as Move modules:
+  private data (owner-only access via owned objects), allowlists (creator-managed
+  address lists), subscriptions (time-limited access with payments), time-lock
+  encryption (automatic unlock at a specified time), and secure voting
+  (encrypted ballots revealed only after voting closes).
 ---
 
 # Access policy example patterns

--- a/docs/content/GettingStarted.mdx
+++ b/docs/content/GettingStarted.mdx
@@ -1,6 +1,8 @@
 ---
 title: Getting Started
-description: Learn how to quickly bootstrap your application with Seal for decentralized encryption and programmable access control on Sui.
+description: >-
+  Learn how to quickly bootstrap your application with Seal for decentralized
+  encryption and programmable access control on Sui.
 keywords:
   - getting started
   - Seal SDK
@@ -10,6 +12,37 @@ keywords:
   - key servers
   - TypeScript SDK
   - bootstrap
+goal:
+  description: >-
+    Reader can bootstrap a Seal integration from scratch — install the SDK,
+    choose key servers, define an access policy, encrypt data, and decrypt it
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 200
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+    - headings:
+        - { pattern: "Bootstrap" }
+        - { pattern: "Next steps" }
+      label: Needs key procedural headings
+questions:
+  - How do I get started with Seal?
+  - How do I install the Seal SDK?
+  - How do I encrypt data with Seal?
+  - How do I set up access control with Seal?
+answer: >-
+  To get started with Seal, install the @aspect-build/seal SDK, choose key
+  servers from the Testnet provider list, define a Move access policy with a
+  seal_approve function, encrypt your data using the SealClient, store it on
+  Walrus or other storage, and decrypt it by proving access through a
+  programmable transaction block.
 ---
 
 :::note

--- a/docs/content/KeyServerCommitteeOps.mdx
+++ b/docs/content/KeyServerCommitteeOps.mdx
@@ -1,6 +1,9 @@
 ---
 title: Key Server Operations for Decentralized Server Type
-description: Learn how to set up and operate a key server as a decentralized (committee mode) server type, including DKG ceremonies, key rotation, and aggregator configuration.
+description: >-
+  Learn how to set up and operate a key server as a decentralized (committee
+  mode) server type, including DKG ceremonies, key rotation, and aggregator
+  configuration.
 keywords:
   - key server operations
   - decentralized key server
@@ -12,6 +15,37 @@ keywords:
   - MPC committee
   - coordinator
   - committee members
+goal:
+  description: >-
+    Reader can set up and operate a decentralized (committee mode) key server,
+    run DKG ceremonies, rotate keys, and configure an aggregator
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 500
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+    - steps_present: 3
+      label: Needs numbered steps for procedural content
+questions:
+  - How do I set up a decentralized Seal key server?
+  - How does DKG work in Seal committee mode?
+  - How do I rotate keys in a Seal committee?
+  - What is the coordinator role in Seal committee mode?
+  - How do I configure a Seal aggregator server?
+answer: >-
+  To operate a decentralized Seal key server, form a committee of members who
+  run a Distributed Key Generation (DKG) ceremony in three phases —
+  registration, message creation, and finalization — coordinated by a
+  designated coordinator. The resulting key shares are distributed across
+  members, and an aggregator server collects and combines partial decryption
+  shares from the committee to serve client requests.
 ---
 
 import InfrastructureRequirements from './_InfrastructureRequirements.mdx';

--- a/docs/content/KeyServerOps.mdx
+++ b/docs/content/KeyServerOps.mdx
@@ -1,6 +1,9 @@
 ---
 title: Key Server Operations for Independent Server Type
-description: Learn how to operate a Seal key server as an independent server type in Open or Permissioned mode as a service provider or for your own development and testing.
+description: >-
+  Learn how to operate a Seal key server as an independent server type in Open
+  or Permissioned mode as a service provider or for your own development and
+  testing.
 keywords:
   - key server operations
   - independent server type
@@ -13,6 +16,36 @@ keywords:
   - key import
   - CORS configuration
   - infrastructure requirements
+goal:
+  description: >-
+    Reader can deploy and operate an independent Seal key server in Open or
+    Permissioned mode, manage client registrations, and export/import keys
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 500
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+    - steps_present: 3
+      label: Needs numbered steps for procedural content
+questions:
+  - How do I run an independent Seal key server?
+  - What is the difference between Open and Permissioned mode?
+  - How do I register clients on a Permissioned key server?
+  - How do I export and import Seal key server keys?
+  - How do I deploy a Seal key server with Docker?
+answer: >-
+  An independent Seal key server runs as a single operator with a master key
+  and supports two modes: Open mode (serves all packages with one key) and
+  Permissioned mode (per-client keys with an allowlist). Operators can
+  register clients, export and import keys for backup, configure CORS, and
+  deploy using Docker.
 ---
 
 import InfrastructureRequirements from './_InfrastructureRequirements.mdx';

--- a/docs/content/Pricing.mdx
+++ b/docs/content/Pricing.mdx
@@ -1,6 +1,8 @@
 ---
 title: Seal Pricing
-description: Learn about Seal's decentralized key server network, pricing models, and verified providers for both Testnet and Mainnet environments.
+description: >-
+  Learn about Seal's decentralized key server network, pricing models, and
+  verified providers for both Testnet and Mainnet environments.
 keywords:
   - Seal pricing
   - key server providers
@@ -10,6 +12,33 @@ keywords:
   - Testnet
   - Mainnet
   - threshold encryption
+goal:
+  description: >-
+    Reader can identify verified key server providers and understand pricing
+    models for Seal on Testnet and Mainnet
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 100
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How much does Seal cost?
+  - What key server providers are available for Seal?
+  - Which Seal key servers are available on Testnet?
+  - Which Seal key servers are available on Mainnet?
+answer: >-
+  Seal's key server network includes verified providers on both Testnet and
+  Mainnet, offering Open mode (serves all packages) and Permissioned mode
+  (per-client allowlisting) key servers. Providers include Mysten Labs, Ruby
+  Nodes, NodeInfra, Studio Mirai, Overclock, H2O Nodes, Triton One, Natsai,
+  and Mhax.io.
 ---
 
 # Seal pricing

--- a/docs/content/SealCLI.mdx
+++ b/docs/content/SealCLI.mdx
@@ -1,6 +1,8 @@
 ---
 title: Seal CLI
-description: Learn how to use the Seal CLI to generate keys, encrypt and decrypt data, inspect encrypted objects, and interact with key servers.
+description: >-
+  Learn how to use the Seal CLI to generate keys, encrypt and decrypt data,
+  inspect encrypted objects, and interact with key servers.
 keywords:
   - Seal CLI
   - seal-cli
@@ -11,6 +13,37 @@ keywords:
   - symmetric key
   - AES encryption
   - IBE
+goal:
+  description: >-
+    Reader can use the seal-cli tool to generate keys, encrypt and decrypt
+    data, inspect encrypted objects, and interact with key servers
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 200
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+    - headings:
+        - { pattern: "ncrypt" }
+        - { pattern: "ecrypt" }
+      label: Needs key procedural headings
+questions:
+  - How do I use the Seal CLI?
+  - How do I encrypt data with the Seal CLI?
+  - How do I decrypt data with the Seal CLI?
+  - How do I generate keys with seal-cli?
+  - How do I inspect encrypted objects with seal-cli?
+answer: >-
+  The Seal CLI (seal-cli) is a command-line tool for generating IBE key
+  pairs, encrypting data with AES, decrypting with symmetric keys, extracting
+  user secret keys, performing threshold decryption, inspecting encrypted
+  objects, and interacting with key servers to encrypt data and fetch keys.
 ---
 
 # Seal CLI

--- a/docs/content/SecurityBestPractices.mdx
+++ b/docs/content/SecurityBestPractices.mdx
@@ -1,6 +1,9 @@
 ---
 title: Security Best Practices and Risk Mitigations
-description: Learn security best practices for using Seal, including threshold configuration, key server selection, encryption strategies, and risk mitigation approaches.
+description: >-
+  Learn security best practices for using Seal, including threshold
+  configuration, key server selection, encryption strategies, and risk
+  mitigation approaches.
 keywords:
   - security best practices
   - risk mitigation
@@ -13,6 +16,35 @@ keywords:
   - audit logging
   - revocation
   - identity namespace
+goal:
+  description: >-
+    Reader understands key security considerations when using Seal and can
+    apply best practices for threshold config, key server selection, and
+    encryption strategies
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - What are the security best practices for Seal?
+  - How should I configure threshold encryption in Seal?
+  - How do I choose key server providers for Seal?
+  - What is envelope encryption in Seal?
+  - How do I mitigate key leakage risks with Seal?
+answer: >-
+  Key security best practices for Seal include designing identity namespaces
+  carefully (fetched keys can decrypt future content matching the same
+  identity), configuring appropriate threshold values for multi-key-server
+  setups, vetting key server providers, using layered or envelope encryption
+  for sensitive data, and implementing audit logging.
 ---
 
 # Security best practices and risk mitigations

--- a/docs/content/ServerOverview.mdx
+++ b/docs/content/ServerOverview.mdx
@@ -1,6 +1,8 @@
 ---
 title: Seal Server Overview
-description: Learn about different Seal server types and setup for both clients and operators.
+description: >-
+  Learn about different Seal server types and setup for both clients and
+  operators.
 keywords:
   - seal server overview
   - key server operations
@@ -12,6 +14,34 @@ keywords:
   - permissioned mode
   - server architecture
   - deployment options
+goal:
+  description: >-
+    Reader understands the two Seal server types (Decentralized and
+    Independent), their trade-offs, and can choose the right one for their
+    use case
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 200
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - What Seal server types are available?
+  - What is the difference between Decentralized and Independent Seal servers?
+  - How do I choose the right Seal server type?
+  - What is committee mode in Seal?
+answer: >-
+  Seal supports two server types: Decentralized (committee mode), where key
+  shares are distributed across multiple members with a stable onchain
+  identity and support for member rotation, and Independent, where a single
+  operator manages keys in either Open mode (all packages) or Permissioned
+  mode (per-client allowlisting).
 ---
 
 Seal supports two server types for key management: **Decentralized** (committee mode) and **Independent**.

--- a/docs/content/UsingSeal.mdx
+++ b/docs/content/UsingSeal.mdx
@@ -1,6 +1,8 @@
 ---
 title: Using Seal
-description: Learn how to protect your app and user data with Seal, including access control management, encryption, decryption, and performance optimization.
+description: >-
+  Learn how to protect your app and user data with Seal, including access
+  control management, encryption, decryption, and performance optimization.
 keywords:
   - using Seal
   - access control
@@ -12,6 +14,34 @@ keywords:
   - onchain decryption
   - performance optimization
   - envelope encryption
+goal:
+  description: >-
+    Reader can integrate Seal into their application — set up SealClient,
+    define access policies, encrypt and decrypt data, and optimize performance
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 500
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - How do I use Seal to encrypt and decrypt data?
+  - How do I set up the SealClient?
+  - How do I write a seal_approve function in Move?
+  - How does onchain decryption work with Seal?
+  - How do I optimize Seal performance with session keys?
+answer: >-
+  To use Seal, define a Move access policy with a seal_approve function, set
+  up a SealClient in TypeScript with your chosen key servers, encrypt data
+  using the client, and decrypt by constructing a programmable transaction
+  block that calls your seal_approve function. Session keys and envelope
+  encryption patterns can optimize performance for repeated operations.
 ---
 
 import SealPackageIds from './_SealPackageIds.mdx';

--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: What is Seal?
-description: Seal is a decentralized secrets management service that uses access control policies on Sui to secure sensitive data at rest on decentralized storage.
+description: >-
+  Seal is a decentralized secrets management service that uses access control
+  policies on Sui to secure sensitive data at rest on decentralized storage.
 keywords:
   - Seal
   - decentralized secrets management
@@ -15,6 +17,33 @@ keywords:
   - decentralized key server
   - committee mode key server
   - threshold encryption
+goal:
+  description: >-
+    Reader understands what Seal is, its core capabilities, supported use cases,
+    and how it fits into the Sui ecosystem
+  requires:
+    - has_frontmatter:
+        - title
+        - description
+        - keywords
+      label: Has required frontmatter fields
+    - min_words: 300
+      label: Needs more content depth
+    - has_questions: true
+      label: Needs questions for AI search visibility
+    - has_answer: true
+      label: Needs answer summary for AI citation
+questions:
+  - What is Seal?
+  - What is decentralized secrets management on Sui?
+  - How does Seal encrypt and decrypt data?
+  - What are Seal's main use cases?
+  - How does Seal use Identity-Based Encryption?
+answer: >-
+  Seal is a decentralized secrets management (DSM) service on Sui that uses
+  Identity-Based Encryption and onchain access control policies to let
+  developers encrypt sensitive data at rest on decentralized storage like
+  Walrus, with decryption gated by programmable policies validated on Sui.
 ---
 
 Seal is a decentralized secrets management (DSM) service that relies on access control policies defined and validated on [Sui](https://docs.sui.io/concepts/components). Application developers and users can use Seal to secure sensitive data at rest on decentralized storage like [Walrus](https://docs.wal.app/), or on any other onchain or off-chain storage.

--- a/docs/site/frontmatter.schema.json
+++ b/docs/site/frontmatter.schema.json
@@ -1,0 +1,164 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://seal-docs.wal.app/frontmatter.schema.json",
+  "title": "Seal docs page frontmatter",
+  "description": "Canonical schema for the YAML frontmatter on Seal documentation pages (docs/content/**/*.mdx). Validated locally via `pnpm docs:validate-frontmatter`. Unknown top-level keys are allowed (additionalProperties: true) so Docusaurus-native frontmatter fields not enumerated here don't break validation; the nested `goal` and goal-check objects are validated strictly (additionalProperties: false) because downstream tooling relies on their exact shape.",
+  "type": "object",
+  "required": ["title", "description", "keywords"],
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Page title. Rendered as the H1 and used for navigation and search."
+    },
+    "description": {
+      "type": "string",
+      "minLength": 1,
+      "description": "One-sentence summary of what this page covers."
+    },
+    "keywords": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Search keywords for this page."
+    },
+    "questions": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1 },
+      "description": "GEO/AEO: 2-5 questions this page answers. AI engines match user queries against these."
+    },
+    "answer": {
+      "type": "string",
+      "minLength": 1,
+      "description": "GEO/AEO: 1-2 sentence direct answer to the page's primary question, cited verbatim by AI engines."
+    },
+    "goal": { "$ref": "#/$defs/goal" },
+    "draft": {
+      "type": "boolean",
+      "description": "When true, the page is a draft and excluded from production builds."
+    },
+    "sidebar_label": { "type": "string" },
+    "sidebar_position": { "type": "number" },
+    "pagination_prev": { "type": ["string", "null"] },
+    "pagination_next": { "type": ["string", "null"] },
+    "hide_title": { "type": "boolean" },
+    "hide_table_of_contents": { "type": "boolean" }
+  },
+  "additionalProperties": true,
+  "$defs": {
+    "goal": {
+      "type": "object",
+      "description": "Defines what the page should achieve for the reader plus mechanically verifiable checks evaluated by the audit pipeline.",
+      "required": ["description", "requires"],
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "What the reader can do or understand after reading the page."
+        },
+        "requires": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/goalCheck" },
+          "description": "List of mechanically verifiable checks. Each check must match exactly one check type."
+        }
+      },
+      "additionalProperties": false
+    },
+    "goalCheck": {
+      "type": "object",
+      "description": "A single goal check. Every check carries a `label` (shown in failure reports) plus exactly one check-type key (enforced via oneOf).",
+      "required": ["label"],
+      "properties": {
+        "label": { "type": "string", "minLength": 1 },
+        "pattern": {
+          "type": "string",
+          "description": "Regex the body text must match at least `min` times."
+        },
+        "min": {
+          "type": "number",
+          "description": "Minimum count for `pattern`, `has_tables`, `question_headings`, `steps_present`, etc."
+        },
+        "max": { "type": "number" },
+        "headings": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              { "type": "string" },
+              {
+                "type": "object",
+                "required": ["pattern"],
+                "properties": { "pattern": { "type": "string" } },
+                "additionalProperties": false
+              }
+            ]
+          },
+          "description": "Page must have headings matching each pattern."
+        },
+        "links_to": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Page must contain links to each internal path."
+        },
+        "has_tables": {
+          "description": "Page must have at least `min` markdown tables (or a count when given as a number).",
+          "type": ["boolean", "number"]
+        },
+        "has_images": {
+          "type": "boolean",
+          "description": "Whether the page has (true) or must not have (false) images."
+        },
+        "has_frontmatter": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Frontmatter fields that must be present."
+        },
+        "min_words": {
+          "type": "number",
+          "description": "Minimum body word count (outside code blocks)."
+        },
+        "has_questions": {
+          "type": "boolean",
+          "description": "Whether the page must have (true) a questions: frontmatter block."
+        },
+        "has_answer": {
+          "type": "boolean",
+          "description": "Whether the page must have (true) an answer: frontmatter field."
+        },
+        "answer_in_intro": {
+          "type": "number",
+          "description": "Minimum words in the first paragraph so it can serve as a direct answer."
+        },
+        "question_headings": {
+          "type": "number",
+          "description": "Minimum count of question-format headings (What/How/Why...)."
+        },
+        "steps_present": {
+          "type": "number",
+          "description": "Minimum count of numbered steps for procedural content."
+        },
+        "code_explanation_ratio": {
+          "type": "number",
+          "description": "Minimum ratio of explanation to code."
+        }
+      },
+      "additionalProperties": false,
+      "oneOf": [
+        { "required": ["pattern"] },
+        { "required": ["headings"] },
+        { "required": ["links_to"] },
+        { "required": ["has_tables"] },
+        { "required": ["has_images"] },
+        { "required": ["has_frontmatter"] },
+        { "required": ["min_words"] },
+        { "required": ["has_questions"] },
+        { "required": ["has_answer"] },
+        { "required": ["answer_in_intro"] },
+        { "required": ["question_headings"] },
+        { "required": ["steps_present"] },
+        { "required": ["code_explanation_ratio"] }
+      ]
+    }
+  }
+}

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -13,7 +13,11 @@
     "clear": "docusaurus clear",
     "serve": "node src/shared/js/serve-with-rewrites.js",
     "write-translations": "docusaurus write-translations",
-    "write-heading-ids": "docusaurus write-heading-ids"
+    "write-heading-ids": "docusaurus write-heading-ids",
+    "docs:audit": "node scripts/audit-docs.mjs",
+    "docs:audit:summary": "node scripts/audit-docs.mjs --summary",
+    "docs:audit:failures": "node scripts/audit-docs.mjs --only-failures --summary",
+    "docs:validate-frontmatter": "node scripts/validate-frontmatter.mjs --summary"
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",
@@ -35,7 +39,8 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.9.2",
-    "@docusaurus/types": "3.9.2"
+    "@docusaurus/types": "3.9.2",
+    "ajv": "^8.17.1"
   },
   "browserslist": {
     "production": [

--- a/docs/site/pnpm-lock.yaml
+++ b/docs/site/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@docusaurus/types':
         specifier: 3.9.2
         version: 3.9.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
 
 packages:
 

--- a/docs/site/scripts/audit-docs.mjs
+++ b/docs/site/scripts/audit-docs.mjs
@@ -1,0 +1,459 @@
+/*
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+*/
+
+/**
+ * Deterministic docs audit pipeline.
+ *
+ * Three layers:
+ *   1. Base checks   – frontmatter, staleness, links, code fences, TODOs, word count, duplicates
+ *   2. Goal checklist – evaluates goal.requires from page frontmatter
+ *   3. GEO/AEO       – questions and answer field presence
+ *
+ * Usage:
+ *   node scripts/audit-docs.mjs                  # JSON to stdout
+ *   node scripts/audit-docs.mjs --summary        # compact table to stderr, JSON to stdout
+ *   node scripts/audit-docs.mjs --only-failures  # only pages with issues
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import matter from 'gray-matter';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SITE_ROOT = path.resolve(__dirname, '..');
+const CONTENT_ROOT = path.resolve(SITE_ROOT, '..', 'content');
+const REPO_ROOT = path.resolve(SITE_ROOT, '..', '..');
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function globMdx(dir) {
+  const results = [];
+  function walk(d) {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        if (['node_modules', '.docusaurus', 'build', 'dist'].includes(entry.name)) continue;
+        walk(full);
+      } else if (entry.name.endsWith('.mdx')) {
+        results.push(full);
+      }
+    }
+  }
+  walk(dir);
+  return results;
+}
+
+function relativeTo(filePath, root) {
+  return path.relative(root, filePath);
+}
+
+function stripCodeBlocks(text) {
+  return text.replace(/```[\s\S]*?```/g, '').replace(/`[^`\n]+`/g, '');
+}
+
+function stripFrontmatter(raw) {
+  return raw.replace(/^---[\s\S]*?---\n?/, '');
+}
+
+function countWords(text) {
+  const cleaned = stripCodeBlocks(stripFrontmatter(text));
+  const words = cleaned.match(/[a-zA-Z0-9]+/g);
+  return words ? words.length : 0;
+}
+
+function getHeadings(body) {
+  const headings = [];
+  for (const line of body.split('\n')) {
+    const m = line.match(/^(#{1,6})\s+(.*)$/);
+    if (m) {
+      headings.push({ level: m[1].length, text: m[2].trim() });
+    }
+  }
+  return headings;
+}
+
+function getGitLastModified(filePath) {
+  try {
+    const ts = execFileSync(
+      'git', ['log', '-1', '--format=%at', '--', filePath],
+      { cwd: REPO_ROOT, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+    ).trim();
+    if (!ts) return null;
+    return new Date(parseInt(ts, 10) * 1000);
+  } catch {
+    return null;
+  }
+}
+
+function daysSince(date) {
+  if (!date) return null;
+  return Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function buildDocPathSet(contentRoot) {
+  const paths = new Set();
+  const files = [];
+  function walkAll(d) {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        if (['node_modules', '.docusaurus', 'build', 'dist'].includes(entry.name)) continue;
+        walkAll(full);
+      } else if (entry.name.endsWith('.mdx') || entry.name.endsWith('.md')) {
+        files.push(full);
+      }
+    }
+  }
+  walkAll(contentRoot);
+  for (const f of files) {
+    let rel = relativeTo(f, contentRoot);
+    rel = rel.replace(/\.(mdx|md)$/, '');
+    rel = rel.replace(/\/index$/, '');
+    paths.add('/' + rel);
+  }
+  return paths;
+}
+
+// ─── Layer 1: Base Checks ───────────────────────────────────────────────────
+
+function checkFrontmatter(data) {
+  const required = ['title', 'description', 'keywords'];
+  const missing = required.filter(f => !data[f]);
+  return {
+    pass: missing.length === 0,
+    missing,
+  };
+}
+
+function checkBrokenInternalLinks(body, docPaths, filePath) {
+  const broken = [];
+  const linkRe = /\[([^\]]*)\]\((\/?[^)#\s]+)(#[^)]*)?\)/g;
+  let m;
+  while ((m = linkRe.exec(body)) !== null) {
+    const target = m[2];
+    if (target.startsWith('http://') || target.startsWith('https://')) continue;
+    if (target.startsWith('#')) continue;
+    if (target.startsWith('mailto:')) continue;
+    if (/\.\w+$/.test(target) && !target.endsWith('.mdx') && !target.endsWith('.md')) continue;
+
+    let normalized = target;
+    if (!normalized.startsWith('/')) {
+      const dir = '/' + relativeTo(path.dirname(filePath), CONTENT_ROOT);
+      normalized = path.posix.join(dir, normalized);
+    }
+    normalized = normalized.replace(/\.(mdx|md)$/, '');
+    normalized = normalized.replace(/\/index$/, '');
+
+    if (!docPaths.has(normalized)) {
+      broken.push({ text: m[1], target: m[2] });
+    }
+  }
+  return broken;
+}
+
+function checkCodeFences(body) {
+  const fences = body.match(/^```/gm) || [];
+  return {
+    pass: fences.length % 2 === 0,
+    count: fences.length,
+  };
+}
+
+function checkTodos(body) {
+  const matches = [];
+  const lines = body.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (/\b(TODO|FIXME|HACK|PLACEHOLDER|XXX)\b/i.test(lines[i])) {
+      matches.push({ line: i + 1, text: lines[i].trim() });
+    }
+  }
+  return matches;
+}
+
+function checkMissingImages(body, filePath) {
+  const missing = [];
+  const mdImgRe = /!\[[^\]]*\]\(([^)]+)\)/g;
+  const htmlImgRe = /<img\s[^>]*src=["']([^"']+)["']/g;
+
+  const checkPath = (imgPath) => {
+    if (imgPath.startsWith('http://') || imgPath.startsWith('https://')) return;
+    const resolved = imgPath.startsWith('/')
+      ? path.resolve(CONTENT_ROOT, imgPath.slice(1))
+      : path.resolve(path.dirname(filePath), imgPath);
+    if (!fs.existsSync(resolved)) {
+      missing.push(imgPath);
+    }
+  };
+
+  let m;
+  while ((m = mdImgRe.exec(body)) !== null) checkPath(m[1]);
+  while ((m = htmlImgRe.exec(body)) !== null) checkPath(m[1]);
+
+  return missing;
+}
+
+function runBaseChecks(filePath, raw, data, body, docPaths) {
+  const lastModified = getGitLastModified(filePath);
+  const staleDays = daysSince(lastModified);
+  const wordCount = countWords(raw);
+  const frontmatter = checkFrontmatter(data);
+  const brokenLinks = checkBrokenInternalLinks(body, docPaths, filePath);
+  const codeFences = checkCodeFences(body);
+  const todos = checkTodos(body);
+  const missingImages = checkMissingImages(body, filePath);
+
+  const issues = [];
+  if (!frontmatter.pass) issues.push(`Missing frontmatter: ${frontmatter.missing.join(', ')}`);
+  if (brokenLinks.length > 0) issues.push(`${brokenLinks.length} broken internal link(s)`);
+  if (!codeFences.pass) issues.push(`Unclosed code fence (${codeFences.count} backtick lines)`);
+  if (todos.length > 0) issues.push(`${todos.length} TODO/FIXME marker(s)`);
+  if (missingImages.length > 0) issues.push(`${missingImages.length} missing image(s)`);
+  if (wordCount < 100) issues.push(`Very short page (${wordCount} words)`);
+
+  const hasQuestions = Array.isArray(data.questions) && data.questions.length > 0;
+  const hasAnswer = typeof data.answer === 'string' && data.answer.trim().length > 0;
+
+  return {
+    frontmatter,
+    lastModified: lastModified ? lastModified.toISOString().slice(0, 10) : null,
+    staleDays,
+    wordCount,
+    brokenLinks,
+    codeFences,
+    todos,
+    missingImages,
+    issues,
+    geo: { hasQuestions, questionCount: hasQuestions ? data.questions.length : 0, hasAnswer },
+  };
+}
+
+function findDuplicateTitles(allPages) {
+  const titleMap = new Map();
+  for (const page of allPages) {
+    const title = page.data?.title;
+    if (!title) continue;
+    if (!titleMap.has(title)) titleMap.set(title, []);
+    titleMap.get(title).push(page.relativePath);
+  }
+  const duplicates = {};
+  for (const [title, files] of titleMap) {
+    if (files.length > 1) {
+      duplicates[title] = files;
+    }
+  }
+  return duplicates;
+}
+
+// ─── Layer 2: Goal Checklist ────────────────────────────────────────────────
+
+function evaluateGoalRequires(goal, body, data, headings) {
+  if (!goal || !goal.requires) return null;
+
+  const results = [];
+
+  for (const req of goal.requires) {
+    const result = { label: req.label || '(unlabeled)', pass: false };
+
+    if (req.pattern !== undefined && req.min !== undefined) {
+      const re = new RegExp(req.pattern, 'gi');
+      const matches = body.match(re) || [];
+      result.pass = matches.length >= req.min;
+      result.detail = `found ${matches.length}, need >= ${req.min}`;
+    } else if (req.headings) {
+      const missing = [];
+      for (const h of req.headings) {
+        const hPattern = h.pattern || h;
+        const re = new RegExp(hPattern, 'i');
+        const found = headings.some(hd => re.test(hd.text));
+        if (!found) missing.push(hPattern);
+      }
+      result.pass = missing.length === 0;
+      result.detail = missing.length > 0 ? `missing headings: ${missing.join(', ')}` : 'all present';
+    } else if (req.links_to) {
+      const missing = [];
+      for (const target of req.links_to) {
+        const escaped = target.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        const mdLink = new RegExp(`\\]\\(${escaped}`);
+        const hrefAttr = new RegExp(`href=["']${escaped}(["'#/])`);
+        if (!mdLink.test(body) && !hrefAttr.test(body)) missing.push(target);
+      }
+      result.pass = missing.length === 0;
+      result.detail = missing.length > 0 ? `missing links to: ${missing.join(', ')}` : 'all present';
+    } else if (req.has_tables !== undefined) {
+      const tableRows = (body.match(/^\|.+\|$/gm) || []).length;
+      const tableCount = Math.floor(tableRows / 3);
+      const min = typeof req.min === 'number' ? req.min : 1;
+      result.pass = tableCount >= min;
+      result.detail = `~${tableCount} table(s), need >= ${min}`;
+    } else if (req.has_images !== undefined) {
+      const hasImg = /!\[[^\]]*\]\([^)]+\)/.test(body) || /<img\s/.test(body);
+      result.pass = req.has_images ? hasImg : !hasImg;
+      result.detail = hasImg ? 'has images' : 'no images';
+    } else if (req.has_frontmatter) {
+      const missing = req.has_frontmatter.filter(f => !data[f]);
+      result.pass = missing.length === 0;
+      result.detail = missing.length > 0 ? `missing: ${missing.join(', ')}` : 'all present';
+    } else if (req.min_words !== undefined) {
+      const wc = countWords(body);
+      result.pass = wc >= req.min_words;
+      result.detail = `${wc} words, need >= ${req.min_words}`;
+    } else if (req.has_questions !== undefined) {
+      const has = Array.isArray(data.questions) && data.questions.length > 0;
+      result.pass = req.has_questions ? has : !has;
+      result.detail = !has ? 'no questions field' : `${data.questions.length} question(s)`;
+    } else if (req.has_answer !== undefined) {
+      const has = typeof data.answer === 'string' && data.answer.trim().length > 0;
+      result.pass = req.has_answer ? has : !has;
+      result.detail = has ? `${data.answer.trim().length} chars` : 'no answer field';
+    } else if (req.answer_in_intro !== undefined) {
+      const introMatch = body.match(/^([\s\S]*?)(?=^##?\s)/m);
+      const intro = introMatch ? introMatch[1] : body.slice(0, 1000);
+      const introWords = (intro.match(/[a-zA-Z0-9]+/g) || []).length;
+      const minWords = typeof req.answer_in_intro === 'number' ? req.answer_in_intro : 30;
+      result.pass = introWords >= minWords;
+      result.detail = `${introWords} words before first heading, need >= ${minWords}`;
+    } else if (req.question_headings !== undefined) {
+      const questionRe = /^(what|how|why|when|where|can|do|is|are|should|which)\b/i;
+      const qHeadings = headings.filter(h => questionRe.test(h.text));
+      const min = typeof req.question_headings === 'number' ? req.question_headings : 1;
+      result.pass = qHeadings.length >= min;
+      result.detail = `${qHeadings.length} question-style heading(s), need >= ${min}`;
+    } else if (req.steps_present !== undefined) {
+      const steps = (body.match(/^\d+\.\s/gm) || []).length;
+      const min = typeof req.steps_present === 'number' ? req.steps_present : 3;
+      result.pass = steps >= min;
+      result.detail = `${steps} numbered step(s), need >= ${min}`;
+    } else if (req.code_explanation_ratio !== undefined) {
+      const totalWords = (body.match(/[a-zA-Z0-9]+/g) || []).length;
+      const explanationWords = countWords(body);
+      const ratio = totalWords > 0 ? explanationWords / totalWords : 1;
+      const minRatio = typeof req.code_explanation_ratio === 'number' ? req.code_explanation_ratio : 0.4;
+      result.pass = ratio >= minRatio;
+      result.detail = `ratio ${ratio.toFixed(2)}, need >= ${minRatio}`;
+    }
+
+    results.push(result);
+  }
+
+  const allPass = results.every(r => r.pass);
+  return { description: goal.description || null, allPass, checks: results };
+}
+
+// ─── Main ───────────────────────────────────────────────────────────────────
+
+function main() {
+  const args = process.argv.slice(2);
+  const showSummary = args.includes('--summary');
+  const onlyFailures = args.includes('--only-failures');
+
+  const files = globMdx(CONTENT_ROOT);
+  const docPaths = buildDocPathSet(CONTENT_ROOT);
+
+  const allPages = files.map(filePath => {
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const { data, content: body } = matter(raw);
+    const relPath = relativeTo(filePath, CONTENT_ROOT);
+    return { filePath, relativePath: relPath, raw, data, body };
+  });
+
+  const pageResults = allPages.map(page => {
+    const headings = getHeadings(page.body);
+    const base = runBaseChecks(page.filePath, page.raw, page.data, page.body, docPaths);
+    const goal = evaluateGoalRequires(page.data.goal, page.body, page.data, headings);
+
+    return {
+      path: page.relativePath,
+      title: page.data.title || null,
+      base,
+      goal,
+    };
+  });
+
+  const duplicateTitles = findDuplicateTitles(allPages);
+
+  let output = {
+    summary: {
+      totalPages: pageResults.length,
+      pagesWithIssues: pageResults.filter(p => p.base.issues.length > 0).length,
+      pagesWithGoal: pageResults.filter(p => p.goal !== null).length,
+      pagesPassingGoal: pageResults.filter(p => p.goal?.allPass).length,
+      pagesFailingGoal: pageResults.filter(p => p.goal && !p.goal.allPass).length,
+      duplicateTitles: Object.keys(duplicateTitles).length > 0 ? duplicateTitles : null,
+      geo: {
+        pagesWithQuestions: pageResults.filter(p => p.base.geo?.hasQuestions).length,
+        pagesWithAnswer: pageResults.filter(p => p.base.geo?.hasAnswer).length,
+        pagesWithBoth: pageResults.filter(p => p.base.geo?.hasQuestions && p.base.geo?.hasAnswer).length,
+        pagesWithNeither: pageResults.filter(p => !p.base.geo?.hasQuestions && !p.base.geo?.hasAnswer).length,
+      },
+    },
+    pages: onlyFailures
+      ? pageResults.filter(p => p.base.issues.length > 0 || (p.goal && !p.goal.allPass))
+      : pageResults,
+  };
+
+  console.log(JSON.stringify(output, null, 2));
+
+  if (showSummary) {
+    console.error('\n── Audit Summary ──────────────────────────────────────');
+    console.error(`Total pages:       ${output.summary.totalPages}`);
+    console.error(`Pages with issues: ${output.summary.pagesWithIssues}`);
+    console.error(`Pages with goal:   ${output.summary.pagesWithGoal}`);
+    console.error(`  Passing:         ${output.summary.pagesPassingGoal}`);
+    console.error(`  Failing:         ${output.summary.pagesFailingGoal}`);
+
+    const geo = output.summary.geo;
+    console.error(`GEO/AEO readiness:`);
+    console.error(`  With questions:  ${geo.pagesWithQuestions}`);
+    console.error(`  With answer:     ${geo.pagesWithAnswer}`);
+    console.error(`  With both:       ${geo.pagesWithBoth}`);
+    console.error(`  With neither:    ${geo.pagesWithNeither}`);
+
+    if (output.summary.duplicateTitles) {
+      console.error(`\nDuplicate titles:`);
+      for (const [title, files] of Object.entries(output.summary.duplicateTitles)) {
+        console.error(`  "${title}": ${files.join(', ')}`);
+      }
+    }
+
+    const worst = [...pageResults]
+      .sort((a, b) => b.base.issues.length - a.base.issues.length)
+      .slice(0, 10)
+      .filter(p => p.base.issues.length > 0);
+
+    if (worst.length > 0) {
+      console.error('\nTop pages by issue count:');
+      for (const p of worst) {
+        console.error(`  [${p.base.issues.length}] ${p.path}`);
+        for (const issue of p.base.issues) {
+          console.error(`      - ${issue}`);
+        }
+      }
+    }
+
+    const goalFailures = pageResults.filter(p => p.goal && !p.goal.allPass);
+    if (goalFailures.length > 0) {
+      console.error('\nGoal checklist failures:');
+      for (const p of goalFailures) {
+        console.error(`  ${p.path}`);
+        for (const check of p.goal.checks.filter(c => !c.pass)) {
+          console.error(`    ✗ ${check.label}: ${check.detail}`);
+        }
+      }
+    }
+
+    console.error('──────────────────────────────────────────────────────\n');
+  }
+
+  const hasIssues = output.summary.pagesWithIssues > 0 ||
+    output.summary.pagesFailingGoal > 0;
+
+  process.exit(hasIssues ? 1 : 0);
+}
+
+main();

--- a/docs/site/scripts/validate-frontmatter.mjs
+++ b/docs/site/scripts/validate-frontmatter.mjs
@@ -1,0 +1,175 @@
+/*
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+*/
+
+/**
+ * Validate docs page frontmatter against the canonical JSON Schema
+ * (docs/site/frontmatter.schema.json).
+ *
+ * Usage:
+ *   node scripts/validate-frontmatter.mjs                 # validate all pages
+ *   node scripts/validate-frontmatter.mjs file1 file2     # validate specific files
+ *   node scripts/validate-frontmatter.mjs --summary       # human-readable summary
+ *
+ * Exit code is non-zero if any validated page fails schema validation.
+ *
+ * Files prefixed with _ (partials) are excluded from validation.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import matter from 'gray-matter';
+import Ajv from 'ajv/dist/2020.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SITE_ROOT = path.resolve(__dirname, '..');
+const CONTENT_ROOT = path.resolve(SITE_ROOT, '..', 'content');
+const SCHEMA_PATH = path.resolve(SITE_ROOT, 'frontmatter.schema.json');
+
+// Paths excluded from frontmatter validation (partials, snippets).
+const EXCLUDE_PATTERNS = [
+  /(^|\/|\\)_[^/\\]+\.mdx$/,
+];
+
+function isExcluded(relPath) {
+  return EXCLUDE_PATTERNS.some((re) => re.test(relPath));
+}
+
+function globMdx(dir) {
+  const results = [];
+  function walk(d) {
+    for (const entry of fs.readdirSync(d, { withFileTypes: true })) {
+      const full = path.join(d, entry.name);
+      if (entry.isDirectory()) {
+        if (['node_modules', '.docusaurus', 'build', 'dist'].includes(entry.name)) continue;
+        walk(full);
+      } else if (entry.name.endsWith('.mdx')) {
+        results.push(full);
+      }
+    }
+  }
+  walk(dir);
+  return results;
+}
+
+// YAML (via js-yaml/gray-matter) parses unquoted ISO timestamps into Date
+// objects. Normalize them back to ISO strings so string-typed schema fields
+// validate as authored.
+function normalizeDates(value) {
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.map(normalizeDates);
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) out[k] = normalizeDates(v);
+    return out;
+  }
+  return value;
+}
+
+function formatErrors(errors) {
+  if (!errors) return [];
+
+  const oneOfPaths = new Set(
+    errors
+      .filter((e) => e.keyword === 'oneOf' || e.keyword === 'anyOf')
+      .map((e) => e.instancePath),
+  );
+
+  const seen = new Set();
+  const out = [];
+  for (const e of errors) {
+    const loc = e.instancePath || '(root)';
+    if (
+      oneOfPaths.has(e.instancePath) &&
+      e.keyword === 'required' &&
+      e.params?.missingProperty
+    ) {
+      continue;
+    }
+
+    let msg = `${loc} ${e.message}`;
+    if (e.keyword === 'additionalProperties' && e.params?.additionalProperty) {
+      msg = `${loc} has unknown property "${e.params.additionalProperty}"`;
+    } else if (e.keyword === 'enum' && e.params?.allowedValues) {
+      msg = `${loc} ${e.message}: ${e.params.allowedValues.join(', ')}`;
+    } else if (e.keyword === 'oneOf' || e.keyword === 'anyOf') {
+      msg = `${loc} must match exactly one goal check type (one of pattern, headings, links_to, has_tables, has_images, has_frontmatter, min_words, has_questions, has_answer, answer_in_intro, question_headings, steps_present, code_explanation_ratio)`;
+    }
+    if (!seen.has(msg)) {
+      seen.add(msg);
+      out.push(msg);
+    }
+  }
+  return out;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const showSummary = args.includes('--summary');
+  const fileArgs = args.filter((a) => !a.startsWith('--'));
+
+  const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+  const ajv = new Ajv({ allErrors: true, strict: false });
+  const validate = ajv.compile(schema);
+
+  let files;
+  if (fileArgs.length > 0) {
+    files = fileArgs
+      .map((f) => path.resolve(process.cwd(), f))
+      .filter((f) => f.endsWith('.mdx') && fs.existsSync(f));
+  } else {
+    files = globMdx(CONTENT_ROOT);
+  }
+
+  const failures = [];
+  let checked = 0;
+
+  for (const filePath of files) {
+    const relPath = path.relative(CONTENT_ROOT, filePath);
+    if (isExcluded(relPath)) continue;
+
+    checked++;
+
+    let data;
+    try {
+      ({ data } = matter(fs.readFileSync(filePath, 'utf8')));
+      data = normalizeDates(data);
+    } catch (err) {
+      failures.push({ path: relPath, errors: [`frontmatter parse error: ${err.message}`] });
+      continue;
+    }
+
+    const valid = validate(data);
+    if (!valid) {
+      failures.push({ path: relPath, errors: formatErrors(validate.errors) });
+    }
+  }
+
+  const output = { checked, failed: failures.length, failures };
+
+  if (showSummary) {
+    console.error('\n── Frontmatter Schema Validation ──────────────────────');
+    console.error(`Pages checked: ${checked}`);
+    console.error(`Pages failing: ${failures.length}`);
+    if (failures.length > 0) {
+      console.error('');
+      for (const f of failures) {
+        console.error(`  ✗ ${f.path}`);
+        for (const err of f.errors) console.error(`      - ${err}`);
+      }
+    } else {
+      console.error('All pages conform to the frontmatter schema. ✓');
+    }
+    console.error('────────────────────────────────────────────────────────\n');
+  } else {
+    console.log(JSON.stringify(output, null, 2));
+  }
+
+  process.exit(failures.length > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Add frontmatter schema validation (`frontmatter.schema.json`) and two evaluation scripts (`validate-frontmatter.mjs`, `audit-docs.mjs`) matching the infrastructure used in [MystenLabs/sui/docs](https://github.com/MystenLabs/sui/tree/main/docs/site/scripts)
- Add `goal`, `questions`, and `answer` frontmatter fields to all 12 doc pages for mechanical quality checks and AI search engine optimization (GEO/AEO)
- Add 4 pnpm scripts: `docs:validate-frontmatter`, `docs:audit`, `docs:audit:summary`, `docs:audit:failures`

### Validation results
| Metric | Result |
|--------|--------|
| Schema validation | 12/12 passing |
| Goal checks | 12/12 passing |
| GEO/AEO ready (questions + answer) | 12/12 |

## Test plan
- [ ] Run `cd docs/site && pnpm docs:validate-frontmatter` — all 12 pages should pass
- [ ] Run `cd docs/site && pnpm docs:audit:summary` — 12/12 goals passing, 0 goal failures
- [ ] Run `cd docs/site && pnpm start` — verify docs site builds and renders correctly
- [ ] Spot-check frontmatter on a few pages to confirm questions/answers are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)