### PR TITLE
Integrate with SDK subscription helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,7 +2075,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_with",
- "sui-sdk-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sui-sdk-types 0.4.0",
  "sui-types",
  "typenum",
 ]
@@ -4678,13 +4678,13 @@ dependencies = [
  "serde_yaml 0.9.34+deprecated",
  "shared-crypto",
  "snap",
- "sui-crypto 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sui-crypto 0.4.0",
  "sui-move-build",
  "sui-package-alt",
- "sui-rpc 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sui-rpc 0.4.0",
  "sui-rpc-api",
  "sui-sdk",
- "sui-sdk-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sui-sdk-types 0.4.0",
  "sui-types",
  "tap",
  "temp-env",
@@ -8460,7 +8460,7 @@ dependencies = [
  "seal-sdk",
  "serde",
  "serde_json",
- "sui-sdk-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sui-sdk-types 0.4.0",
  "tokio",
 ]
 
@@ -8474,8 +8474,8 @@ dependencies = [
  "fastcrypto-tbls",
  "prost-types 0.14.4",
  "serde",
- "sui-rpc 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "sui-sdk-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sui-rpc 0.4.0",
+ "sui-sdk-types 0.4.0",
  "tokio",
  "tonic 0.14.6",
 ]
@@ -8501,10 +8501,10 @@ dependencies = [
  "sui-keys",
  "sui-move-build",
  "sui-package-alt",
- "sui-rpc 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sui-rpc 0.4.0",
  "sui-rpc-api",
  "sui-sdk",
- "sui-sdk-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sui-sdk-types 0.4.0",
  "sui-types",
  "tokio",
 ]
@@ -8550,7 +8550,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sui-sdk-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sui-sdk-types 0.4.0",
  "sui-types",
  "tracing",
 ]
