### PR TITLE
[docs] Clarify how to read a stored encrypted object offchain

### DIFF
--- a/docs/content/UsingSeal.mdx
+++ b/docs/content/UsingSeal.mdx
@@ -410,6 +410,14 @@ See [`patterns::voting`](https://github.com/MystenLabs/seal/blob/main/move/patte
 
 :::
 
+:::tip[Reading a stored encrypted object offchain]
+
+Onchain decryption usually means storing the output of `parse_encrypted_object` in one of your own structs, the way [`patterns::voting`](https://github.com/MystenLabs/seal/blob/main/move/patterns/sources/voting.move) stores a `vector<Option<EncryptedObject>>` in `Vote`. Reading that struct back offchain does not need a BCS layout: request the object with `showContent` and the full node renders the nested Move struct as JSON.
+
+Do not reach for the SDK's `EncryptedObject` here. That one describes the ciphertext bytes on the wire, which is a different shape from the Move struct.
+
+:::
+
 #### Onchain decryption with the TypeScript SDK
 
 You can use the TypeScript SDK to build a transaction that calls Seal's onchain decryption functions. 


### PR DESCRIPTION
## Description

Documents that a stored `EncryptedObject` is read back from the full node's JSON rendering of the Move struct, not through the SDK's `EncryptedObject`, which shares the name but describes the ciphertext wire format and is a different shape.

## Test plan

Docs only.
