### PR TITLE
[move] Add verify_derived_keys_for_key_servers

### DIFF
--- a/docs/content/UsingSeal.mdx
+++ b/docs/content/UsingSeal.mdx
@@ -386,15 +386,16 @@ To decrypt an encrypted object in a Move package, follow these steps:
 - **Verify derived keys**
     - Use the Seal SDK client to fetch derived keys through `client.getDerivedKeys`, which returns a map of key server object IDs to their derived keys.
     - Convert bytes to `Element<G1>` or `Element<G2>` with [`from_bytes`](https://docs.sui.io/references/framework/sui/group_ops#sui_group_ops_from_bytes).
-    - Call `bf_hmac_encryption::verify_derived_keys` with the raw keys, package ID, identity, and the vector of key server public keys.
-    - The function returns a vector of `VerifiedDerivedKey` objects.          
+    - Call `bf_hmac_encryption::verify_derived_keys_for_key_servers` with the raw keys, the IDs of the key servers that derived them, the package ID, the identity, and the vector of pinned public keys. Each derived key is matched with the public key of the key server that derived it, so the public keys may be given in any order and may cover key servers that did not provide a derived key. The same vector of public keys can then be passed to `decrypt`.
+    - `bf_hmac_encryption::verify_derived_keys` does the same, but expects the derived keys and the public keys to be given in matching order, and no others. Pairing them is then up to the caller.
+    - Both functions return a vector of `VerifiedDerivedKey` objects.
 - **Perform decryption**
     - Call `bf_hmac_encryption::decrypt` with the encrypted object, the verified derived keys, and the vector of pinned public keys.
     - The function returns an `Option<vector<u8>>`. If decryption fails, the return value will be `None`.
 
 :::warning[Public keys are a trusted input]
 
-Seal cannot tell a genuine key server public key from one an attacker made up: `new_public_key` wraps whatever bytes it is given, and `verify_derived_keys` only checks a derived key against the public key passed next to it. An attacker supplying both halves of their own key pair passes both checks and gets back a plaintext of their choosing. The share consistency check inside `decrypt` is no substitute - it covers only key servers without a supplied derived key, so it passes trivially when one derived key per key server is given.
+Seal cannot tell a genuine key server public key from one an attacker made up: `new_public_key` wraps whatever bytes it is given, and the `verify_derived_keys*` functions only check a derived key against the public key it is paired with. An attacker supplying both halves of their own key pair passes both checks and gets back a plaintext of their choosing. The share consistency check inside `decrypt` is no substitute - it covers only key servers without a supplied derived key, so it passes trivially when one derived key per key server is given.
 
 Your package must therefore supply the public keys itself, from hardcoded constants or an object it controls:
 
@@ -433,61 +434,57 @@ const derivedKeys = await client.getDerivedKeys({
   threshold: encryptedObject.threshold,
 });
 
-// 3. Get the public keys corresponding to the derived keys.
-// In practice, this should be done only during the app initialization.
-const publicKeys = await client.getPublicKeys(encryptedObject.services.map(([service, _]) => service));
-const correspondingPublicKeys = derivedKeys.keys().map((objectId) => {
-  const index = encryptedObject.services.findIndex(([s, _]) => s === objectId);
-  return tx.moveCall({
-    target: `${seal_package_id}::bf_hmac_encryption::new_public_key`,
+// 3. Construct the public keys of all key servers of the encrypted object.
+// In practice, the public keys should be pinned during the app initialization.
+const services = encryptedObject.services.map(([service, _]) => service);
+const publicKeys = await client.getPublicKeys(services);
+const publicKeysVector = tx.makeMoveVec({
+  elements: publicKeys.map((publicKey, i) => tx.moveCall({
+    target: `${SEAL_PACKAGE_ID}::bf_hmac_encryption::new_public_key`,
     arguments: [
-      tx.pure.address(objectId),
-      tx.pure.vector("u8", publicKeys[index].toBytes())
+      tx.pure.address(services[i]),
+      tx.pure.vector("u8", publicKey.toBytes()),
     ],
-  });
-}).toArray();
+  })),
+  type: `${SEAL_PACKAGE_ID}::bf_hmac_encryption::PublicKey`,
+});
 
-// 4. Convert the derived keys to G1 elements.
-const derivedKeysAsG1Elements = Array.from(derivedKeys).map(([_, value]) =>
-tx.moveCall({
-  target: `0x2::bls12381::g1_from_bytes`,
-  arguments: [ tx.pure.vector("u8", fromHex(value.toString())) ],
-})
+// 4. Convert the derived keys to G1 elements, keeping the key server IDs in the same order.
+const keyServerIds = Array.from(derivedKeys.keys());
+const derivedKeysAsG1Elements = keyServerIds.map((keyServerId) =>
+  tx.moveCall({
+    target: `0x2::bls12381::g1_from_bytes`,
+    arguments: [ tx.pure.vector("u8", fromHex(derivedKeys.get(keyServerId).toString())) ],
+  })
 );
 
-// 5. Call the Move function verify_derived_keys. This should be cached if decryption for the same ID is performed again. 
+// 5. Call the Move function verify_derived_keys_for_key_servers. The public keys are matched to the
+// derived keys by key server ID, so the same vector can be reused in step 7. This should be cached
+// if decryption for the same ID is performed again.
 const verifiedDerivedKeys = tx.moveCall({
-  target: `${seal_package_id}::bf_hmac_encryption::verify_derived_keys`,
+  target: `${SEAL_PACKAGE_ID}::bf_hmac_encryption::verify_derived_keys_for_key_servers`,
   arguments: [
-  tx.makeMoveVec({ elements: derivedKeysAsG1Elements, type: '0x2::group_ops::Element<0x2::bls12381::G1>' }),
-  tx.pure.address(encryptedObject.packageId),
-  tx.pure.vector("u8", fromHex(encryptedObject.id)),
-    tx.makeMoveVec({ elements: correspondingPublicKeys, type: `${SEAL_PACKAGE_ID}::bf_hmac_encryption::PublicKey` }),
+    tx.makeMoveVec({ elements: derivedKeysAsG1Elements, type: '0x2::group_ops::Element<0x2::bls12381::G1>' }),
+    tx.pure.vector("address", keyServerIds),
+    tx.pure.address(encryptedObject.packageId),
+    tx.pure.vector("u8", fromHex(encryptedObject.id)),
+    publicKeysVector,
   ],
 });
 
 // 6. Construct the parsed encrypted object onchain.
 const parsedEncryptedObject = tx.moveCall({
-  target: `${seal_package_id}::bf_hmac_encryption::parse_encrypted_object`,
+  target: `${SEAL_PACKAGE_ID}::bf_hmac_encryption::parse_encrypted_object`,
   arguments: [tx.pure.vector("u8", encryptedBytes)],
 });
 
-// 7. Construct a list of public key objects. 
-const allPublicKeys = publicKeys.map((publicKey, i) => tx.moveCall({
-  target: `${seal_package_id}::bf_hmac_encryption::new_public_key`,
-  arguments: [
-    tx.pure.address(encryptedObject.services[i][0]),
-    tx.pure.vector("u8", publicKey.toBytes())
-  ],
-}));
-
-// 8. Perform decryption with verified derived keys. 
+// 7. Perform decryption with verified derived keys. 
 const decrypted = tx.moveCall({
-  target: `${seal_package_id}::bf_hmac_encryption::decrypt`,
+  target: `${SEAL_PACKAGE_ID}::bf_hmac_encryption::decrypt`,
   arguments: [
     parsedEncryptedObject,
     verifiedDerivedKeys,
-    tx.makeMoveVec({ elements: allPublicKeys, type: `${SEAL_PACKAGE_ID}::bf_hmac_encryption::PublicKey` }),
+    publicKeysVector,
   ],
 });
 

--- a/move/patterns/sources/voting.move
+++ b/move/patterns/sources/voting.move
@@ -19,7 +19,7 @@ use seal::bf_hmac_encryption::{
     PublicKey,
     decrypt,
     new_public_key,
-    verify_derived_keys,
+    verify_derived_keys_for_key_servers,
     parse_encrypted_object,
 };
 use sui::bls12381::g1_from_bytes;
@@ -153,21 +153,18 @@ public fun finalize_vote(
     assert!(key_servers.length() == derived_keys.length());
     assert!(derived_keys.length() as u8 >= vote.threshold, ENotEnoughKeys);
 
-    // Public keys for the given derived keys
-    // Verify the derived keys
-    let verified_derived_keys: vector<VerifiedDerivedKey> = verify_derived_keys(
-        &derived_keys.map_ref!(|k| g1_from_bytes(k)),
-        @0x0,
-        vote.id(),
-        &key_servers
-            .map_ref!(|ks1| vote.key_servers.find_index!(|ks2| ks1 == ks2).destroy_some())
-            .map!(|i| new_public_key(vote.key_servers[i].to_id(), vote.public_keys[i])),
-    );
-
-    // Public keys for all key servers
-    let all_public_keys: vector<PublicKey> = vote
+    // The public keys of all key servers, as they were pinned when the vote was created.
+    let public_keys: vector<PublicKey> = vote
         .key_servers
         .zip_map!(vote.public_keys, |ks, pk| new_public_key(ks.to_id(), pk));
+
+    let verified_derived_keys: vector<VerifiedDerivedKey> = verify_derived_keys_for_key_servers(
+        &derived_keys.map_ref!(|k| g1_from_bytes(k)),
+        &key_servers.map_ref!(|ks| (*ks).to_id()),
+        @0x0,
+        vote.id(),
+        &public_keys,
+    );
 
     // This aborts if there are not enough keys or if they are invalid, e.g. if they were derived for a different purpose.
     // However, in case the keys are valid but some of the encrypted objects, aka the votes, are invalid, decrypt will just return none for these votes.
@@ -176,7 +173,7 @@ public fun finalize_vote(
         .votes
         .do_ref!(
             |v| v
-                .and_ref!(|v| decrypt(v, &verified_derived_keys, &all_public_keys))
+                .and_ref!(|v| decrypt(v, &verified_derived_keys, &public_keys))
                 .do_ref!(|decrypted| {
                     if (decrypted.length() == 1 && decrypted[0] < vote.options) {
                         let option = decrypted[0] as u64;

--- a/move/seal/sources/bf_hmac_encryption.move
+++ b/move/seal/sources/bf_hmac_encryption.move
@@ -369,6 +369,27 @@ public fun verify_derived_keys(
     })
 }
 
+/// A variant of `verify_derived_keys` where the public keys may be given in any order and may include key servers
+/// which did not provide a derived key, e.g. the same vector given to `decrypt`. The key servers and the derived keys
+/// must be given in the same order.
+///
+/// It is up to the caller to ensure that the given public keys are from the correct key servers.
+public fun verify_derived_keys_for_key_servers(
+    derived_keys: &vector<Element<G1>>,
+    key_servers: &vector<ID>,
+    package_id: address,
+    id: vector<u8>,
+    public_keys: &vector<PublicKey>,
+): vector<VerifiedDerivedKey> {
+    let matching_public_keys = key_servers.map_ref!(|key_server| {
+        let index = public_keys.find_index!(|pk| pk.key_server == *key_server);
+        assert!(index.is_some(), EWrongPublicKeys);
+        let public_key = &public_keys[index.destroy_some()];
+        PublicKey { key_server: *key_server, pk: public_key.pk }
+    });
+    verify_derived_keys(derived_keys, package_id, id, &matching_public_keys)
+}
+
 fun verify_derived_key(
     derived_key: &Element<G1>,
     gid: &Element<G1>,
@@ -1321,4 +1342,46 @@ fun test_zero_index() {
     let encrypted_object =
         x"000000000000000000000000000000000000000000000000000000000000000000040102030403000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000201000000000000000000000000000000000000000000000000000000000000000302020099c6cb593df84708ef4aad86c70c6daf08f4d32b1718fc8a6a9837a127d8c13dd36785d94a80fde73feecaa86d7d9aa50d0bb8b93d5420785dd38857767eb4b980483dd1c9acf20fa9b1297082fe06affb9afdef449b4a9fe5a167d2d3c52944036fa57743a90f01e0d0eb566cbd2f5d7040262241be51b8a9e34d889162e808bc3c393b844e8de5cde6d28286a315d220494f20556c45d22dba66a63b51d8b98704a00331b9fa10d6d958236af6e9cd5add7dff83410a7830ff9efbea7a9a14c3e07cea42b96c8cf80c704ef89f21b6d98de9c5a4d48185f036112e168f7c7d7f011704191015aff28b80290585f1ddafd9ff2baf9d6837617b010401020304f316f4c2f79358a759f7a2602db32c84699a4305cd22e4912cf5e7c2ba0d0f68";
     parse_encrypted_object(encrypted_object);
+}
+
+#[test]
+fun test_decryption_for_key_servers() {
+    use sui::bls12381::g1_from_bytes;
+
+    // The test vector of `test_decryption`, with the public keys and the derived keys given out of order.
+    let pk0 =
+        x"a58bfa576a8efe2e2730bc664b3dbe70257d8e35106e4af7353d007dba092d722314a0aeb6bca5eed735466bbf471aef01e4da8d2efac13112c51d1411f6992b8604656ea2cf6a33ec10ce8468de20e1d7ecbfed8688a281d462f72a41602161";
+    let pk1 =
+        x"a9ce55cfa7009c3116ea29341151f3c40809b816f4ad29baa4f95c1bb23085ef02a46cf1ae5bd570d99b0c6e9faf525306224609300b09e422ae2722a17d2a969777d53db7b52092e4d12014da84bffb1e845c2510e26b3c259ede9e42603cd6";
+    let pk2 =
+        x"93b3220f4f3a46fb33074b590cda666c0ebc75c7157d2e6492c62b4aebc452c29f581361a836d1abcbe1386268a5685103d12dec04aadccaebfa46d4c92e2f2c0381b52d6f2474490d02280a9e9d8c889a3fce2753055e06033f39af86676651";
+    let usk0 =
+        x"8cb19351dbd351d02292a77a18e2f0f4ec0d3becf23f37cc87e4870bf35522c3e59487e0ee5023d5e2e383e40b77bd98";
+    let usk1 =
+        x"a7f6b22719b8ca2e3bfc07bf22ea59245b4aec7a394020cf826199b3cc71e58045e5d6b52506145851e71370e524c362";
+
+    let encrypted_object = parse_encrypted_object(
+        x"00000000000000000000000000000000000000000000000000000000000000000020381dd9078c322a4663c392761a0211b527c127b29583851217f948d62131f40903034401905bebdf8c04f3cd5f04f442a39372c8dc321c29edfb4f9cb30b23ab9601d726ecf6f7036ee3557cd6c7b93a49b231070e8eecada9cfa157e40e3f02e5d302dba72804cc9504a82bbaa13ed4a83a0e2c6219d7e45125cf57fd10cbab957a97030200b687baf3e9b78786fa50237861cb07f5f25febd790769eec41859f353deed5ab6301cbbf4e2616effe8a04a0b46dd2101531117eed7514e59f9ddbf33119eaeb2fd85c35e9c01cccc5a1d20c7000afbc4ad95ff11de52e098ee129be51d6b63b034693204591c2f2904595850da29007772266e36faecf2385c19daca728d8cd4fa354f4cb57faee6f19bff2d7f2736646bb07048a9355869a6975f0c338030d6d422ddfc436e3d077be2c53b521dd73416e9c57ccf53003456d9bc18c1e9b6020825d9248023240d255fe4897349d2e0a0f5a1c32c68a48c45eba309fd5fa8510010d59416fff28cf98412a42787bbc012000000000000000000000000000000000000000000000000000000000000000017b70af332dbf79873c7fa4996aceec9e9507210e34f0bc3066e7328beedeabc8",
+    );
+
+    // The public keys of all key servers, in an order unrelated to the encrypted object.
+    let public_keys = vector[
+        new_public_key(encrypted_object.services[2].to_id(), pk2),
+        new_public_key(encrypted_object.services[0].to_id(), pk0),
+        new_public_key(encrypted_object.services[1].to_id(), pk1),
+    ];
+
+    // Only two of the three key servers provided a derived key, and not in the order they appear in
+    // the encrypted object.
+    let vdks = verify_derived_keys_for_key_servers(
+        &vector[g1_from_bytes(&usk1), g1_from_bytes(&usk0)],
+        &vector[encrypted_object.services[1].to_id(), encrypted_object.services[0].to_id()],
+        @0x0,
+        x"381dd9078c322a4663c392761a0211b527c127b29583851217f948d62131f409",
+        &public_keys,
+    );
+
+    // The same vector of public keys can be reused for the decryption.
+    let decrypted = decrypt(&encrypted_object, &vdks, &public_keys);
+    assert_eq!(decrypted.destroy_some(), b"Hello, world!");
 }


### PR DESCRIPTION
Adds `verify_derived_keys_for_key_servers`, a variant of `verify_derived_keys` which pairs the public keys with the derived keys by key server ID instead of by position, so they can be given in any order and can include key servers that provided no derived key. `patterns::voting` and the docs now use it.