@@ -9635,7 +9635,7 @@ dependencies = [
  "sui-macros",
  "sui-network",
  "sui-protocol-config",
- "sui-rpc 0.3.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-rpc 0.3.2",
  "sui-rpc-store",
  "sui-simulator",
  "sui-storage",
@@ -9655,20 +9655,6 @@ dependencies = [
  "twox-hash",
  "typed-store",
  "zstd 0.12.4",
-]
-
-[[package]]
-name = "sui-crypto"
-version = "0.3.1"
-dependencies = [
- "base64ct",
- "ed25519-dalek",
- "k256 0.13.4",
- "p256",
- "rand_core 0.6.4",
- "sha2 0.10.9",
- "signature 2.2.0",
- "sui-sdk-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -9694,7 +9680,23 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "signature 2.2.0",
- "sui-sdk-types 0.3.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-sdk-types 0.3.2",
+]
+
+[[package]]
+name = "sui-crypto"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c71cc9ba615bd3960106553d1c6affda579a8587ae0b36ffa199ce94f607fc9"
+dependencies = [
+ "base64ct",
+ "ed25519-dalek",
+ "k256 0.13.4",
+ "p256",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "signature 2.2.0",
+ "sui-sdk-types 0.4.0",
 ]
 
 [[package]]
@@ -9915,7 +9917,7 @@ dependencies = [
  "sui-http",
  "sui-indexer-alt-framework-store-traits",
  "sui-indexer-alt-metrics",
- "sui-rpc 0.3.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-rpc 0.3.2",
  "sui-types",
  "tempfile",
  "thiserror 1.0.69",
@@ -10333,7 +10335,7 @@ dependencies = [
  "sui-http",
  "sui-macros",
  "sui-protocol-config",
- "sui-rpc 0.3.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-rpc 0.3.2",
  "sui-simulator",
  "sui-storage",
  "sui-swarm-config",
@@ -10562,29 +10564,6 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.3.2"
-dependencies = [
- "base64 0.22.1",
- "bcs 0.1.6",
- "bytes",
- "futures",
- "http",
- "http-body",
- "hyper",
- "prost 0.14.4",
- "prost-types 0.14.4",
- "serde",
- "serde_json",
- "sui-sdk-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tap",
- "tokio",
- "tonic 0.14.6",
- "tonic-prost",
- "tower 0.5.3",
-]
-
-[[package]]
-name = "sui-rpc"
-version = "0.3.2"
 source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8#5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8"
 dependencies = [
  "base64 0.22.1",
@@ -10598,8 +10577,33 @@ dependencies = [
  "prost-types 0.14.4",
  "serde",
  "serde_json",
- "sui-crypto 0.3.1 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
- "sui-sdk-types 0.3.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-crypto 0.3.1",
+ "sui-sdk-types 0.3.2",
+ "tap",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-prost",
+ "tower 0.5.3",
+]
+
+[[package]]
+name = "sui-rpc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed3e2bef1c8236610fb0f32489d689c2c8ba7087917d5f2b8b842cb2a4b73ce"
+dependencies = [
+ "base64 0.22.1",
+ "bcs 0.1.6",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "hyper",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
+ "serde",
+ "serde_json",
+ "sui-sdk-types 0.4.0",
  "tap",
  "tokio",
  "tonic 0.14.6",
@@ -10634,7 +10638,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sui-config",
- "sui-crypto 0.3.1 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-crypto 0.3.1",
  "sui-display",
  "sui-http",
  "sui-inverted-index",
@@ -10642,9 +10646,9 @@ dependencies = [
  "sui-name-service",
  "sui-package-resolver",
  "sui-protocol-config",
- "sui-rpc 0.3.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-rpc 0.3.2",
  "sui-rpc-cursor",
- "sui-sdk-types 0.3.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-sdk-types 0.3.2",
  "sui-transaction-builder",
  "sui-transaction-checks",
  "sui-types",
@@ -10722,14 +10726,14 @@ dependencies = [
  "serde_with",
  "shared-crypto",
  "sui-config",
- "sui-crypto 0.3.1 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-crypto 0.3.1",
  "sui-json",
  "sui-json-rpc-api",
  "sui-json-rpc-types",
  "sui-keys",
- "sui-rpc 0.3.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-rpc 0.3.2",
  "sui-rpc-api",
- "sui-sdk-types 0.3.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-sdk-types 0.3.2",
  "sui-transaction-builder",
  "sui-types",
  "thiserror 1.0.69",
@@ -10753,6 +10757,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.3.2"
+source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8#5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8"
 dependencies = [
  "base64ct",
  "bcs 0.1.6",
@@ -10772,8 +10777,9 @@ dependencies = [
 
 [[package]]
 name = "sui-sdk-types"
-version = "0.3.2"
-source = "git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8#5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c4cf4b8ba51ccb8c8f77405e6b50025ccfe174e06e09b0a542ccbc3f224af5"
 dependencies = [
  "base64ct",
  "bcs 0.1.6",
@@ -10895,7 +10901,7 @@ dependencies = [
  "sui-config",
  "sui-json-rpc-types",
  "sui-protocol-config",
- "sui-rpc 0.3.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-rpc 0.3.2",
  "sui-types",
  "tap",
  "telemetry-subscribers",
@@ -11104,8 +11110,8 @@ dependencies = [
  "sui-enum-compat-util",
  "sui-macros",
  "sui-protocol-config",
- "sui-rpc 0.3.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
- "sui-sdk-types 0.3.2 (git+https://github.com/MystenLabs/sui-rust-sdk.git?rev=5781b718f2dbe43c8ce3de6f84fbd82c90f52aa8)",
+ "sui-rpc 0.3.2",
+ "sui-sdk-types 0.3.2",
  "tap",
  "thiserror 1.0.69",
  "tonic 0.14.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9660,8 +9660,6 @@ dependencies = [
 [[package]]
 name = "sui-crypto"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b8f54c4405002c9ece67cb848479f80837185a55a59d8c0a105240f737d0da"
 dependencies = [
  "base64ct",
  "ed25519-dalek",
@@ -10564,8 +10562,6 @@ dependencies = [
 [[package]]
 name = "sui-rpc"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "617504d5c6b748af0494b73db80fb893840522329788c48c826d8298e7edb0aa"
 dependencies = [
  "base64 0.22.1",
  "bcs 0.1.6",
@@ -10757,8 +10753,6 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22266119e43d3da1a8bc9945c8b569a513e7682f561265d70ef8b6e198dd664"
 dependencies = [
  "base64ct",
  "bcs 0.1.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,9 @@ sui-package-alt = { git = "https://github.com/mystenlabs/sui", rev = "6f6f095c24
 sui-rpc-api = { git = "https://github.com/mystenlabs/sui", rev = "6f6f095c246733e7b155abebb63a4e64d64e17b9", package = "sui-rpc-api" }
 sui_keys = { git = "https://github.com/mystenlabs/sui", rev = "6f6f095c246733e7b155abebb63a4e64d64e17b9", package = "sui-keys" }
 
-sui-sdk-types = { version = "0.3.2", features = ["serde"] }
-sui-rpc = "0.3.2"
-sui-crypto = { version = "0.3.1", features = ["ed25519", "secp256k1", "secp256r1", "passkey"] }
+sui-sdk-types = { path = "/Users/nick/workplace/sui-rust-sdk/worktrees/resumption/crates/sui-sdk-types", features = ["serde"] }
+sui-rpc = { path = "/Users/nick/workplace/sui-rust-sdk/worktrees/resumption/crates/sui-rpc" }
+sui-crypto = { path = "/Users/nick/workplace/sui-rust-sdk/worktrees/resumption/crates/sui-crypto", features = ["ed25519", "secp256k1", "secp256r1", "passkey"] }
 
 [profile.release]
 panic = 'abort'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,9 @@ sui-package-alt = { git = "https://github.com/mystenlabs/sui", rev = "6f6f095c24
 sui-rpc-api = { git = "https://github.com/mystenlabs/sui", rev = "6f6f095c246733e7b155abebb63a4e64d64e17b9", package = "sui-rpc-api" }
 sui_keys = { git = "https://github.com/mystenlabs/sui", rev = "6f6f095c246733e7b155abebb63a4e64d64e17b9", package = "sui-keys" }
 
-sui-sdk-types = { path = "/Users/nick/workplace/sui-rust-sdk/worktrees/resumption/crates/sui-sdk-types", features = ["serde"] }
-sui-rpc = { path = "/Users/nick/workplace/sui-rust-sdk/worktrees/resumption/crates/sui-rpc" }
-sui-crypto = { path = "/Users/nick/workplace/sui-rust-sdk/worktrees/resumption/crates/sui-crypto", features = ["ed25519", "secp256k1", "secp256r1", "passkey"] }
+sui-sdk-types = { version = "0.4.0", features = ["serde"] }
+sui-rpc = "0.4.0"
+sui-crypto = { version = "0.4.0", features = ["ed25519", "secp256k1", "secp256r1", "passkey"] }
 
 [profile.release]
 panic = 'abort'

--- a/Dockerfile.aggregator
+++ b/Dockerfile.aggregator
@@ -1,9 +1,9 @@
 # Start with a Rust base image
-FROM rust:1.90-bullseye  AS builder
+FROM rust:1.90-trixie AS builder
 
 ARG PROFILE=release
 
-WORKDIR work
+WORKDIR /work
 
 COPY ./crates ./crates
 COPY ./Cargo.toml ./Cargo.lock ./
@@ -20,7 +20,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
     cargo build --bin aggregator-server --profile $PROFILE --config net.git-fetch-with-cli=true \
     && cp /work/target/release/aggregator-server /work/aggregator-server
 
-FROM debian:bullseye-slim AS runtime
+FROM debian:trixie-slim AS runtime
 
 EXPOSE 2024
 

--- a/crates/key-server/src/metrics.rs
+++ b/crates/key-server/src/metrics.rs
@@ -10,6 +10,11 @@ use prometheus::{
 };
 use std::sync::Arc;
 use std::time::Instant;
+use sui_rpc::client::{
+    LedgerStreamEvent, LedgerStreamFamily, LedgerStreamOperation, LedgerStreamStage,
+};
+use tonic::Code;
+use tracing::{error, info, warn};
 
 /// Known valid routes for metrics labeling.
 /// Any route not in this list will be normalized to "unknown" to prevent
@@ -70,6 +75,8 @@ pub struct KeyServerMetrics {
 
     /// Sui RPC request duration by label
     pub sui_rpc_request_duration_millis: HistogramVec,
+    /// Resumable ledger stream retries, recoveries, and interruptions
+    sui_ledger_stream_state_transitions_total: IntCounterVec,
 
     /// Dry run gas cost per package
     pub dry_run_gas_cost_per_package: HistogramVec,
@@ -174,6 +181,13 @@ impl KeyServerMetrics {
                 registry
             )
             .unwrap(),
+            sui_ledger_stream_state_transitions_total: register_int_counter_vec_with_registry!(
+                "sui_ledger_stream_state_transitions_total",
+                "Sui resumable ledger stream retries, recoveries, and interruptions",
+                &["family", "event", "status"],
+                registry
+            )
+            .unwrap(),
             dry_run_gas_cost_per_package: register_histogram_vec_with_registry!(
                 "dry_run_gas_cost_per_package",
                 "Dry run gas cost per package",
@@ -225,6 +239,214 @@ impl KeyServerMetrics {
 
     pub fn observe_error(&self, error_type: &str) {
         self.errors.with_label_values(&[error_type]).inc();
+    }
+
+    pub fn observe_ledger_stream_event(&self, event: LedgerStreamEvent) {
+        match event {
+            LedgerStreamEvent::RpcResponse {
+                family,
+                operation,
+                code,
+                elapsed,
+                ..
+            } => {
+                self.sui_rpc_request_duration_millis
+                    .with_label_values(&[
+                        ledger_stream_rpc_method(family, operation),
+                        grpc_code_label(code),
+                    ])
+                    .observe(elapsed.as_secs_f64() * 1_000.0);
+            }
+            LedgerStreamEvent::RetryScheduled {
+                family,
+                operation,
+                stage,
+                status,
+                consecutive_failures,
+                delay,
+                ..
+            } => {
+                self.observe_ledger_stream_transition(
+                    family,
+                    "retry_scheduled",
+                    grpc_code_label(status.code()),
+                );
+                warn!(
+                    family = ledger_stream_family_label(family),
+                    operation = ledger_stream_operation_label(operation),
+                    stage = ledger_stream_stage_label(stage),
+                    code = grpc_code_label(status.code()),
+                    status_message = status.message(),
+                    consecutive_failures,
+                    delay_ms = delay.as_secs_f64() * 1_000.0,
+                    "Sui ledger stream retry scheduled"
+                );
+            }
+            LedgerStreamEvent::RetryRecovered {
+                family,
+                operation,
+                started_in,
+                consecutive_failures,
+                elapsed,
+                ..
+            } => {
+                self.observe_ledger_stream_transition(family, "retry_recovered", "ok");
+                info!(
+                    family = ledger_stream_family_label(family),
+                    operation = ledger_stream_operation_label(operation),
+                    started_in = ledger_stream_stage_label(started_in),
+                    consecutive_failures,
+                    elapsed_ms = elapsed.as_secs_f64() * 1_000.0,
+                    "Sui ledger stream retry recovered"
+                );
+            }
+            LedgerStreamEvent::SubscriptionStreamInterrupted {
+                family,
+                stage,
+                status,
+                ..
+            } => {
+                self.observe_ledger_stream_transition(
+                    family,
+                    "subscription_interrupted",
+                    grpc_code_label(status.code()),
+                );
+                warn!(
+                    family = ledger_stream_family_label(family),
+                    stage = ledger_stream_stage_label(stage),
+                    code = grpc_code_label(status.code()),
+                    status_message = status.message(),
+                    "Sui ledger subscription interrupted"
+                );
+            }
+            LedgerStreamEvent::GapRecoveryStarted { family, .. } => {
+                self.observe_ledger_stream_transition(family, "gap_recovery_started", "none");
+                info!(
+                    family = ledger_stream_family_label(family),
+                    "Sui ledger stream gap recovery started"
+                );
+            }
+            LedgerStreamEvent::SubscriptionBufferLimitReached {
+                family,
+                buffered_items,
+                limit,
+                ..
+            } => {
+                self.observe_ledger_stream_transition(family, "buffer_limit_reached", "none");
+                warn!(
+                    family = ledger_stream_family_label(family),
+                    buffered_items, limit, "Sui ledger stream buffer limit reached"
+                );
+            }
+            LedgerStreamEvent::TerminalError { family, status, .. } => {
+                self.observe_ledger_stream_transition(
+                    family,
+                    "terminal_error",
+                    grpc_code_label(status.code()),
+                );
+                error!(
+                    family = ledger_stream_family_label(family),
+                    code = grpc_code_label(status.code()),
+                    status_message = status.message(),
+                    "Sui ledger stream terminated"
+                );
+            }
+            _ => {}
+        }
+    }
+
+    fn observe_ledger_stream_transition(
+        &self,
+        family: LedgerStreamFamily,
+        event: &'static str,
+        status: &'static str,
+    ) {
+        self.sui_ledger_stream_state_transitions_total
+            .with_label_values(&[ledger_stream_family_label(family), event, status])
+            .inc();
+    }
+}
+
+fn ledger_stream_family_label(family: LedgerStreamFamily) -> &'static str {
+    match family {
+        LedgerStreamFamily::Checkpoint => "checkpoint",
+        LedgerStreamFamily::Transaction => "transaction",
+        LedgerStreamFamily::Event => "event",
+        _ => "unknown",
+    }
+}
+
+fn ledger_stream_operation_label(operation: LedgerStreamOperation) -> &'static str {
+    match operation {
+        LedgerStreamOperation::List => "list",
+        LedgerStreamOperation::GetServiceInfo => "get_service_info",
+        LedgerStreamOperation::Subscribe => "subscribe",
+        _ => "unknown",
+    }
+}
+
+fn ledger_stream_stage_label(stage: LedgerStreamStage) -> &'static str {
+    match stage {
+        LedgerStreamStage::List => "list",
+        LedgerStreamStage::InitialReplay => "initial_replay",
+        LedgerStreamStage::LiveTipStartup => "live_tip_startup",
+        LedgerStreamStage::PollingBaseline => "polling_baseline",
+        LedgerStreamStage::PollingTail => "polling_tail",
+        LedgerStreamStage::GapRecovery => "gap_recovery",
+        LedgerStreamStage::LiveSubscription => "live_subscription",
+        _ => "unknown",
+    }
+}
+
+fn ledger_stream_rpc_method(
+    family: LedgerStreamFamily,
+    operation: LedgerStreamOperation,
+) -> &'static str {
+    match (family, operation) {
+        (LedgerStreamFamily::Checkpoint, LedgerStreamOperation::List) => "stream_checkpoints_list",
+        (LedgerStreamFamily::Checkpoint, LedgerStreamOperation::GetServiceInfo) => {
+            "stream_checkpoints_get_service_info"
+        }
+        (LedgerStreamFamily::Checkpoint, LedgerStreamOperation::Subscribe) => {
+            "stream_checkpoints_subscribe"
+        }
+        (LedgerStreamFamily::Transaction, LedgerStreamOperation::List) => {
+            "stream_transactions_list"
+        }
+        (LedgerStreamFamily::Transaction, LedgerStreamOperation::GetServiceInfo) => {
+            "stream_transactions_get_service_info"
+        }
+        (LedgerStreamFamily::Transaction, LedgerStreamOperation::Subscribe) => {
+            "stream_transactions_subscribe"
+        }
+        (LedgerStreamFamily::Event, LedgerStreamOperation::List) => "stream_events_list",
+        (LedgerStreamFamily::Event, LedgerStreamOperation::GetServiceInfo) => {
+            "stream_events_get_service_info"
+        }
+        (LedgerStreamFamily::Event, LedgerStreamOperation::Subscribe) => "stream_events_subscribe",
+        _ => "stream_unknown",
+    }
+}
+
+fn grpc_code_label(code: Code) -> &'static str {
+    match code {
+        Code::Ok => "ok",
+        Code::Cancelled => "cancelled",
+        Code::Unknown => "unknown",
+        Code::InvalidArgument => "invalid_argument",
+        Code::DeadlineExceeded => "deadline_exceeded",
+        Code::NotFound => "not_found",
+        Code::AlreadyExists => "already_exists",
+        Code::PermissionDenied => "permission_denied",
+        Code::ResourceExhausted => "resource_exhausted",
+        Code::FailedPrecondition => "failed_precondition",
+        Code::Aborted => "aborted",
+        Code::OutOfRange => "out_of_range",
+        Code::Unimplemented => "unimplemented",
+        Code::Internal => "internal",
+        Code::Unavailable => "unavailable",
+        Code::DataLoss => "data_loss",
+        Code::Unauthenticated => "unauthenticated",
     }
 }
 

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -844,6 +844,10 @@ impl Server {
         tokio::spawn(async move {
             info!("Committee rotation event monitor task started");
 
+            let stream_config = sui_rpc_client.ledger_stream_config().with_observer({
+                let metrics = metrics.clone();
+                move |event| metrics.observe_ledger_stream_event(event)
+            });
             let mut next_stream_start = EventStreamStart::Tip;
             loop {
                 // Fetch current committee ID and package ID from key server object.
@@ -884,15 +888,11 @@ impl Server {
 
                 // Follow rotation events from the current tip. The logical stream repairs
                 // subscription gaps with ListEvents and keeps retrying transient failures.
-                let stream_config = sui_rpc_client.ledger_stream_config().with_observer({
-                    let metrics = metrics.clone();
-                    move |event| metrics.observe_ledger_stream_event(event)
-                });
                 let mut stream = sui_rpc_client.subscribe_events(
                     event_filter,
                     &["contents", "checkpoint", "transaction_index", "event_index"],
                     next_stream_start.clone(),
-                    stream_config,
+                    stream_config.clone(),
                 );
 
                 info!("Committee rotation event subscription established");

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -29,7 +29,7 @@ use errors::InternalError;
 use fastcrypto::ed25519::Ed25519Signature;
 use fastcrypto::encoding::{Encoding, Hex};
 use fastcrypto::traits::VerifyingKey;
-use futures::future::pending;
+use futures::{future::pending, StreamExt};
 use key_server::sui_rpc_client::{build_grpc_client, SuiRpcClient};
 use key_server_options::KeyServerOptions;
 use master_keys::{CommitteeKeyState, MasterKeys};
@@ -53,6 +53,7 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, RwLock};
 use sui_crypto::{UserSignatureVerifier, Verifier};
+use sui_rpc::client::EventStreamStart;
 use sui_rpc::proto::sui::rpc::v2::execution_error::ExecutionErrorKind;
 use sui_rpc::proto::sui::rpc::v2::{filter, Event, EventFilter};
 use sui_sdk_types::{
@@ -841,6 +842,9 @@ impl Server {
 
         // Spawn the background task that subscribes to rotation events.
         tokio::spawn(async move {
+            info!("Committee rotation event monitor task started");
+
+            let mut next_stream_start = EventStreamStart::Tip;
             loop {
                 // Fetch current committee ID and package ID from key server object.
                 let (committee_id, committee_pkg_id) = match sui_rpc_client
@@ -878,23 +882,29 @@ impl Server {
                 };
                 let event_filter = rotation_event_filter(&event_pkg_id);
 
-                // Subscribe to new rotation events from the current chain tip.
-                let mut stream = match sui_rpc_client
-                    .subscribe_events(event_filter, &["contents"])
-                    .await
-                {
-                    Ok(stream) => stream,
-                    Err(e) => {
-                        warn!("Failed to subscribe to committee rotation events: {}", e);
-                        tokio::time::sleep(EVENT_MONITOR_RETRY_DELAY).await;
-                        continue;
-                    }
-                };
+                // Follow rotation events from the current tip. The logical stream repairs
+                // subscription gaps with ListEvents and keeps retrying transient failures.
+                let stream_config = sui_rpc_client.ledger_stream_config().with_observer({
+                    let metrics = metrics.clone();
+                    move |event| metrics.observe_ledger_stream_event(event)
+                });
+                let mut stream = sui_rpc_client.subscribe_events(
+                    event_filter,
+                    &[
+                        "contents",
+                        "checkpoint",
+                        "transaction_index",
+                        "event_index",
+                    ],
+                    next_stream_start.clone(),
+                    stream_config,
+                );
 
                 info!("Committee rotation event subscription established");
                 loop {
-                    match stream.message().await {
-                        Ok(Some(frame)) => {
+                    match stream.next().await {
+                        Some(Ok(frame)) => {
+                            next_stream_start = EventStreamStart::Resume(frame.cursor.clone());
                             if let Some(event) = &frame.event {
                                 handle_rotation_event(event, &committee_id, &metrics);
                                 // The rotation changes the committee id (and possibly
@@ -903,12 +913,12 @@ impl Server {
                                 break;
                             }
                         }
-                        Ok(None) => {
-                            warn!("Committee rotation event subscription ended");
+                        Some(Err(e)) => {
+                            warn!("Committee rotation event subscription error: {}", e);
                             break;
                         }
-                        Err(e) => {
-                            warn!("Committee rotation event subscription error: {}", e);
+                        None => {
+                            warn!("Committee rotation event subscription ended");
                             break;
                         }
                     }

--- a/crates/key-server/src/server.rs
+++ b/crates/key-server/src/server.rs
@@ -890,12 +890,7 @@ impl Server {
                 });
                 let mut stream = sui_rpc_client.subscribe_events(
                     event_filter,
-                    &[
-                        "contents",
-                        "checkpoint",
-                        "transaction_index",
-                        "event_index",
-                    ],
+                    &["contents", "checkpoint", "transaction_index", "event_index"],
                     next_stream_start.clone(),
                     stream_config,
                 );

--- a/crates/key-server/src/sui_rpc_client.rs
+++ b/crates/key-server/src/sui_rpc_client.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Shared gRPC client wrapper used by both the key-server and aggregator binaries.
-//! All public methods retry via [`sui_rpc_with_retries`] and observe per-call
-//! metrics through the optional `sui_rpc_request_duration_millis` histogram.
+//! Unary methods retry via [`sui_rpc_with_retries`]; ledger streams use the SDK's
+//! resumable retry and gap-recovery state machine.
 
+use futures::stream::BoxStream;
+use futures::StreamExt;
 use prometheus::HistogramVec;
 use prost_types::FieldMask;
 use seal_committee::grpc_helper::{
@@ -20,13 +22,13 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use sui_rpc::client::Client as SuiGrpcClient;
 use sui_rpc::client::HeadersInterceptor;
+use sui_rpc::client::{EventStreamFrame, EventStreamRequest, EventStreamStart, LedgerStreamConfig};
 use sui_rpc::field::FieldMaskUtil;
 use sui_rpc::proto::sui::rpc::v2::transaction_kind::Data as TransactionKindData;
 use sui_rpc::proto::sui::rpc::v2::{
     Bcs, EventFilter, GetEpochRequest, GetObjectRequest, GetPackageRequest,
     ListPackageVersionsRequest, SimulateTransactionRequest, SimulateTransactionResponse,
-    SubscribeEventsRequest, SubscribeEventsResponse, Transaction, UserSignature,
-    VerifySignatureRequest,
+    Transaction, UserSignature, VerifySignatureRequest,
 };
 use sui_sdk_types::Address;
 
@@ -246,6 +248,16 @@ impl SuiRpcClient {
     /// Returns a clone of the request-duration histogram (if any).
     pub fn request_duration_millis(&self) -> Option<HistogramVec> {
         self.request_duration_millis.clone()
+    }
+    /// Builds stream retry settings from this client's retry delays.
+    ///
+    /// Ledger streams recover indefinitely; `RetryConfig::max_retries` applies only to
+    /// finite unary RPC calls.
+    pub fn ledger_stream_config(&self) -> LedgerStreamConfig {
+        let mut config = LedgerStreamConfig::default();
+        config.base_retry_delay = self.rpc_retry_config.min_delay;
+        config.max_retry_delay = self.rpc_retry_config.max_delay;
+        config
     }
 
     /// Call grpc through retry and metrics.
@@ -505,30 +517,22 @@ impl SuiRpcClient {
         .await
     }
 
-    /// Subscribes to events matching `filter` via the fullnode's gRPC event
-    /// subscription and returns the response stream. `read_mask_paths` selects
-    /// the `Event` fields present on each frame.
-    pub async fn subscribe_events(
+    /// Streams events matching `filter` through the SDK's resumable Subscribe/List
+    /// state machine.
+    pub fn subscribe_events(
         &self,
         filter: EventFilter,
         read_mask_paths: &[&str],
-    ) -> RpcResult<tonic::Streaming<SubscribeEventsResponse>> {
-        let request = SubscribeEventsRequest::default()
+        start: EventStreamStart,
+        config: LedgerStreamConfig,
+    ) -> BoxStream<'static, Result<EventStreamFrame, tonic::Status>> {
+        let request = EventStreamRequest::new()
             .with_read_mask(FieldMask::from_paths(read_mask_paths))
-            .with_filter(filter);
-
-        self.run_grpc_with_retries("subscribe_events", move |mut grpc_client| {
-            let request = request.clone();
-            async move {
-                grpc_client
-                    .subscription_client()
-                    .subscribe_events(request)
-                    .await
-                    .map(|r| r.into_inner())
-                    .map_err(RpcError::from_grpc)
-            }
-        })
-        .await
+            .with_filter(filter)
+            .with_start(start);
+        self.sui_grpc_client
+            .stream_events_with_config(request, config)
+            .boxed()
     }
 
     /// Returns the current reference gas price via gRPC.


### PR DESCRIPTION
## Description

I added some subscription helpers to the SDK to manage automatically re-connecting if the stream drops for any reason (gateway connection reaping, full node restarts, etc) and backfilling the gap of what was missed while the stream was disconnected.

This PR replaces Seal's subscriptions with those resuming streams.

Right now it's a draft because the SDK changes haven't actually landed. That PR is here. <https://github.com/MystenLabs/sui-rust-sdk/pull/307>

## Test plan

How did you test the new or updated feature?
